### PR TITLE
Fix case insensitive match on non ASCII data in SQLite

### DIFF
--- a/dialect/sql/builder.go
+++ b/dialect/sql/builder.go
@@ -1386,14 +1386,21 @@ func (p *Predicate) EqualFold(col, sub string) *Predicate {
 			// We assume the CHARACTER SET is configured to utf8mb4,
 			// because this how it is defined in dialect/sql/schema.
 			b.Ident(col).WriteString(" COLLATE utf8mb4_general_ci = ")
+			b.Arg(sub)
 		case dialect.Postgres:
 			b.Ident(col).WriteString(" ILIKE ")
-		default: // SQLite.
+			b.Arg(sub)
+		case dialect.SQLite:
+			b.Ident(col)
+			b.WriteOp(OpEQ)
+			b.Arg(sub)
+			b.WriteString(" COLLATE NOCASE ")
+		default:
 			f.Lower(col)
 			b.WriteString(f.String())
 			b.WriteOp(OpEQ)
+			b.Arg(strings.ToLower(sub))
 		}
-		b.Arg(strings.ToLower(sub))
 	})
 }
 

--- a/dialect/sql/builder.go
+++ b/dialect/sql/builder.go
@@ -1394,7 +1394,7 @@ func (p *Predicate) EqualFold(col, sub string) *Predicate {
 			b.Ident(col)
 			b.WriteOp(OpEQ)
 			b.Arg(sub)
-			b.WriteString(" COLLATE NOCASE ")
+			b.WriteString(" COLLATE NOCASE")
 		default:
 			f.Lower(col)
 			b.WriteString(f.String())
@@ -1425,13 +1425,19 @@ func (p *Predicate) ContainsFold(col, sub string) *Predicate {
 			// We assume the CHARACTER SET is configured to utf8mb4,
 			// because this how it is defined in dialect/sql/schema.
 			b.Ident(col).WriteString(" COLLATE utf8mb4_general_ci LIKE ")
+			b.Arg("%" + sub + "%")
 		case dialect.Postgres:
 			b.Ident(col).WriteString(" ILIKE ")
-		default: // SQLite.
+			b.Arg("%" + sub + "%")
+		case dialect.SQLite:
+			b.Ident(col).WriteString(" LIKE ")
+			b.Arg("%" + sub + "%")
+			b.WriteString(" COLLATE NOCASE")
+		default:
 			f.Lower(col)
 			b.WriteString(f.String()).WriteString(" LIKE ")
+			b.Arg("%" + strings.ToLower(sub) + "%")
 		}
-		b.Arg("%" + strings.ToLower(sub) + "%")
 	})
 }
 

