### PR TITLE
fix BC break in schema by falling back to the original method.

### DIFF
--- a/entc/gen/type.go
+++ b/entc/gen/type.go
@@ -1044,7 +1044,7 @@ func (f Field) ScanType() string {
 		if f.Nillable && !f.standardNullType() {
 			return "sql.NullScanner"
 		}
-		return f.Type.RType.String()
+		return f.Type.RTypeString()
 	}
 	switch f.Type.Type {
 	case field.TypeJSON, field.TypeBytes:
@@ -1069,7 +1069,7 @@ func (f Field) ScanType() string {
 // nillable-type supported by the SQL driver (e.g. []byte).
 func (f Field) NewScanType() string {
 	if f.Type.ValueScanner() {
-		expr := fmt.Sprintf("new(%s)", f.Type.RType.String())
+		expr := fmt.Sprintf("new(%s)", f.Type.RTypeString())
 		if f.Nillable && !f.standardNullType() {
 			expr = fmt.Sprintf("&sql.NullScanner{S: %s}", expr)
 		}
@@ -1103,7 +1103,7 @@ func (f Field) ScanTypeField(rec string) string {
 			expr = "*" + expr
 		}
 		if f.Nillable && !f.standardNullType() {
-			return fmt.Sprintf("%s.S.(*%s)", expr, f.Type.RType.String())
+			return fmt.Sprintf("%s.S.(*%s)", expr, f.Type.RTypeString())
 		}
 		return expr
 	}

--- a/schema/field/type.go
+++ b/schema/field/type.go
@@ -102,6 +102,15 @@ func (t TypeInfo) String() string {
 	}
 }
 
+// String returns the string representation of a type.
+func (t TypeInfo) RTypeString() string {
+	if t.RType != nil && t.RType.String() != "" {
+		return t.RType.String()
+	}
+
+	return t.String()
+}
+
 // Valid reports if the given type if known type.
 func (t TypeInfo) Valid() bool {
 	return t.Type.Valid()


### PR DESCRIPTION
hmm, in https://github.com/ent/ent/pull/1428/files a BC break in the schema was introduced that is a bit of a pain to migrate.

the main issue is that `RType.Ident` is blank in old schema, I think a very simple fix is to fallback to using the `Type.String()` as `Type.Ident` isn't blank and can be used.  

ugh this is harder to fix than it looks ...  
I *think* this doesn't cause any harm and will allow for smooth upgrading...

it isn't very pretty though as someone could accidently start using `Type.RType.String()` again somewhere in the future instead of `Type.RTypeString()` ...


