### PR TITLE
always prefix receivers with _

### DIFF
--- a/entc/gen/func.go
+++ b/entc/gen/func.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"go/token"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -208,11 +207,7 @@ func receiver(s string) (r string) {
 			break
 		}
 	}
-	name := strings.ToLower(s)
-	if token.Lookup(name).IsKeyword() {
-		name = "_" + name
-	}
-	return name
+	return "_" + strings.ToLower(s)
 }
 
 // typeScope wraps the Type object with extended scope.

--- a/entc/gen/func_test.go
+++ b/entc/gen/func_test.go
@@ -19,6 +19,14 @@ func Test_receiver(t *testing.T) {
 			"UserSelect",
 			"us",
 		},
+		{
+			"OSQuery",
+			"oq",
+		},
+		{
+			"OSSelect",
+			"os",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.arg, func(t *testing.T) {

--- a/entc/gen/func_test.go
+++ b/entc/gen/func_test.go
@@ -75,6 +75,10 @@ func Test_snake(t *testing.T) {
 			"HTTPCode",
 			"http_code",
 		},
+		{
+			"OS",
+			"os",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.arg, func(t *testing.T) {

--- a/entc/gen/func_test.go
+++ b/entc/gen/func_test.go
@@ -15,35 +15,35 @@ func Test_receiver(t *testing.T) {
 	}{
 		{
 			"[]T",
-			"t",
+			"_t",
 		},
 		{
 			"[1]T",
-			"t",
+			"_t",
 		},
 		{
 			"User",
-			"u",
+			"_u",
 		},
 		{
 			"UserQuery",
-			"uq",
+			"_uq",
 		},
 		{
 			"UserSelect",
-			"us",
+			"_us",
 		},
 		{
 			"OS",
-			"o",
+			"_o",
 		},
 		{
 			"OSQuery",
-			"oq",
+			"_oq",
 		},
 		{
 			"OSSelect",
-			"os",
+			"_os",
 		},
 	}
 	for _, tt := range tests {

--- a/entc/gen/func_test.go
+++ b/entc/gen/func_test.go
@@ -12,6 +12,18 @@ func Test_receiver(t *testing.T) {
 		want string
 	}{
 		{
+			"[]T",
+			"t",
+		},
+		{
+			"[1]T",
+			"t",
+		},
+		{
+			"User",
+			"u",
+		},
+		{
 			"UserQuery",
 			"uq",
 		},

--- a/entc/gen/func_test.go
+++ b/entc/gen/func_test.go
@@ -32,6 +32,10 @@ func Test_receiver(t *testing.T) {
 			"us",
 		},
 		{
+			"OS",
+			"o",
+		},
+		{
 			"OSQuery",
 			"oq",
 		},

--- a/entc/gen/func_test.go
+++ b/entc/gen/func_test.go
@@ -1,0 +1,30 @@
+// Copyright 2019-present Facebook Inc. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
+package gen
+
+import "testing"
+
+func Test_receiver(t *testing.T) {
+	tests := []struct {
+		arg  string
+		want string
+	}{
+		{
+			"UserQuery",
+			"uq",
+		},
+		{
+			"UserSelect",
+			"us",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.arg, func(t *testing.T) {
+			if got := receiver(tt.arg); got != tt.want {
+				t.Errorf("receiver() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/entc/gen/func_test.go
+++ b/entc/gen/func_test.go
@@ -4,7 +4,9 @@
 
 package gen
 
-import "testing"
+import (
+	"testing"
+)
 
 func Test_receiver(t *testing.T) {
 	tests := []struct {
@@ -48,6 +50,36 @@ func Test_receiver(t *testing.T) {
 		t.Run(tt.arg, func(t *testing.T) {
 			if got := receiver(tt.arg); got != tt.want {
 				t.Errorf("receiver() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_snake(t *testing.T) {
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		arg  string
+		want string
+	}{
+		{
+			"Username",
+			"username",
+		},
+		{
+			"FullName",
+			"full_name",
+		},
+		{
+			"HTTPCode",
+			"http_code",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.arg, func(t *testing.T) {
+			if got := snake(tt.arg); got != tt.want {
+				t.Errorf("snake() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
I have a model named `OS`, which generates package name `os`. Everything works ok until dealing with select query objects, which generates `os` as the receiver name, conflicting with the package name. I made the fix by always prefixing receivers with _, which might be too broad. Feedbacks welcomed.