--- a/dialect/sql/builder_test.go
+++ b/dialect/sql/builder_test.go
@@ -949,6 +949,14 @@ func TestBuilder(t *testing.T) {
 			wantArgs:  []interface{}{"bar", "baz"},
 		},
 		{
+			input: Dialect(dialect.SQLite).
+				Select().
+				From(Table("users")).
+				Where(Or(EqualFold("name", "BAR"), EqualFold("name", "BAZ"))),
+			wantQuery: "SELECT * FROM `users` WHERE `name` = ? COLLATE NOCASE OR `name` = ? COLLATE NOCASE",
+			wantArgs:  []interface{}{"bar", "baz"},
+		},
+		{
 			input: Dialect(dialect.Postgres).
 				Select().
 				From(Table("users")).

--- a/dialect/sql/builder_test.go
+++ b/dialect/sql/builder_test.go
@@ -954,7 +954,7 @@ func TestBuilder(t *testing.T) {
 				From(Table("users")).
 				Where(Or(EqualFold("name", "BAR"), EqualFold("name", "BAZ"))),
 			wantQuery: "SELECT * FROM `users` WHERE `name` = ? COLLATE NOCASE OR `name` = ? COLLATE NOCASE",
-			wantArgs:  []interface{}{"bar", "baz"},
+			wantArgs:  []interface{}{"BAR", "BAZ"},
 		},
 		{
 			input: Dialect(dialect.Postgres).
@@ -962,7 +962,7 @@ func TestBuilder(t *testing.T) {
 				From(Table("users")).
 				Where(Or(EqualFold("name", "BAR"), EqualFold("name", "BAZ"))),
 			wantQuery: `SELECT * FROM "users" WHERE "name" ILIKE $1 OR "name" ILIKE $2`,
-			wantArgs:  []interface{}{"bar", "baz"},
+			wantArgs:  []interface{}{"BAR", "BAZ"},
 		},
 		{
 			input: Dialect(dialect.MySQL).
@@ -970,15 +970,22 @@ func TestBuilder(t *testing.T) {
 				From(Table("users")).
 				Where(Or(EqualFold("name", "BAR"), EqualFold("name", "BAZ"))),
 			wantQuery: "SELECT * FROM `users` WHERE `name` COLLATE utf8mb4_general_ci = ? OR `name` COLLATE utf8mb4_general_ci = ?",
-			wantArgs:  []interface{}{"bar", "baz"},
+			wantArgs:  []interface{}{"BAR", "BAZ"},
+		},
+		{
+			input: Select().
+				From(Table("users")).
+				Where(And(ContainsFold("name", "Ariel"), ContainsFold("nick", "Bar"))),
+			wantQuery: "SELECT * FROM `users` WHERE LOWER(`name`) LIKE ? AND LOWER(`nick`) LIKE ?",
+			wantArgs:  []interface{}{"%ariel%", "%bar%"},
 		},
 		{
 			input: Dialect(dialect.SQLite).
 				Select().
 				From(Table("users")).
 				Where(And(ContainsFold("name", "Ariel"), ContainsFold("nick", "Bar"))),
-			wantQuery: "SELECT * FROM `users` WHERE LOWER(`name`) LIKE ? AND LOWER(`nick`) LIKE ?",
-			wantArgs:  []interface{}{"%ariel%", "%bar%"},
+			wantQuery: "SELECT * FROM `users` WHERE `name` LIKE ? COLLATE NOCASE AND `nick` LIKE ? COLLATE NOCASE",
+			wantArgs:  []interface{}{"%Ariel%", "%Bar%"},
 		},
 		{
 			input: Dialect(dialect.Postgres).
@@ -986,7 +993,7 @@ func TestBuilder(t *testing.T) {
 				From(Table("users")).
 				Where(And(ContainsFold("name", "Ariel"), ContainsFold("nick", "Bar"))),
 			wantQuery: `SELECT * FROM "users" WHERE "name" ILIKE $1 AND "nick" ILIKE $2`,
-			wantArgs:  []interface{}{"%ariel%", "%bar%"},
+			wantArgs:  []interface{}{"%Ariel%", "%Bar%"},
 		},
 		{
 			input: Dialect(dialect.MySQL).
@@ -994,7 +1001,7 @@ func TestBuilder(t *testing.T) {
 				From(Table("users")).
 				Where(And(ContainsFold("name", "Ariel"), ContainsFold("nick", "Bar"))),
 			wantQuery: "SELECT * FROM `users` WHERE `name` COLLATE utf8mb4_general_ci LIKE ? AND `nick` COLLATE utf8mb4_general_ci LIKE ?",
-			wantArgs:  []interface{}{"%ariel%", "%bar%"},
+			wantArgs:  []interface{}{"%Ariel%", "%Bar%"},
 		},
 		{
 			input: func() Querier {


### PR DESCRIPTION
The current implementation for SQLite used the LOWER function for transforming the string, which according to SQLite's documentation only works for ASCII characters
> The lower(X) function returns a copy of string X with all ASCII characters converted to lower case. The default built-in lower() function works for ASCII characters only. To do case conversions on non-ASCII characters, load the ICU extension. 

https://sqlite.org/lang_corefunc.html#lower

I replaced the query with `COLLATE NOCASE`:

> NOCASE - Similar to binary, except that it uses sqlite3_strnicmp() for the comparison. Hence the 26 upper case characters of ASCII are folded to their lower case equivalents before the comparison is performed. Note that only ASCII characters are case folded. SQLite does not attempt to do full UTF case folding due to the size of the tables required. Also note that any U+0000 characters in the string are considered string terminators for comparison purposes.

https://sqlite.org/datatype3.html#collating_sequences