### PR TITLE
Run integration tests for inspect

### DIFF
--- a/dialect/sql/schema/inspect.go
+++ b/dialect/sql/schema/inspect.go
@@ -56,6 +56,9 @@ func (i *Inspector) Tables(ctx context.Context) ([]*Table, error) {
 	tx := dialect.NopTx(i.sqlDialect)
 	tables := make([]*Table, 0, len(names))
 	for _, name := range names {
+		if i.skipTable(ctx, name) {
+			continue
+		}
 		t, err := i.table(ctx, tx, name)
 		if err != nil {
 			return nil, err
@@ -63,6 +66,15 @@ func (i *Inspector) Tables(ctx context.Context) ([]*Table, error) {
 		tables = append(tables, t)
 	}
 	return tables, nil
+}
+
+// skipTable skip system tables
+func (i *Inspector) skipTable(ctx context.Context, name string) bool {
+	if dialect.SQLite == i.Dialect() {
+		return name == "sqlite_sequence"
+	}
+
+	return false
 }
 
 func (i *Inspector) tables(ctx context.Context) ([]string, error) {

--- a/entc/integration/inspect_test.go
+++ b/entc/integration/inspect_test.go
@@ -1,0 +1,19 @@
+// Copyright 2019-present Facebook Inc. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+package integration
+
+import (
+	"context"
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/schema"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func Inspect(t *testing.T, drv *sql.Driver) {
+	inspect, err := schema.NewInspect(drv)
+	require.NoError(t, err)
+	_, err = inspect.Tables(context.Background())
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Created this to repo a failure I encountered on inspect for sqlite

Tracked down the failure to strange behaviour on sqlite for this query

```sql
SELECT `name`, `type`, `notnull`, `dflt_value`, `pk` FROM pragma_table_info('sqlite_sequence') ORDER BY `pk`;
```

Output:

| name | type | notnull | dflt\_value | pk |
| :--- | :--- | :--- | :--- | :--- |
| name |  | 0 | NULL | 0 |
| seq |  | 0 | NULL | 0 |

The empty type breaks table parsing
