### PR TITLE
doc/md: fix added missing context import

### DIFF
--- a/doc/md/getting-started.md
+++ b/doc/md/getting-started.md
@@ -126,6 +126,7 @@ To get started, create a new `ent.Client`. For this example, we will use SQLite3
 package main
 
 import (
+	"context"
 	"log"
 
 	"<project>/ent"


### PR DESCRIPTION
hello `ent` team,

at one of the getting started sample code there is a missing `context` import.

