### PR TITLE
doc: use pkg.go.dev for documentation links

### DIFF
--- a/doc/md/crud.md
+++ b/doc/md/crud.md
@@ -280,7 +280,7 @@ err := client.File.
 
 Each generated node type has its own type of mutation. For example, all [`User` builders](crud.md#create-an-entity), share
 the same generated `UserMutation` object.
-However, all builder types implement the generic <a target="_blank" href="https://godoc.org/github.com/facebook/ent#Mutation">`ent.Mutation`<a> interface.
+However, all builder types implement the generic <a target="_blank" href="https://pkg.go.dev/github.com/facebook/ent?tab=doc#Mutation">`ent.Mutation`<a> interface.
 
 For example, in order to write a generic code that apply a set of methods on both `ent.UserCreate`
 and `ent.UserUpdate`, use the `UserMutation` object:

--- a/doc/md/hooks.md
+++ b/doc/md/hooks.md
@@ -21,11 +21,11 @@ There are 5 types of mutations:
 Each generated node type has its own type of mutation. For example, all [`User` builders](crud.md#create-an-entity), share
 the same generated `UserMutation` object.
 
-However, all builder types implement the generic <a target="_blank" href="https://godoc.org/github.com/facebook/ent#Mutation">`ent.Mutation`<a> interface.
+However, all builder types implement the generic <a target="_blank" href="https://pkg.go.dev/github.com/facebook/ent?tab=doc#Mutation">`ent.Mutation`<a> interface.
  
 ## Hooks
 
-Hooks are functions that get an <a target="_blank" href="https://godoc.org/github.com/facebook/ent#Mutator">`ent.Mutator`<a> and return a mutator back.
+Hooks are functions that get an <a target="_blank" href="https://pkg.go.dev/github.com/facebook/ent?tab=doc#Mutator">`ent.Mutator`<a> and return a mutator back.
 They function as middleware between mutators. It's similar to the popular HTTP middleware pattern.
 
 ```go

--- a/doc/md/schema-fields.md
+++ b/doc/md/schema-fields.md
@@ -177,7 +177,7 @@ and for time fields, the type is `time.Time`. The `GoType` method provides an op
 default ent type with a custom one.
 
 The custom type must be either a type that is convertible to the Go basic type, or a type that implements the
-[ValueScanner](https://godoc.org/github.com/facebook/ent/schema/field#ValueScanner) interface.
+[ValueScanner](https://pkg.go.dev/github.com/facebook/ent/schema/field?tab=doc#ValueScanner) interface.
 
 
 ```go

--- a/doc/md/templates.md
+++ b/doc/md/templates.md
@@ -44,7 +44,7 @@ In order to override an existing template, use its name. For example:
 ## Annotations
 Schema annotations allow to attach metadata to fields and edges and inject them to external templates.  
 An annotation must be a Go type that is serializable to JSON raw value (e.g. struct, map or slice)
-and implement the [Annotation](https://godoc.org/github.com/facebook/ent/schema/field#Annotation) interface.
+and implement the [Annotation](https://pkg.go.dev/github.com/facebook/ent/schema/field?tab=doc#Annotation) interface.
 
 Here's an example of an annotation and its usage in schema and template:
 
@@ -104,4 +104,4 @@ A custom template for implementing the `Node` API for GraphQL -
 ## Documentation
 
 Templates are executed on either a specific node-type or the entire schema graph. For API
-documentation, see the <a target="_blank" href="https://godoc.org/github.com/facebook/ent/entc/gen">GoDoc<a>.
+documentation, see the <a target="_blank" href="https://pkg.go.dev/github.com/facebook/ent/entc/gen?tab=doc">GoDoc<a>.

--- a/doc/website/siteConfig.js
+++ b/doc/website/siteConfig.js
@@ -37,7 +37,7 @@ const siteConfig = {
   // For no header links in the top nav bar -> headerLinks: [],
   headerLinks: [
     {doc: 'getting-started', label: 'Docs'},
-    {href: 'https://godoc.org/github.com/facebook/ent', label: 'GoDoc'},
+    {href: 'https://pkg.go.dev/github.com/facebook/ent?tab=doc', label: 'GoDoc'},
     {href: 'https://github.com/facebook/ent', label: 'Github'},
     { blog: true, label: 'Blog' },
   ],


### PR DESCRIPTION
pkg.go.dev serves Go documentation. However, it also understands modules
and has information about past versions of a package. Later this year
godoc.org will be redirected to pkg.go.dev.

Let's use this subdomain going forward when linking Go documentation.

Reference: https://blog.golang.org/pkg.go.dev-2020