### PR TITLE
Fix: Append UNION before ORDER BY

### DIFF
--- a/dialect/sql/builder.go
+++ b/dialect/sql/builder.go
@@ -2320,6 +2320,9 @@ func (s *Selector) Query() (string, []interface{}) {
 		b.WriteString(" HAVING ")
 		b.Join(s.having)
 	}
+	if len(s.union) > 0 {
+		s.joinUnion(&b)
+	}
 	if len(s.order) > 0 {
 		s.joinOrder(&b)
 	}
@@ -2330,9 +2333,6 @@ func (s *Selector) Query() (string, []interface{}) {
 	if s.offset != nil {
 		b.WriteString(" OFFSET ")
 		b.WriteString(strconv.Itoa(*s.offset))
-	}
-	if len(s.union) > 0 {
-		s.joinUnion(&b)
 	}
 	s.joinLock(&b)
 	s.total = b.total

--- a/dialect/sql/builder_test.go
+++ b/dialect/sql/builder_test.go
@@ -1715,4 +1715,3 @@ func TestSelector_UnionOrderBy(t *testing.T) {
 		Query()
 	require.Equal(t, `SELECT * FROM "users" WHERE "active" = $1 UNION SELECT * FROM "old_users1" ORDER BY "users"."whatever"`, query)
 }
-

--- a/dialect/sql/builder_test.go
+++ b/dialect/sql/builder_test.go
@@ -1703,3 +1703,16 @@ func TestSelectWithLock(t *testing.T) {
 	require.Equal(t, "SELECT * FROM `users` WHERE `id` = ? LOCK IN SHARE MODE", query)
 	require.Equal(t, 20, args[0])
 }
+
+func TestSelector_UnionOrderBy(t *testing.T) {
+	table := Table("users")
+	query, _ := Dialect(dialect.Postgres).
+		Select("*").
+		From(table).
+		Where(EQ("active", true)).
+		Union(Select("*").From(Table("old_users1"))).
+		OrderBy(table.C("whatever")).
+		Query()
+	require.Equal(t, `SELECT * FROM "users" WHERE "active" = $1 UNION SELECT * FROM "old_users1" ORDER BY "users"."whatever"`, query)
+}
+


### PR DESCRIPTION
As reported in issue #1754 , specifying ORDER BY with union results in syntax error as ORDER BY wrongly gets appended before UNION. This PR fixes that by modifying the builder to append UNION before ORDER BY.
- Resolves #1754