### PR TITLE
enable crowdin translation 

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Install Dependencies
         working-directory: doc/website
         run: yarn
+      - name: Sync Translation
+        working-directory: doc/website
+        run: yarn crowdin:sync
       - name: Build Docs
         working-directory: doc/website
         run: yarn build

--- a/doc/website/crowdin.yaml
+++ b/doc/website/crowdin.yaml
@@ -1,0 +1,34 @@
+#
+# Your Crowdin credentials
+#
+"project_id" : "446988"
+"api_token_env" : "CROWDIN_TOKEN"
+"base_path" : ".."
+"base_url" : "https://api.crowdin.com"
+
+#
+# Choose file structure in Crowdin
+# e.g. true or false
+#
+"preserve_hierarchy": true
+
+#
+# Files configuration
+#
+files: [
+  # JSON translation files
+  {
+    source: '/website/i18n/en/**/*',
+    translation: '/website/i18n/%two_letters_code%/**/%original_file_name%',
+  },
+  # Docs Markdown files
+  {
+    source: '/md/**/*',
+    translation: '/website/i18n/%two_letters_code%/docusaurus-plugin-content-docs/current/**/%original_file_name%',
+  },
+  # Blog Markdown files
+  {
+    source: '/website/blog/**/*',
+    translation: '/website/i18n/%two_letters_code%/docusaurus-plugin-content-blog/**/%original_file_name%',
+  },
+]

--- a/doc/website/docusaurus.config.js
+++ b/doc/website/docusaurus.config.js
@@ -1,5 +1,9 @@
 module.exports={
   "title": "ent",
+  "i18n": {
+    "defaultLocale": 'en',
+    "locales": ['en', 'zh', 'ja', 'he'],
+  },
   "tagline": "An entity framework for Go",
   "url": "https://entgo.io",
   "baseUrl": "/",

--- a/doc/website/package.json
+++ b/doc/website/package.json
@@ -4,14 +4,17 @@
     "start": "docusaurus start",
     "build": "docusaurus build",
     "publish-gh-pages": "docusaurus-publish",
-    "write-translations": "docusaurus-write-translations",
+    "write-translations": "docusaurus write-translations",
     "version": "docusaurus-version",
     "rename-version": "docusaurus-rename-version",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
-    "docusaurus": "docusaurus"
+    "docusaurus": "docusaurus",
+    "crowdin": "crowdin",
+    "crowdin:sync": "docusaurus write-translations && crowdin upload && crowdin download"
   },
   "dependencies": {
+    "@crowdin/cli": "3",
     "@docusaurus/core": "2.0.0-alpha.72",
     "@docusaurus/preset-classic": "2.0.0-alpha.72",
     "clsx": "^1.1.1",

--- a/doc/website/src/pages/index.js
+++ b/doc/website/src/pages/index.js
@@ -12,6 +12,8 @@ const React = require('react');
 import LayoutProviders from '@theme/LayoutProviders';
 import Footer from '@theme/Footer';
 import Navbar from '@theme/Navbar';
+import Link from '@docusaurus/Link';
+
 
 const CompLibrary = {
   Container: props => <div {...props}></div>,
@@ -137,11 +139,11 @@ class HomeSplash extends React.Component {
 class HomeNav extends React.Component {
     render() {
         return <ul className="home-nav">
-            <li className=""><a href="/docs/getting-started" target="_self">Docs</a></li>
-            <li className=""><a href="/docs/tutorial-setup" target="_self">Tutorial</a></li>
+            <li className=""><Link to={"/docs/getting-started"}>Docs</Link></li>
+            <li className=""><Link to="/docs/tutorial-setup">Tutorial</Link></li>
             <li className="header-godoc-link"><a href="https://pkg.go.dev/entgo.io/ent?tab=doc" target="_blank">GoDoc</a></li>
             <li className=""><a href="https://github.com/ent/ent" target="_blank">Github</a></li>
-            <li className=""><a href="/blog/" target="_self">Blog</a></li>
+            <li className=""><Link to="/blog/">Blog</Link></li>
         </ul>
     }
 }


### PR DESCRIPTION
Enabling i18n. Currently not adding the language picking to the top navbar until we have some content in. 
Adding crowdin sync to the CD flow. 
Changing `<a>` tags that ref internal document in the index page to `<Link>` components so b/c docusaurus will account for i18n that way. 

Before merging we need to set the Crowdin env var for the auth token. 