### PR TITLE
docs/md/codegen fix typo in EnsureStructTag example

### DIFF
--- a/doc/md/code-gen.md
+++ b/doc/md/code-gen.md
@@ -222,7 +222,7 @@ func EnsureStructTag(name string) gen.Hook {
 				for _, field := range node.Fields {
 					tag := reflect.StructTag(field.StructTag)
 					if _, ok := tag.Lookup(name); !ok {
-						return fmt.Errorf("struct tag %q is missing for field %s.%s", name, node.Name, f.Name)
+						return fmt.Errorf("struct tag %q is missing for field %s.%s", name, node.Name, field.Name)
 					}
 				}
 			}


### PR DESCRIPTION
Fixed a typo  that blocked the code from compiling 