### PR TITLE
dialect/sql/sqlgraph: skip setting last-insert-id if provided

### DIFF
--- a/dialect/sql/sqlgraph/graph.go
+++ b/dialect/sql/sqlgraph/graph.go
@@ -964,7 +964,10 @@ func (c *creator) batchInsert(ctx context.Context, tx dialect.ExecQuerier, inser
 		return err
 	}
 	for i, node := range c.Nodes {
-		node.ID.Value = ids[i]
+		// ID field was provided by the user.
+		if node.ID.Value == nil {
+			node.ID.Value = ids[i]
+		}
 	}
 	return nil
 }

--- a/entc/integration/customid/customid_test.go
+++ b/entc/integration/customid/customid_test.go
@@ -134,11 +134,15 @@ func CustomID(t *testing.T, client *ent.Client) {
 	require.Equal(t, pedro.ID, bee.Edges.Owner.ID)
 
 	pets = client.Pet.CreateBulk(
-		client.Pet.Create().SetID("luna").SetOwner(a8m),
-		client.Pet.Create().SetID("layla").SetOwner(a8m),
+		client.Pet.Create().SetID("luna").SetOwner(a8m).AddFriends(xabi),
+		client.Pet.Create().SetID("layla").SetOwner(a8m).AddFriendIDs(pedro.ID),
+		client.Pet.Create().AddFriends(pedro, xabi),
 	).SaveX(ctx)
 	require.Equal(t, "luna", pets[0].ID)
+	require.Equal(t, xabi.ID, pets[0].QueryFriends().OnlyIDX(ctx))
 	require.Equal(t, "layla", pets[1].ID)
+	require.Equal(t, pedro.ID, pets[1].QueryFriends().OnlyIDX(ctx))
+	require.Equal(t, []string{"pedro", "xabi"}, pets[2].QueryFriends().Order(ent.Asc(pet.FieldID)).IDsX(ctx))
 
 	u1, u2 := uuid.New(), uuid.New()
 	blobs := client.Blob.CreateBulk(


### PR DESCRIPTION
Fixed #1290. Issue in BulkCreate(<T>) for m2m edges