### PR TITLE
fix: add case for check is default value schema change or not

### DIFF
--- a/dialect/sql/schema/migrate.go
+++ b/dialect/sql/schema/migrate.go
@@ -364,6 +364,8 @@ func (m *Migrate) changeSet(curr, new *Table) (*changes, error) {
 		// Change nullability of a column.
 		case c1.Nullable != c2.Nullable:
 			change.column.modify = append(change.column.modify, c1)
+		case c1.Default != c2.Default:
+			change.column.modify = append(change.column.modify, c1)
 		}
 	}
 


### PR DESCRIPTION
As reported in issue #1758, we need to add a case to check whether the default value in a schema has changed or not. if there is a change in the default attribute then we have to make sure our migration also changes the default value.