### PR TITLE
doc/website/blog: Fixes a typo in elk blog post.

### DIFF
--- a/doc/website/blog/2021-07-29-generate-a-fully-working-go-crud-http-api-with-ent.md
+++ b/doc/website/blog/2021-07-29-generate-a-fully-working-go-crud-http-api-with-ent.md
@@ -38,7 +38,7 @@ cd elk-example
 go mod init elk-example
 ```
 
-Invoke the ent code generator and create three schemas: User, Pet, Group:
+Invoke the ent code generator and create two schemas: User, Pet:
 
 ```shell
 go run -mod=mod entgo.io/ent/cmd/ent init Pet User


### PR DESCRIPTION
This was feedbacked to me by a reader.