### PR TITLE
dialect/sql/schema: do not set timestamp to nullable columns on MySQL…

### DIFF
--- a/dialect/sql/schema/mysql.go
+++ b/dialect/sql/schema/mysql.go
@@ -254,9 +254,12 @@ func (d *MySQL) cType(c *Column) (t string) {
 		t = c.scanTypeOr("double")
 	case field.TypeTime:
 		t = c.scanTypeOr("timestamp")
-		// In MySQL, timestamp columns are `NOT NULL` by default, and assigning NULL
-		// assigns the current_timestamp(). We avoid this if not set otherwise.
-		c.Nullable = c.Attr == ""
+		// In MySQL < v8.0.2, the TIMESTAMP column has both `DEFAULT CURRENT_TIMESTAMP` and
+		// `ON UPDATE CURRENT_TIMESTAMP` if neither is specified explicitly. this behavior is
+		// suppressed if the column is defined with a `DEFAULT` clause or with the `NULL` attribute.
+		if compareVersions(d.version, "8.0.2") == -1 && c.Default == nil {
+			c.Nullable = c.Attr == ""
+		}
 	case field.TypeEnum:
 		values := make([]string, len(c.Enums))
 		for i, e := range c.Enums {

--- a/dialect/sql/schema/mysql_test.go
+++ b/dialect/sql/schema/mysql_test.go
@@ -58,6 +58,8 @@ func TestMySQL_Create(t *testing.T) {
 						{Name: "doc", Type: field.TypeJSON, Nullable: true},
 						{Name: "enums", Type: field.TypeEnum, Enums: []string{"a", "b"}},
 						{Name: "uuid", Type: field.TypeUUID, Nullable: true},
+						{Name: "ts", Type: field.TypeTime},
+						{Name: "ts_default", Type: field.TypeTime, Default: "CURRENT_TIMESTAMP"},
 						{Name: "datetime", Type: field.TypeTime, SchemaType: map[string]string{dialect.MySQL: "datetime"}, Default: "CURRENT_TIMESTAMP"},
 						{Name: "decimal", Type: field.TypeFloat32, SchemaType: map[string]string{dialect.MySQL: "decimal(6,2)"}},
 					},
@@ -71,7 +73,7 @@ func TestMySQL_Create(t *testing.T) {
 			before: func(mock mysqlMock) {
 				mock.start("5.7.8")
 				mock.tableExists("users", false)
-				mock.ExpectExec(escape("CREATE TABLE IF NOT EXISTS `users`(`id` bigint AUTO_INCREMENT NOT NULL, `name` varchar(255) NULL, `age` bigint NOT NULL, `doc` json NULL, `enums` enum('a', 'b') NOT NULL, `uuid` char(36) binary NULL, `datetime` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP, `decimal` decimal(6,2) NOT NULL, PRIMARY KEY(`id`)) CHARACTER SET utf8 COLLATE utf8_general_ci ENGINE = INNODB")).
+				mock.ExpectExec(escape("CREATE TABLE IF NOT EXISTS `users`(`id` bigint AUTO_INCREMENT NOT NULL, `name` varchar(255) NULL, `age` bigint NOT NULL, `doc` json NULL, `enums` enum('a', 'b') NOT NULL, `uuid` char(36) binary NULL, `ts` timestamp NULL, `ts_default` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP, `datetime` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP, `decimal` decimal(6,2) NOT NULL, PRIMARY KEY(`id`)) CHARACTER SET utf8 COLLATE utf8_general_ci ENGINE = INNODB")).
 					WillReturnResult(sqlmock.NewResult(0, 1))
 				mock.ExpectCommit()
 			},
@@ -201,7 +203,7 @@ func TestMySQL_Create(t *testing.T) {
 			},
 		},
 		{
-			name: "add column to table",
+			name: "add columns to table",
 			tables: []*Table{
 				{
 					Name: "users",
@@ -219,6 +221,7 @@ func TestMySQL_Create(t *testing.T) {
 						{Name: "big", Type: field.TypeInt64},
 						{Name: "big_unsigned", Type: field.TypeUint64},
 						{Name: "decimal", Type: field.TypeFloat64, SchemaType: map[string]string{dialect.MySQL: "decimal(6,2)"}},
+						{Name: "ts", Type: field.TypeTime},
 						{Name: "timestamp", Type: field.TypeTime, SchemaType: map[string]string{dialect.MySQL: "TIMESTAMP"}, Default: "CURRENT_TIMESTAMP"},
 					},
 					PrimaryKey: []*Column{
@@ -250,7 +253,7 @@ func TestMySQL_Create(t *testing.T) {
 					WithArgs("users").
 					WillReturnRows(sqlmock.NewRows([]string{"index_name", "column_name", "non_unique", "seq_in_index"}).
 						AddRow("PRIMARY", "id", "0", "1"))
-				mock.ExpectExec(escape("ALTER TABLE `users` ADD COLUMN `age` bigint NOT NULL")).
+				mock.ExpectExec(escape("ALTER TABLE `users` ADD COLUMN `age` bigint NOT NULL, ADD COLUMN `ts` timestamp NOT NULL")).
 					WillReturnResult(sqlmock.NewResult(0, 1))
 				mock.ExpectCommit()
 			},


### PR DESCRIPTION
…v8.*

Fixed #1541