### PR TITLE
Add IndexBuilder.IfNotExists and use for Create() case.

### DIFF
--- a/dialect/sql/builder.go
+++ b/dialect/sql/builder.go
@@ -524,6 +524,7 @@ type IndexBuilder struct {
 	Builder
 	name    string
 	unique  bool
+	exists  bool
 	table   string
 	columns []string
 }
@@ -544,6 +545,12 @@ type IndexBuilder struct {
 //
 func CreateIndex(name string) *IndexBuilder {
 	return &IndexBuilder{name: name}
+}
+
+// IfNotExists appends the `IF NOT EXISTS` clause to the `CREATE INDEX` statement.
+func (i *IndexBuilder) IfNotExists() *IndexBuilder {
+	i.exists = true
+	return i
 }
 
 // Unique sets the index to be a unique index.
@@ -577,6 +584,9 @@ func (i *IndexBuilder) Query() (string, []interface{}) {
 		i.WriteString("UNIQUE ")
 	}
 	i.WriteString("INDEX ")
+	if i.exists {
+		i.WriteString("IF NOT EXISTS ")
+	}
 	i.Ident(i.name)
 	i.WriteString(" ON ")
 	i.Ident(i.table).Nested(func(b *Builder) {

--- a/dialect/sql/builder_test.go
+++ b/dialect/sql/builder_test.go
@@ -1313,6 +1313,14 @@ func TestBuilder(t *testing.T) {
 			wantQuery: `CREATE INDEX "name_index" ON "users"("name")`,
 		},
 		{
+			input: Dialect(dialect.Postgres).
+				CreateIndex("name_index").
+				IfNotExists().
+				Table("users").
+				Column("name"),
+			wantQuery: `CREATE INDEX IF NOT EXISTS "name_index" ON "users"("name")`,
+		},
+		{
 			input:     CreateIndex("unique_name").Unique().Table("users").Columns("first", "last"),
 			wantQuery: "CREATE UNIQUE INDEX `unique_name` ON `users`(`first`, `last`)",
 		},

--- a/dialect/sql/schema/postgres.go
+++ b/dialect/sql/schema/postgres.go
@@ -397,7 +397,7 @@ func hasUniqueName(i *Index) bool {
 	return name != suffix
 }
 
-// addIndex returns the querying for adding an index to PostgreSQL.
+// addIndex returns the query for adding an index to PostgreSQL.
 func (d *Postgres) addIndex(i *Index, table string) *sql.IndexBuilder {
 	name := i.Name
 	if !hasUniqueName(i) {
@@ -406,7 +406,7 @@ func (d *Postgres) addIndex(i *Index, table string) *sql.IndexBuilder {
 		name = fmt.Sprintf("%s_%s", table, i.Name)
 	}
 	idx := sql.Dialect(dialect.Postgres).
-		CreateIndex(name).Table(table)
+		CreateIndex(name).IfNotExists().Table(table)
 	if i.Unique {
 		idx.Unique()
 	}

--- a/dialect/sql/schema/postgres_test.go
+++ b/dialect/sql/schema/postgres_test.go
@@ -533,7 +533,7 @@ func TestPostgres_Create(t *testing.T) {
 				mock.ExpectQuery(escape(fmt.Sprintf(indexesQuery, "CURRENT_SCHEMA()", "users"))).
 					WillReturnRows(sqlmock.NewRows([]string{"index_name", "column_name", "primary", "unique", "seq_in_index"}).
 						AddRow("users_pkey", "id", "t", "t", 0))
-				mock.ExpectExec(escape(`CREATE UNIQUE INDEX "users_age" ON "users"("age")`)).
+				mock.ExpectExec(escape(`CREATE UNIQUE INDEX IF NOT EXISTS "users_age" ON "users"("age")`)).
 					WillReturnResult(sqlmock.NewResult(0, 1))
 				mock.ExpectCommit()
 			},
@@ -655,9 +655,9 @@ func TestPostgres_Create(t *testing.T) {
 						AddRow(0))
 				mock.ExpectExec(escape(`DROP INDEX "user_score"`)).
 					WillReturnResult(sqlmock.NewResult(0, 1))
-				mock.ExpectExec(escape(`CREATE UNIQUE INDEX "users_age" ON "users"("age")`)).
+				mock.ExpectExec(escape(`CREATE UNIQUE INDEX IF NOT EXISTS "users_age" ON "users"("age")`)).
 					WillReturnResult(sqlmock.NewResult(0, 1))
-				mock.ExpectExec(escape(`CREATE UNIQUE INDEX "user_score" ON "users"("score")`)).
+				mock.ExpectExec(escape(`CREATE UNIQUE INDEX IF NOT EXISTS "user_score" ON "users"("score")`)).
 					WillReturnResult(sqlmock.NewResult(0, 1))
 				mock.tableExists("equipment", true)
 				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).

--- a/dialect/sql/schema/sqlite.go
+++ b/dialect/sql/schema/sqlite.go
@@ -142,9 +142,9 @@ func (d *SQLite) addColumn(c *Column) *sql.ColumnBuilder {
 	return b
 }
 
-// addIndex returns the querying for adding an index to SQLite.
+// addIndex returns the query for adding an index to SQLite.
 func (d *SQLite) addIndex(i *Index, table string) *sql.IndexBuilder {
-	return i.Builder(table)
+	return i.Builder(table).IfNotExists()
 }
 
 // dropIndex drops a SQLite index.


### PR DESCRIPTION
Append-only mode creates tables with the `IF NOT EXISTS` annotation.
Make indices case symmetric with this.