### PR TITLE
all: add (*testing.B).ReportAllocs() to all benchmarks

### DIFF
--- a/dialect/gremlin/encoding/graphson/bench_test.go
+++ b/dialect/gremlin/encoding/graphson/bench_test.go
@@ -31,6 +31,7 @@ func generateObject() *book {
 func BenchmarkMarshalObject(b *testing.B) {
 	obj := generateObject()
 
+	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		_, err := Marshal(obj)
@@ -41,6 +42,7 @@ func BenchmarkMarshalObject(b *testing.B) {
 }
 
 func BenchmarkUnmarshalObject(b *testing.B) {
+	b.ReportAllocs()
 	out, err := Marshal(generateObject())
 	if err != nil {
 		b.Fatal(err)
@@ -58,6 +60,7 @@ func BenchmarkUnmarshalObject(b *testing.B) {
 }
 
 func BenchmarkMarshalInterface(b *testing.B) {
+	b.ReportAllocs()
 	data, err := jsoniter.Marshal(generateObject())
 	if err != nil {
 		b.Fatal(err)
@@ -78,6 +81,7 @@ func BenchmarkMarshalInterface(b *testing.B) {
 }
 
 func BenchmarkUnmarshalInterface(b *testing.B) {
+	b.ReportAllocs()
 	data, err := Marshal(generateObject())
 	if err != nil {
 		b.Fatal(err)

--- a/dialect/sql/bench_test.go
+++ b/dialect/sql/bench_test.go
@@ -13,6 +13,7 @@ import (
 func BenchmarkInsertBuilder_Default(b *testing.B) {
 	for _, d := range []string{dialect.SQLite, dialect.MySQL, dialect.Postgres} {
 		b.Run(d, func(b *testing.B) {
+			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
 				Dialect(d).Insert("users").Default().Returning("id").Query()
 			}
@@ -23,6 +24,7 @@ func BenchmarkInsertBuilder_Default(b *testing.B) {
 func BenchmarkInsertBuilder_Small(b *testing.B) {
 	for _, d := range []string{dialect.SQLite, dialect.MySQL, dialect.Postgres} {
 		b.Run(d, func(b *testing.B) {
+			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
 				Dialect(d).Insert("users").
 					Columns("id", "age", "first_name", "last_name", "nickname", "spouse_id", "created_at", "updated_at").

--- a/entc/gen/bench_test.go
+++ b/entc/gen/bench_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func BenchmarkGraph_Gen(b *testing.B) {
+	b.ReportAllocs()
 	target := filepath.Join(os.TempDir(), "ent")
 	require.NoError(b, os.MkdirAll(target, os.ModePerm), "creating tmpdir")
 	defer os.RemoveAll(target)


### PR DESCRIPTION
This allows a full picture when continuous benchmarking
is added to this repository and when any changes are made
to the code in here.

Fixes #1918

This allows for hassle-free continuous benchmarking for example per https://dashboard.github.orijtech.com/benchmark/1cd1d34215e044cda8e391a2daf7448a
![Screen Shot 2021-09-06 at 2 15 03 AM](https://user-images.githubusercontent.com/4898263/132192398-155a646d-f2c6-4daf-b9fa-1c5a8d2685af.png)
