### PR TITLE
Update graphql.md

### DIFF
--- a/doc/md/graphql.md
+++ b/doc/md/graphql.md
@@ -80,7 +80,7 @@ However, if you use a custom format for the global unique identifiers, you can c
 ```go
 func (r *queryResolver) Node(ctx context.Context, guid string) (ent.Noder, error) {
 	typ, id := parseGUID(guid)
-	return r.client.Noder(ctx, id, ent.WithNodeType(typ))
+	return r.client.Noder(ctx, id, ent.WithFixedNodeType(typ))
 }
 ```
 


### PR DESCRIPTION
fix typo in doc: `WithNodeType` accepts a mapping function, while `WithFixedNodeType` accepts a `string` e.g. the typ name.