### PR TITLE
(WIP) Upserts (Resolving #139)

### DIFF
--- a/dialect/sql/builder_test.go
+++ b/dialect/sql/builder_test.go
@@ -485,6 +485,11 @@ func TestBuilder(t *testing.T) {
 			wantArgs:  []interface{}{"foo", 10, "foo", 20},
 		},
 		{
+			input:     Dialect(dialect.Postgres).Insert("users").Columns("email").Values("user@example.com").ConflictColumns("email").UpdateSet("email", "user-1@example.com"),
+			wantQuery: `INSERT INTO "users" ("email") VALUES ($1) ON CONFLICT ("email") DO UPDATE SET "email" = $2`,
+			wantArgs:  []interface{}{"user@example.com", "user-1@example.com"},
+		},
+		{
 			input: Delete("users").
 				Where(NotNull("parent_id")),
 			wantQuery: "DELETE FROM `users` WHERE `parent_id` IS NOT NULL",
@@ -1258,13 +1263,13 @@ func TestBuilder(t *testing.T) {
 				Or().
 				Where(And(NEQ("f", "f"), NEQ("g", "g"))),
 			wantQuery: strings.NewReplacer("\n", "", "\t", "").Replace(`
-SELECT * FROM "users" 
-WHERE 
+SELECT * FROM "users"
+WHERE
 	(
-		(("id" = $1 AND "group_id" IN ($2, $3)) OR ("id" = $4 AND "group_id" IN ($5, $6))) 
-		AND 
+		(("id" = $1 AND "group_id" IN ($2, $3)) OR ("id" = $4 AND "group_id" IN ($5, $6)))
+		AND
 		(("a" = $7 OR ("b" = $8 AND "c" = $9)) AND (NOT ("d" IS NULL OR "e" IS NOT NULL)))
-	) 
+	)
 	OR ("f" <> $10 AND "g" <> $11)`),
 			wantArgs: []interface{}{1, 2, 3, 2, 4, 5, "a", "b", "c", "f", "g"},
 		},

--- a/entc/gen/template/dialect/sql/upsert.tmpl
+++ b/entc/gen/template/dialect/sql/upsert.tmpl
@@ -1,0 +1,12 @@
+{{/*
+Copyright 2019-present Facebook Inc. All rights reserved.
+This source code is licensed under the Apache 2.0 license found
+in the LICENSE file in the root directory of this source tree.
+*/}}
+
+{{ define "dialect/sql/upsert" }}
+{{ $builder := pascal $.Scope.Builder }}
+{{ $receiver := receiver $builder }}
+{{ $mutation := print $receiver ".mutation"  }}
+
+


### PR DESCRIPTION
This PR aims to implement database level upserts using `ON CONFLICT ...` (Postgres) and equivalent in MySQL, adding new DSL methods for declaring an Upsert operation:

```go
// Pet holds the schema definition for the Pet entity.
type Pet struct {
	ent.Schema
}

// Fields of the Pet.
func (Pet) Fields() []ent.Field {
	return []ent.Field{
		field.String("name"),
	}
}

func (Pet) Indexes() []ent.Index {
	return []ent.Index{
		index.Fields("name").Unique(),
	}
}

// Usage:
pedro, err := client.Pet.
    Upsert().
    Create().SetName("pedro").
    Update().SetName("pedro-2").
    Save(ctx)

```

Resolving #139