### PR TITLE
🐛 handle sql json type for schema OfflineMigration

### DIFF
--- a/dialect/sql/schema/schema.go
+++ b/dialect/sql/schema/schema.go
@@ -218,6 +218,12 @@ func (c *Column) ScanDefault(value string) error {
 			return fmt.Errorf("scanning string value for column %q: %v", c.Name, err)
 		}
 		c.Default = v.String
+	case c.Type == field.TypeJSON:
+		v := &sql.NullString{}
+		if err := v.Scan(value); err != nil {
+			return fmt.Errorf("scanning json value for column %q: %v", c.Name, err)
+		}
+		c.Default = v.String
 	default:
 		return fmt.Errorf("unsupported type: %v", c.Type)
 	}


### PR DESCRIPTION
I was seeing the following error:
```
"failed printing schema changes: sql/schema: unsupported type: json.RawMessage"
```

This happened, when I call:

```
client.Schema.WriteTo(ctx, f, migrate.WithDropIndex(true), migrate.WithDropColumn(true))
```

Note: I'll use this `client.Schema.WriteTo` to detect data model changes which gives me an indication for required SQL changes for the data migration