### PR TITLE
Fix typo in "O2O Same Type" section

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -340,7 +340,7 @@ func (Node) Edges() []ent.Edge {
 -		edge.To("next", Node.Type).
 -			Unique(),
 -		edge.From("prev", Node.Type).
--			Ref("next).
+-			Ref("next").
 -			Unique(),
 	}
 }


### PR DESCRIPTION
Double quotation was missing, so it has been added.