### PR TITLE
handle pg bytea for schema changes

### DIFF
--- a/dialect/sql/schema/schema.go
+++ b/dialect/sql/schema/schema.go
@@ -261,6 +261,8 @@ func (c *Column) ScanDefault(value string) error {
 			return fmt.Errorf("scanning json value for column %q: %w", c.Name, err)
 		}
 		c.Default = v.String
+	case c.Type == field.TypeBytes:
+		c.Default = []byte(value)
 	default:
 		return fmt.Errorf("unsupported default type: %v", c.Type)
 	}


### PR DESCRIPTION
A schema definition like:

```
field.Bytes("data"),
```

errors when schema changes are printed with:

```
failed printing schema changes: sql/schema: unsupported default type: []byte
```

This PR addresses this issue.