### PR TITLE
schema.Column ScanDefault allowed uuid default to function

### DIFF
--- a/dialect/sql/schema/schema.go
+++ b/dialect/sql/schema/schema.go
@@ -263,8 +263,13 @@ func (c *Column) ScanDefault(value string) error {
 		c.Default = v.String
 	case c.Type == field.TypeBytes:
 		c.Default = []byte(value)
+	case c.Type == field.TypeUUID:
+		// skip function
+		if !strings.Contains(value, "()") {
+			c.Default = value
+		}
 	default:
-		return fmt.Errorf("unsupported default type: %v", c.Type)
+		return fmt.Errorf("unsupported default type: %v default to %q", c.Type, value)
 	}
 	return nil
 }

--- a/dialect/sql/schema/schema_test.go
+++ b/dialect/sql/schema/schema_test.go
@@ -94,4 +94,10 @@ func TestColumn_ScanDefault(t *testing.T) {
 	require.NoError(t, c1.ScanDefault("false"))
 	require.Equal(t, false, c1.Default)
 	require.Error(t, c1.ScanDefault("foo"))
+
+	c1 = &Column{Type: field.TypeUUID}
+	require.NoError(t, c1.ScanDefault("gen_random_uuid()"))
+	require.Equal(t, nil, c1.Default)
+	require.NoError(t, c1.ScanDefault("00000000-0000-0000-0000-000000000000"))
+	require.Equal(t, "00000000-0000-0000-0000-000000000000", c1.Default)
 }


### PR DESCRIPTION
also add more info in error, the error before `unsupported default type: [16]byte` is too hard to find the error reason