### PR TITLE
ent/circleci: hide cloudfront distribution id echoed by create-invalidation command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
         command: aws s3 sync . s3://entgo.io --delete --exclude "assets/*"
     - run:
         name: Invalidate Cache
-        command: aws cloudfront create-invalidation --distribution-id $CDN_DISTRIBUTION_ID --paths "/*"
+        command: aws cloudfront create-invalidation --distribution-id $CDN_DISTRIBUTION_ID --paths "/*" | jq -M "del(.Location)"
 
 workflows:
   version: 2.1


### PR DESCRIPTION
Summary:
Example output:
```
> aws cloudfront create-invalidation --distribution-id $CDN_DISTRIBUTION_ID --paths "/*" | jq -M "del(.Location)"                                                                      alexsn@Titan
{
  "Invalidation": {
    "Id": "IXPTPF87PGPXA",
    "Status": "InProgress",
    "CreateTime": "2019-08-25T11:06:53.442Z",
    "InvalidationBatch": {
      "Paths": {
        "Quantity": 1,
        "Items": [
          "/*"
        ]
      },
      "CallerReference": "cli-1566731212-457274"
    }
  }
}
```

Differential Revision: D17046012

