### PR TITLE
docs: fix missing ref in schema example

### DIFF
--- a/doc/md/traversals.md
+++ b/doc/md/traversals.md
@@ -65,6 +65,8 @@ func (User) Edges() []ent.Edge {
 		edge.To("friends", User.Type),
 		edge.From("groups", Group.Type).
 			Ref("users"),
+		edge.From("manage", Group.Type).
+			Ref("admin"),
 	}
 }
 ``` 


### PR DESCRIPTION
Make it match with [schema definition in example](https://github.com/facebook/ent/blob/master/examples/traversal/ent/schema/user.go)