### PR TITLE
Support for USING 'method' in create index

### DIFF
--- a/dialect/sql/builder.go
+++ b/dialect/sql/builder.go
@@ -526,6 +526,7 @@ type IndexBuilder struct {
 	unique  bool
 	exists  bool
 	table   string
+	method  string
 	columns []string
 }
 
@@ -565,6 +566,12 @@ func (i *IndexBuilder) Table(table string) *IndexBuilder {
 	return i
 }
 
+// Using sets the method to create the index with.
+func (i *IndexBuilder) Using(method string) *IndexBuilder {
+	i.method = method
+	return i
+}
+
 // Column appends a column to the column list for the index.
 func (i *IndexBuilder) Column(column string) *IndexBuilder {
 	i.columns = append(i.columns, column)
@@ -589,7 +596,11 @@ func (i *IndexBuilder) Query() (string, []interface{}) {
 	}
 	i.Ident(i.name)
 	i.WriteString(" ON ")
-	i.Ident(i.table).Nested(func(b *Builder) {
+	i.Ident(i.table)
+	if i.method != "" {
+		i.WriteString(fmt.Sprintf(" USING %v", i.Quote(i.method)))
+	}
+	i.Nested(func(b *Builder) {
 		b.IdentComma(i.columns...)
 	})
 	return i.String(), nil

--- a/dialect/sql/builder.go
+++ b/dialect/sql/builder.go
@@ -597,14 +597,25 @@ func (i *IndexBuilder) Query() (string, []interface{}) {
 	i.Ident(i.name)
 	i.WriteString(" ON ")
 	i.Ident(i.table)
-	if i.method != "" && i.dialect == dialect.Postgres {
-		i.WriteString(fmt.Sprintf(" USING %v", i.Quote(i.method)))
-	}
-	i.Nested(func(b *Builder) {
-		b.IdentComma(i.columns...)
-	})
-	if i.method != "" && i.dialect == dialect.MySQL {
-		i.WriteString(fmt.Sprintf(" USING %v", i.Quote(i.method)))
+	switch i.dialect {
+	case dialect.Postgres:
+		if i.method != "" {
+			i.WriteString(" USING ").Ident(i.method)
+		}
+		i.Nested(func(b *Builder) {
+			b.IdentComma(i.columns...)
+		})
+	case dialect.MySQL:
+		i.Nested(func(b *Builder) {
+			b.IdentComma(i.columns...)
+		})
+		if i.method != "" {
+			i.WriteString(" USING " + i.method)
+		}
+	default:
+		i.Nested(func(b *Builder) {
+			b.IdentComma(i.columns...)
+		})
 	}
 	return i.String(), nil
 }

--- a/dialect/sql/builder.go
+++ b/dialect/sql/builder.go
@@ -597,12 +597,15 @@ func (i *IndexBuilder) Query() (string, []interface{}) {
 	i.Ident(i.name)
 	i.WriteString(" ON ")
 	i.Ident(i.table)
-	if i.method != "" {
+	if i.method != "" && i.dialect == dialect.Postgres {
 		i.WriteString(fmt.Sprintf(" USING %v", i.Quote(i.method)))
 	}
 	i.Nested(func(b *Builder) {
 		b.IdentComma(i.columns...)
 	})
+	if i.method != "" && i.dialect == dialect.MySQL {
+		i.WriteString(fmt.Sprintf(" USING %v", i.Quote(i.method)))
+	}
 	return i.String(), nil
 }
 

--- a/dialect/sql/builder_test.go
+++ b/dialect/sql/builder_test.go
@@ -1321,6 +1321,15 @@ func TestBuilder(t *testing.T) {
 			wantQuery: `CREATE INDEX IF NOT EXISTS "name_index" ON "users"("name")`,
 		},
 		{
+			input: Dialect(dialect.Postgres).
+				CreateIndex("name_index").
+				IfNotExists().
+				Table("users").
+				Using("gin").
+				Column("name"),
+			wantQuery: `CREATE INDEX IF NOT EXISTS "name_index" ON "users" USING "gin"("name")`,
+		},
+		{
 			input:     CreateIndex("unique_name").Unique().Table("users").Columns("first", "last"),
 			wantQuery: "CREATE UNIQUE INDEX `unique_name` ON `users`(`first`, `last`)",
 		},

--- a/dialect/sql/builder_test.go
+++ b/dialect/sql/builder_test.go
@@ -1336,7 +1336,7 @@ func TestBuilder(t *testing.T) {
 				Table("users").
 				Using("HASH").
 				Column("name"),
-			wantQuery: "CREATE INDEX IF NOT EXISTS `name_index` ON `users`(`name`) USING `HASH`",
+			wantQuery: "CREATE INDEX IF NOT EXISTS `name_index` ON `users`(`name`) USING HASH",
 		},
 		{
 			input:     CreateIndex("unique_name").Unique().Table("users").Columns("first", "last"),

--- a/dialect/sql/builder_test.go
+++ b/dialect/sql/builder_test.go
@@ -1330,6 +1330,15 @@ func TestBuilder(t *testing.T) {
 			wantQuery: `CREATE INDEX IF NOT EXISTS "name_index" ON "users" USING "gin"("name")`,
 		},
 		{
+			input: Dialect(dialect.MySQL).
+				CreateIndex("name_index").
+				IfNotExists().
+				Table("users").
+				Using("HASH").
+				Column("name"),
+			wantQuery: "CREATE INDEX IF NOT EXISTS `name_index` ON `users`(`name`) USING `HASH`",
+		},
+		{
 			input:     CreateIndex("unique_name").Unique().Table("users").Columns("first", "last"),
 			wantQuery: "CREATE UNIQUE INDEX `unique_name` ON `users`(`first`, `last`)",
 		},


### PR DESCRIPTION
Working with ent is a great experience, and I found it also useful in maintaining raw queries and index creation where the static nature of ent can be at least used with existing generated entities.

Most of the custom stuff requires completely new structures (like for `create/drop text search dictionary` or `create/drop text search configuration`), so there was no need for any modification. However with the index creation there is a `USING <method>` portion - at least in Postgres, where `btree`, `hash`, `gist`, `spgist`, `gin`, and `brin` can be specified. Unfortunately this construction hast to be right in front of the column list, so I'm asking if this could be simply added to the ent itself, as creating a completely new batch of methods seems like an overkill. May be in the future this could be exposed to the front of the schema configuration.

https://www.postgresql.org/docs/12/sql-createindex.html