### PR TITLE
feat(dialect): support mediumtext

### DIFF
--- a/dialect/sql/schema/mysql.go
+++ b/dialect/sql/schema/mysql.go
@@ -461,6 +461,9 @@ func (d *MySQL) scanColumn(c *Column, rows *sql.Rows) error {
 	case "text":
 		c.Size = math.MaxUint16
 		c.Type = field.TypeString
+	case "mediumtext":
+		c.Size = 1<<24 - 1
+		c.Type = field.TypeString
 	case "longtext":
 		c.Size = math.MaxInt32
 		c.Type = field.TypeString


### PR DESCRIPTION
Signed-off-by: storyicon <yuanchao@bilibili.com>

When using the `mediumtext` type of MySQL, the following problems occur:
```
sql/schema: mysql: unknown column type "mediumtext" for version "5.7.31-log"
```
This PR is intended to fix this problem.