### PR TITLE
dialect/sql: minor improvements to insert command

### DIFF
--- a/dialect/sql/bench_test.go
+++ b/dialect/sql/bench_test.go
@@ -1,0 +1,35 @@
+// Copyright 2019-present Facebook Inc. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
+package sql
+
+import (
+	"testing"
+
+	"entgo.io/ent/dialect"
+)
+
+func BenchmarkInsertBuilder_Default(b *testing.B) {
+	for _, d := range []string{dialect.SQLite, dialect.MySQL, dialect.Postgres} {
+		b.Run(d, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				Dialect(d).Insert("users").Default().Returning("id").Query()
+			}
+		})
+	}
+}
+
+func BenchmarkInsertBuilder_Small(b *testing.B) {
+	for _, d := range []string{dialect.SQLite, dialect.MySQL, dialect.Postgres} {
+		b.Run(d, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				Dialect(d).Insert("users").
+					Columns("id", "age", "first_name", "last_name", "nickname", "spouse_id", "created_at", "updated_at").
+					Values(1, 30, "Ariel", "Mashraki", "a8m", 2, "2009-11-10 23:00:00", "2009-11-10 23:00:00").
+					Returning("id").
+					Query()
+			}
+		})
+	}
+}


### PR DESCRIPTION
```
benchmark                                     old ns/op     new ns/op     delta
BenchmarkInsertBuilder_Default/default-16     6210          922           -85.15%

benchmark                                     old allocs     new allocs     delta
BenchmarkInsertBuilder_Default/default-16     86             16             -81.40%

benchmark                                     old bytes     new bytes     delta
BenchmarkInsertBuilder_Default/default-16     4098          1088          -73.45%

benchmark                                    old ns/op     new ns/op     delta
BenchmarkInsertBuilder_Small/sqlite3-16      2169          1801          -16.97%
BenchmarkInsertBuilder_Small/mysql-16        2140          1825          -14.72%
BenchmarkInsertBuilder_Small/postgres-16     2613          2223          -14.93%

benchmark                                    old allocs     new allocs     delta
BenchmarkInsertBuilder_Small/sqlite3-16      27             21             -22.22%
BenchmarkInsertBuilder_Small/mysql-16        27             21             -22.22%
BenchmarkInsertBuilder_Small/postgres-16     36             30             -16.67%

benchmark                                    old bytes     new bytes     delta
BenchmarkInsertBuilder_Small/sqlite3-16      1944          1304          -32.92%
BenchmarkInsertBuilder_Small/mysql-16        1944          1304          -32.92%
BenchmarkInsertBuilder_Small/postgres-16     1976          1336          -32.39%
```