### PR TITLE
Fixes #566: Missing generate.go when --target is used in entc init command

### DIFF
--- a/cmd/entc/entc.go
+++ b/cmd/entc/entc.go
@@ -36,7 +36,6 @@ func main() {
 					Example: examples(
 						"entc init Example",
 						"entc init --target entv1/schema User Group",
-						"entc init --target entv1/schema --entity entities User Group",
 					),
 					Args: func(_ *cobra.Command, names []string) error {
 						for _, name := range names {

--- a/cmd/entc/entc.go
+++ b/cmd/entc/entc.go
@@ -197,9 +197,6 @@ func createDir(schema, entity string) error {
 	if err == nil || !os.IsNotExist(err) {
 		return err
 	}
-	if err := os.MkdirAll(schema, os.ModePerm); err != nil {
-		return fmt.Errorf("creating schema directory: %w", err)
-	}
 
 	if entity == "" {
 		entity = defaultEntity
@@ -208,6 +205,14 @@ func createDir(schema, entity string) error {
 				entity = schmDir
 			}
 		}
+	}
+
+	if relPath, err := filepath.Rel(entity, schema); err == nil && relPath == "." {
+		return errors.New("schemas and entities can't be generated in the same path. see: entc help init")
+	}
+
+	if err := os.MkdirAll(schema, os.ModePerm); err != nil {
+		return fmt.Errorf("creating schema directory: %w", err)
 	}
 
 	_, err = os.Stat(entity)

--- a/cmd/entc/entc.go
+++ b/cmd/entc/entc.go
@@ -202,12 +202,11 @@ func createDir(schema, entity string) error {
 	}
 
 	if entity == "" {
+		entity = defaultEntity
 		if strings.Contains(schema, "/") {
 			if schmDir := filepath.Dir(schema); schmDir != "." {
 				entity = schmDir
 			}
-		} else {
-			entity = defaultEntity
 		}
 	}
 

--- a/cmd/entc/entc.go
+++ b/cmd/entc/entc.go
@@ -29,13 +29,14 @@ func main() {
 	cmd.AddCommand(
 		func() *cobra.Command {
 			var (
-				target string
-				cmd    = &cobra.Command{
+				target, entity string
+				cmd            = &cobra.Command{
 					Use:   "init [flags] [schemas]",
 					Short: "initialize an environment with zero or more schemas",
 					Example: examples(
 						"entc init Example",
 						"entc init --target entv1/schema User Group",
+						"entc init --target entv1/schema --entity entities User Group",
 					),
 					Args: func(_ *cobra.Command, names []string) error {
 						for _, name := range names {
@@ -46,13 +47,14 @@ func main() {
 						return nil
 					},
 					Run: func(cmd *cobra.Command, names []string) {
-						if err := initEnv(target, names); err != nil {
+						if err := initEnv(target, entity, names); err != nil {
 							log.Fatalln(err)
 						}
 					},
 				}
 			)
 			cmd.Flags().StringVar(&target, "target", defaultSchema, "target directory for schemas")
+			cmd.Flags().StringVar(&entity, "entity", "", "target directory for entities")
 			return cmd
 		}(),
 		&cobra.Command{
@@ -174,8 +176,8 @@ func (idType) String() string {
 }
 
 // initEnv initialize an environment for ent codegen.
-func initEnv(target string, names []string) error {
-	if err := createDir(target); err != nil {
+func initEnv(schema string, entity string, names []string) error {
+	if err := createDir(schema, entity); err != nil {
 		return err
 	}
 	for _, name := range names {
@@ -183,25 +185,58 @@ func initEnv(target string, names []string) error {
 		if err := tmpl.Execute(b, name); err != nil {
 			log.Fatalln(err)
 		}
-		target := filepath.Join(target, strings.ToLower(name+".go"))
-		if err := ioutil.WriteFile(target, b.Bytes(), 0644); err != nil {
+		schema := filepath.Join(schema, strings.ToLower(name+".go"))
+		if err := ioutil.WriteFile(schema, b.Bytes(), 0644); err != nil {
 			log.Fatalln(err)
 		}
 	}
 	return nil
 }
 
-func createDir(target string) error {
-	_, err := os.Stat(target)
+func createDir(schema, entity string) error {
+	_, err := os.Stat(schema)
 	if err == nil || !os.IsNotExist(err) {
 		return err
 	}
-	if err := os.MkdirAll(target, os.ModePerm); err != nil {
+	if err := os.MkdirAll(schema, os.ModePerm); err != nil {
 		return fmt.Errorf("creating schema directory: %w", err)
 	}
-	if target != defaultSchema {
+
+	if entity == "" {
+		if strings.Contains(schema, "/") {
+			if schmDir := filepath.Dir(schema); schmDir != "." {
+				entity = schmDir
+			}
+		} else {
+			entity = defaultEntity
+		}
+	}
+
+	_, err = os.Stat(entity)
+	if err != nil && !os.IsNotExist(err) && !os.IsExist(err) {
+		return err
+	}
+
+	if err := os.MkdirAll(entity, os.ModePerm); err != nil {
+		return fmt.Errorf("creating entity directory: %w", err)
+	}
+
+	if entity != defaultEntity {
+		relPath, err := filepath.Rel(entity, schema)
+		if err != nil {
+			return fmt.Errorf("getting schema relative path to entity path: %w", err)
+		}
+		if filepath.Dir(relPath) == "." {
+			relPath = "./" + relPath
+		}
+
+		gf := []byte(fmt.Sprintf(genFileTemplate, filepath.Base(entity), relPath))
+		if err := ioutil.WriteFile(filepath.Join(entity, "generate.go"), gf, 0644); err != nil {
+			return fmt.Errorf("creating generate.go file: %w", err)
+		}
 		return nil
 	}
+
 	if err := ioutil.WriteFile("ent/generate.go", []byte(genFile), 0644); err != nil {
 		return fmt.Errorf("creating generate.go file: %w", err)
 	}
@@ -231,10 +266,14 @@ func ({{ . }}) Edges() []ent.Edge {
 `))
 
 const (
+	// default entities package path.
+	defaultEntity = "ent"
 	// default schema package path.
 	defaultSchema = "ent/schema"
 	// ent/generate.go file used for "go generate" command.
 	genFile = "package ent\n\n//go:generate go run github.com/facebook/ent/cmd/entc generate ./schema\n"
+	// ent/generate.go file template used for "go generate" command.
+	genFileTemplate = "package %s\n\n//go:generate go run github.com/facebook/ent/cmd/entc generate --target . %s\n"
 )
 
 // examples formats the given examples to the cli.

--- a/cmd/entc/entc_test.go
+++ b/cmd/entc/entc_test.go
@@ -15,6 +15,8 @@ import (
 
 func TestCmd(t *testing.T) {
 	defer os.RemoveAll("ent")
+	defer os.RemoveAll("entities")
+	defer os.RemoveAll("schemas")
 	cmd := exec.Command("go", "run", "github.com/facebook/ent/cmd/entc", "init", "User")
 	stderr := bytes.NewBuffer(nil)
 	cmd.Stderr = stderr
@@ -24,6 +26,41 @@ func TestCmd(t *testing.T) {
 	require.NoError(t, err)
 	_, err = os.Stat("ent/schema/user.go")
 	require.NoError(t, err)
+
+	cmd = exec.Command(
+		"go",
+		"run",
+		"github.com/facebook/ent/cmd/entc",
+		"init",
+		"--target",
+		"schemas",
+		"--entity",
+		"entities",
+		"User",
+	)
+	stderr = bytes.NewBuffer(nil)
+	cmd.Stderr = stderr
+	require.NoError(t, cmd.Run(), stderr.String())
+
+	_, err = os.Stat("entities/generate.go")
+	require.NoError(t, err)
+	_, err = os.Stat("schemas/user.go")
+	require.NoError(t, err)
+
+	cmd = exec.Command(
+		"go",
+		"run",
+		"github.com/facebook/ent/cmd/entc",
+		"init",
+		"--target",
+		"samedir",
+		"--entity",
+		"samedir",
+		"User",
+	)
+	stderr = bytes.NewBuffer(nil)
+	cmd.Stderr = stderr
+	require.Error(t, cmd.Run(), "schemas and entities can't be generated in the same path. see: entc help init")
 
 	cmd = exec.Command("go", "run", "github.com/facebook/ent/cmd/entc", "generate", "./ent/schema")
 	stderr = bytes.NewBuffer(nil)


### PR DESCRIPTION
`--entity` init command argument sets the target path for generating entities.
It inherits the default path from the schema path so the default
the behavior remains the same.


The default behavior would be the same. Example `entc init User Group`:

```
├── ent
|   ├── schema
│   |   ├── user.go
│   |   ├── ....
│   |   └── group.go
│   ├── generate.go
│   ├── user_query.go
│   ├── ....
│   └── user_create.go
└── project-root.md
```

`entc init --target entv1/schema --entity myent User Group`:
```
├── entv1
|   ├── schema
│   |   ├── user.go
│   |   ├── ....
│   |   └── group.go
├── myent
│   ├── generate.go
│   ├── user_query.go
│   ├── ....
│   └── user_create.go
└── project-root.md
```

`entc init --target schema --entity entity User Group`:
```
├── schema
│   |   ├── user.go
│   |   ├── ....
│   |   └── group.go
├── entity
│   ├── generate.go
│   ├── user_query.go
│   ├── ....
│   └── user_create.go
└── project-root.md
```