### PR TITLE
refactor(entc/integration): change Save to Exec in create operation

### DIFF
--- a/entc/integration/hooks/hooks_test.go
+++ b/entc/integration/hooks/hooks_test.go
@@ -25,7 +25,7 @@ func TestSchemaHooks(t *testing.T) {
 	ctx := context.Background()
 	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1", enttest.WithMigrateOptions(migrate.WithGlobalUniqueID(true)))
 	defer client.Close()
-	_, err := client.Card.Create().SetNumber("123").Save(ctx)
+	err := client.Card.Create().SetNumber("123").Exec(ctx)
 	require.EqualError(t, err, "card number is too short", "error is returned from hook")
 	crd := client.Card.Create().SetNumber("1234").SaveX(ctx)
 	require.Equal(t, "unknown", crd.Name, "name was set by hook")
@@ -37,7 +37,7 @@ func TestSchemaHooks(t *testing.T) {
 		})
 	})
 	client.Card.Create().SetNumber("1234").SaveX(ctx)
-	_, err = client.Card.Update().Save(ctx)
+	err = client.Card.Update().Exec(ctx)
 	require.EqualError(t, err, "OpUpdate operation is not allowed")
 }
 

--- a/entc/integration/hooks/hooks_test.go
+++ b/entc/integration/hooks/hooks_test.go
@@ -257,7 +257,7 @@ func TestOldValues(t *testing.T) {
 	}, ^ent.OpUpdateOne))
 	a8m := client.User.Create().SetName("a8m").SaveX(ctx)
 	require.Equal(t, "a8m", a8m.Name)
-	_, err := client.User.UpdateOne(a8m).SetName("Ariel").SetVersion(a8m.Version).Save(ctx)
+	err := client.User.UpdateOne(a8m).SetName("Ariel").SetVersion(a8m.Version).Exec(ctx)
 	require.EqualError(t, err, "version field must be incremented by 1")
 	a8m = client.User.UpdateOne(a8m).SetName("Ariel").SetVersion(a8m.Version + 1).SaveX(ctx)
 	require.Equal(t, "Ariel", a8m.Name)

--- a/entc/integration/migrate/migrate_test.go
+++ b/entc/integration/migrate/migrate_test.go
@@ -253,7 +253,7 @@ func SanityV2(t *testing.T, dbdialect string, client *entv2.Client) {
 	)
 
 	// Blob type was extended.
-	err = u.Update().SetBlob(make([]byte, 256)).SetState(user.StateLoggedOut).Exec(ctx)
+	u, err = u.Update().SetBlob(make([]byte, 256)).SetState(user.StateLoggedOut).Save(ctx)
 	require.NoError(t, err, "data type blob was extended in v2")
 	require.Equal(t, make([]byte, 256), u.Blob)
 

--- a/entc/integration/migrate/migrate_test.go
+++ b/entc/integration/migrate/migrate_test.go
@@ -150,22 +150,22 @@ func SanityV1(t *testing.T, dbdialect string, client *entv1.Client) {
 	require.EqualValues(t, 1, u.Age)
 	require.Equal(t, "foo", u.Name)
 
-	_, err := client.User.Create().SetAge(2).SetName("foobarbazqux").Save(ctx)
+	err := client.User.Create().SetAge(2).SetName("foobarbazqux").Exec(ctx)
 	require.Error(t, err, "name is limited to 10 chars")
 
 	// Unique index on (name, address).
 	client.User.Create().SetAge(3).SetName("foo").SetNickname("nick_foo_2").SetAddress("tlv").SetState(userv1.StateLoggedIn).SaveX(ctx)
-	_, err = client.User.Create().SetAge(4).SetName("foo").SetAddress("tlv").Save(ctx)
+	err = client.User.Create().SetAge(4).SetName("foo").SetAddress("tlv").Exec(ctx)
 	require.Error(t, err)
 
 	// Blob type limited to 255.
 	u = u.Update().SetBlob([]byte("hello")).SaveX(ctx)
 	require.Equal(t, "hello", string(u.Blob))
-	_, err = u.Update().SetBlob(make([]byte, 256)).Save(ctx)
+	err = u.Update().SetBlob(make([]byte, 256)).Exec(ctx)
 	require.True(t, strings.Contains(t.Name(), "Postgres") || err != nil, "blob should be limited on SQLite and MySQL")
 
 	// Invalid enum value.
-	_, err = client.User.Create().SetAge(1).SetName("bar").SetNickname("nick_bar").SetState("unknown").Save(ctx)
+	err = client.User.Create().SetAge(1).SetName("bar").SetNickname("nick_bar").SetState("unknown").Exec(ctx)
 	require.Error(t, err)
 
 	// Conversions
@@ -232,16 +232,16 @@ func SanityV2(t *testing.T, dbdialect string, client *entv2.Client) {
 	require.Equal(t, []byte("[]"), u.Buffer)
 	require.Equal(t, user.StateLoggedOut, u.State)
 
-	_, err := u.Update().SetState(user.State("boring")).Save(ctx)
+	err := u.Update().SetState(user.State("boring")).Exec(ctx)
 	require.Error(t, err, "invalid enum value")
 	u = u.Update().SetState(user.StateOnline).SaveX(ctx)
 	require.Equal(t, user.StateOnline, u.State)
 
-	_, err = client.User.Create().SetAge(1).SetName("foobarbazqux").SetNickname("nick_bar").SetPhone("200").Save(ctx)
+	err = client.User.Create().SetAge(1).SetName("foobarbazqux").SetNickname("nick_bar").SetPhone("200").Exec(ctx)
 	require.NoError(t, err, "name is not limited to 10 chars and nickname is not unique")
 
 	// New unique index was added to (age, phone).
-	_, err = client.User.Create().SetAge(1).SetName("foo").SetPhone("200").SetNickname("nick_bar").Save(ctx)
+	err = client.User.Create().SetAge(1).SetName("foo").SetPhone("200").SetNickname("nick_bar").Exec(ctx)
 	require.Error(t, err)
 	require.True(t, entv2.IsConstraintError(err))
 
@@ -253,7 +253,7 @@ func SanityV2(t *testing.T, dbdialect string, client *entv2.Client) {
 	)
 
 	// Blob type was extended.
-	u, err = u.Update().SetBlob(make([]byte, 256)).SetState(user.StateLoggedOut).Save(ctx)
+	err = u.Update().SetBlob(make([]byte, 256)).SetState(user.StateLoggedOut).Exec(ctx)
 	require.NoError(t, err, "data type blob was extended in v2")
 	require.Equal(t, make([]byte, 256), u.Blob)
 
@@ -302,9 +302,9 @@ func SanityV2(t *testing.T, dbdialect string, client *entv2.Client) {
 func CheckConstraint(t *testing.T, client *entv2.Client) {
 	ctx := context.Background()
 	t.Log("testing check constraints")
-	_, err := client.Media.Create().SetText("boring").Save(ctx)
+	err := client.Media.Create().SetText("boring").Exec(ctx)
 	require.Error(t, err)
-	_, err = client.Media.Create().SetSourceURI("entgo.io").Save(ctx)
+	err = client.Media.Create().SetSourceURI("entgo.io").Exec(ctx)
 	require.Error(t, err)
 }
 


### PR DESCRIPTION
**Description**

I made some code changes to file `type_test.go`, changing from `Save` to `Exec` in the Create operation.

List of file that I'have changed:

1. `entc/integration/migrate/migrate_test.go`
2. `entc/integration/hooks/hooks_test.go`

Please check it, if you have a time, Thanks!

cc @a8m 