### PR TITLE
Dialect: improve equalfold

### DIFF
--- a/dialect/sql/builder_test.go
+++ b/dialect/sql/builder_test.go
@@ -936,7 +936,15 @@ func TestBuilder(t *testing.T) {
 				Select().
 				From(Table("users")).
 				Where(Or(EqualFold("name", "BAR"), EqualFold("name", "BAZ"))),
-			wantQuery: `SELECT * FROM "users" WHERE LOWER("name") = $1 OR LOWER("name") = $2`,
+			wantQuery: `SELECT * FROM "users" WHERE "name" ILIKE $1 OR "name" ILIKE $2`,
+			wantArgs:  []interface{}{"bar", "baz"},
+		},
+		{
+			input: Dialect(dialect.MySQL).
+				Select().
+				From(Table("users")).
+				Where(Or(EqualFold("name", "BAR"), EqualFold("name", "BAZ"))),
+			wantQuery: "SELECT * FROM `users` WHERE `name` COLLATE utf8mb4_general_ci = ? OR `name` COLLATE utf8mb4_general_ci = ?",
 			wantArgs:  []interface{}{"bar", "baz"},
 		},
 		{


### PR DESCRIPTION
Hello ! 

I recently found a ticket mentioning the performance problem of EqualFold because it used "lower", and the impact it had on the different indexes. (#1484 )

I took some inspiration from the ContainsFold method and updated EqualFold to follow the same pattern, except for SQLite that needed the old way of doing (because if we have to lower on both sides, let's just use equal)