### PR TITLE
Fix typos in documentation

### DIFF
--- a/doc/md/crud.md
+++ b/doc/md/crud.md
@@ -243,7 +243,7 @@ err := client.User.
 	Create().
 	SetName("Ariel").
 	OnConflictColumns(user.FieldName).
-	UpadteNewValues().
+	UpdateNewValues().
 	Exec(ctx)
 
 // Setting the column names using the SQL API.
@@ -253,7 +253,7 @@ err := client.User.
 	OnConflict(
 	    sql.ConflictColumns(user.FieldName),	
 	).
-	UpadteNewValues().
+	UpdateNewValues().
 	Exec(ctx)
 
 // Setting the constraint name using the SQL API.
@@ -263,7 +263,7 @@ err := client.User.
 	OnConflict(
 	    sql.ConflictConstraint(constraint),	
 	).
-	UpadteNewValues().
+	UpdateNewValues().
 	Exec(ctx)
 ```
 
@@ -298,7 +298,7 @@ for such operations.
 err := client.User.             // UserClient
 	CreateBulk(builders...).    // User bulk create.
 	OnConflict().               // User bulk upsert.
-	UpadteNewValues().          // Use the values that were set on create in case of conflict.
+	UpdateNewValues().          // Use the values that were set on create in case of conflict.
 	Exec(ctx)                   // Execute the statement.
 ```
 

--- a/doc/md/features.md
+++ b/doc/md/features.md
@@ -172,7 +172,7 @@ id, err := client.User.
 	SetAge(30).
 	SetName("Ariel").
 	OnConflict().
-	UpadteNewValues().
+	UpdateNewValues().
 	ID(ctx)
 
 // In PostgreSQL, the conflict target is required.
@@ -181,7 +181,7 @@ err := client.User.
 	SetAge(30).
 	SetName("Ariel").
 	OnConflictColumns(user.FieldName).
-	UpadteNewValues().
+	UpdateNewValues().
 	Exec(ctx)
 
 // Bulk upsert is also supported.
@@ -191,7 +191,7 @@ client.User.
 		sql.ConflictWhere(...),
 		sql.UpdateWhere(...),
 	).
-	UpadteNewValues().
+	UpdateNewValues().
 	Exec(ctx)
 
 // INSERT INTO "users" (...) VALUES ... ON CONFLICT WHERE ... DO UPDATE SET ... WHERE ...


### PR DESCRIPTION
I found these while reading the documentation.

![Screen Shot 2021-08-05 at 9 17 29 AM](https://user-images.githubusercontent.com/662807/128365589-7e60e5b9-1dbf-4de0-ac35-a456466aea9d.png)
