### PR TITLE
entc/gen: use default name in column construction

### DIFF
--- a/entc/gen/type.go
+++ b/entc/gen/type.go
@@ -474,7 +474,7 @@ func (f Field) Column() *schema.Column {
 		}
 	}
 	if f.Default && !f.IsTime() {
-		c.Default = "Default" + pascal(f.Name)
+		c.Default = f.DefaultName()
 	}
 	return c
 }


### PR DESCRIPTION
Differential Revision: D17599004

