### PR TITLE
set default mysql table collation to utf8mb4_bin

### DIFF
--- a/dialect/sql/schema/schema.go
+++ b/dialect/sql/schema/schema.go
@@ -77,9 +77,9 @@ func (t *Table) MySQL(version string) *sql.TableBuilder {
 	for _, pk := range t.PrimaryKey {
 		b.PrimaryKey(pk.Name)
 	}
-	// default character set to MySQL table.
-	// columns can be override using the "Charset" field.
-	b.Charset("utf8mb4")
+	// default charset / collation on MySQL table.
+	// columns can be override using the Charset / Collate fields.
+	b.Charset("utf8mb4").Collate("utf8mb4_bin")
 	return b
 }
 

--- a/entc/integration/integration_test.go
+++ b/entc/integration/integration_test.go
@@ -100,6 +100,7 @@ var tests = []func(*testing.T, *ent.Client){
 	Sanity,
 	Paging,
 	Charset,
+	Collation,
 	Relation,
 	Predicate,
 	UniqueConstraint,
@@ -243,6 +244,15 @@ func Charset(t *testing.T, client *ent.Client) {
 	require.Equal("נטי", f2.Name)
 	require.Equal("Ariel", f3.Name)
 	require.Equal("Nati", f4.Name)
+}
+
+func Collation(t *testing.T, client *ent.Client) {
+	require := require.New(t)
+	ctx := context.Background()
+	_ = client.File.Create().SetName("Foo").SaveX(ctx)
+	query := client.File.Query().Where(file.Name("foo"))
+	require.False(query.ExistX(ctx))
+	require.Nil(query.FirstX(ctx))
 }
 
 func Predicate(t *testing.T, client *ent.Client) {


### PR DESCRIPTION
Summary: See [Case Sensitivity in String Searches](https://dev.mysql.com/doc/refman/5.7/en/case-sensitivity.html)

Differential Revision: D16782072

