### PR TITLE
don't call inner Scan for nil values

### DIFF
--- a/dialect/sql/driver.go
+++ b/dialect/sql/driver.go
@@ -160,5 +160,8 @@ type NullScanner struct {
 // Scan implements the Scanner interface.
 func (n *NullScanner) Scan(value interface{}) error {
 	n.Valid = value != nil
-	return n.S.Scan(value)
+	if n.Valid {
+		return n.S.Scan(value)
+	}
+	return nil
 }


### PR DESCRIPTION
This allows you to use `.Nillable()` on a column with a `.GoType()` which doesn't support `Scan(nil)`.


In our cases this was for `field.Float("price").GoType(decimal.Decimal{}).Nillable()`.  
Now I know there's `decimal.NullDecimal` in this case but it's more cumbersome and the property will actually be a pointer to `decimal.NullDecimal`: `price *decimal.NullDecimal` because of the `Nillable()` (which you want to set the NULL in the migration).  
As a result you get things like `update.SetPrice(&decimal.NullDecimal{Decimal: request.Decimal, Valid: true})` where you need to create a pointer to the struct which is already intended to manage the nullness of the value :/

And I do think this is probably applicable to other things which people would like to use for .GoType()`, not every `Scan()` was writting with the idea of handling a nil value.