### PR TITLE
doc: update supported dialects

### DIFF
--- a/doc/md/dialects.md
+++ b/doc/md/dialects.md
@@ -11,12 +11,12 @@ and it's being tested constantly on the following 3 versions: `5.6.35`, `5.7.26`
 ## MariaDB
 
 MariaDB supports all the features that are mentioned in the [Migration](migrate.md) section,
-and it's being tested constantly on the following 2 versions: `10.2` and latest version.
+and it's being tested constantly on the following 3 versions: `10.2`, `10.3` and latest version.
 
 ## PostgreSQL
 
 PostgreSQL supports all the features that are mentioned in the [Migration](migrate.md) section,
-and it's being tested constantly on the following 3 versions: `10`, `11` and `12`. 
+and it's being tested constantly on the following 4 versions: `10`, `11`, `12` and `13`.
 
 ## SQLite
 


### PR DESCRIPTION
* MariaDB 10.3 has supported by https://github.com/ent/ent/pull/1407.
* PostgreSQL 13 has supported by https://github.com/ent/ent/pull/961.