### PR TITLE
refactor(entc/integration): change `Save` to `Exec` in create operation

### DIFF
--- a/entc/integration/type_test.go
+++ b/entc/integration/type_test.go
@@ -117,23 +117,23 @@ func Types(t *testing.T, client *ent.Client) {
 	require.NoError(err)
 	require.False(exists)
 
-	_, err = client.FieldType.Create().
+	err = client.FieldType.Create().
 		SetInt(1).
 		SetInt8(8).
 		SetInt16(16).
 		SetInt32(32).
 		SetInt64(64).
 		SetRawData(make([]byte, 40)).
-		Save(ctx)
+		Exec(ctx)
 	require.Error(err, "MaxLen validator should reject this operation")
-	_, err = client.FieldType.Create().
+	err = client.FieldType.Create().
 		SetInt(1).
 		SetInt8(8).
 		SetInt16(16).
 		SetInt32(32).
 		SetInt64(64).
 		SetRawData(make([]byte, 2)).
-		Save(ctx)
+		Exec(ctx)
 	require.Error(err, "MinLen validator should reject this operation")
 	ft = ft.Update().
 		SetInt(1).
@@ -198,13 +198,13 @@ func Types(t *testing.T, client *ent.Client) {
 	require.EqualValues(100, ft.Int64, "UpdateDefault sets the value to 100")
 	require.EqualValues(100, ft.Duration, "UpdateDefault sets the value to 100ns")
 
-	_, err = client.Task.CreateBulk(
+	err = client.Task.CreateBulk(
 		client.Task.Create().SetPriority(schema.PriorityLow),
 		client.Task.Create().SetPriority(schema.PriorityMid),
 		client.Task.Create().SetPriority(schema.PriorityHigh),
-	).Save(ctx)
+	).Exec(ctx)
 	require.NoError(err)
-	_, err = client.Task.Create().SetPriority(schema.Priority(10)).Save(ctx)
+	err = client.Task.Create().SetPriority(schema.Priority(10)).Exec(ctx)
 	require.Error(err)
 
 	tasks := client.Task.Query().Order(ent.Asc(task.FieldPriority)).AllX(ctx)


### PR DESCRIPTION
**Description**

I made some code changes to file `type_test.go`, changing from `Save` to `Exec` in the `Create` operation.

Please check it, if you have a time, Thanks!

cc @a8m 