### PR TITLE
entc/gen: fix bug with enum separators

### DIFF
--- a/entc/gen/type.go
+++ b/entc/gen/type.go
@@ -903,7 +903,7 @@ func (f Field) EnumValues() []string {
 
 // EnumName returns the constant name for the enum.
 func (f Field) EnumName(enum string) string {
-	if !token.IsExported(enum) {
+	if !token.IsExported(enum) || !token.IsIdentifier(enum) {
 		enum = pascal(enum)
 	}
 	return pascal(f.Name) + enum

--- a/entc/integration/ent/entql.go
+++ b/entc/integration/ent/entql.go
@@ -310,6 +310,7 @@ var schemaGraph = func() *sqlgraph.Schema {
 			user.FieldPhone:       {Type: field.TypeString, Column: user.FieldPhone},
 			user.FieldPassword:    {Type: field.TypeString, Column: user.FieldPassword},
 			user.FieldRole:        {Type: field.TypeEnum, Column: user.FieldRole},
+			user.FieldEmployment:  {Type: field.TypeEnum, Column: user.FieldEmployment},
 			user.FieldSSOCert:     {Type: field.TypeString, Column: user.FieldSSOCert},
 		},
 	}
@@ -1914,6 +1915,11 @@ func (f *UserFilter) WherePassword(p entql.StringP) {
 // WhereRole applies the entql string predicate on the role field.
 func (f *UserFilter) WhereRole(p entql.StringP) {
 	f.Where(p.Field(user.FieldRole))
+}
+
+// WhereEmployment applies the entql string predicate on the employment field.
+func (f *UserFilter) WhereEmployment(p entql.StringP) {
+	f.Where(p.Field(user.FieldEmployment))
 }
 
 // WhereSSOCert applies the entql string predicate on the SSOCert field.

--- a/entc/integration/ent/migrate/schema.go
+++ b/entc/integration/ent/migrate/schema.go
@@ -372,6 +372,7 @@ var (
 		{Name: "phone", Type: field.TypeString, Unique: true, Nullable: true},
 		{Name: "password", Type: field.TypeString, Nullable: true},
 		{Name: "role", Type: field.TypeEnum, Enums: []string{"user", "admin", "free-user", "test user"}, Default: "user"},
+		{Name: "employment", Type: field.TypeEnum, Enums: []string{"Full-Time", "Part-Time", "Contract"}, Default: "Full-Time"},
 		{Name: "sso_cert", Type: field.TypeString, Nullable: true},
 		{Name: "group_blocked", Type: field.TypeInt, Nullable: true},
 		{Name: "user_spouse", Type: field.TypeInt, Unique: true, Nullable: true},
@@ -385,19 +386,19 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "users_groups_blocked",
-				Columns:    []*schema.Column{UsersColumns[11]},
+				Columns:    []*schema.Column{UsersColumns[12]},
 				RefColumns: []*schema.Column{GroupsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "users_users_spouse",
-				Columns:    []*schema.Column{UsersColumns[12]},
+				Columns:    []*schema.Column{UsersColumns[13]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "users_users_parent",
-				Columns:    []*schema.Column{UsersColumns[13]},
+				Columns:    []*schema.Column{UsersColumns[14]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
 				OnDelete:   schema.SetNull,
 			},

--- a/entc/integration/ent/mutation.go
+++ b/entc/integration/ent/mutation.go
@@ -11903,6 +11903,7 @@ type UserMutation struct {
 	phone            *string
 	password         *string
 	role             *user.Role
+	employment       *user.Employment
 	_SSOCert         *string
 	clearedFields    map[string]struct{}
 	card             *int
@@ -12446,6 +12447,42 @@ func (m *UserMutation) OldRole(ctx context.Context) (v user.Role, err error) {
 // ResetRole resets all changes to the "role" field.
 func (m *UserMutation) ResetRole() {
 	m.role = nil
+}
+
+// SetEmployment sets the "employment" field.
+func (m *UserMutation) SetEmployment(u user.Employment) {
+	m.employment = &u
+}
+
+// Employment returns the value of the "employment" field in the mutation.
+func (m *UserMutation) Employment() (r user.Employment, exists bool) {
+	v := m.employment
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldEmployment returns the old "employment" field's value of the User entity.
+// If the User object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *UserMutation) OldEmployment(ctx context.Context) (v user.Employment, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, fmt.Errorf("OldEmployment is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, fmt.Errorf("OldEmployment requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldEmployment: %w", err)
+	}
+	return oldValue.Employment, nil
+}
+
+// ResetEmployment resets all changes to the "employment" field.
+func (m *UserMutation) ResetEmployment() {
+	m.employment = nil
 }
 
 // SetSSOCert sets the "SSOCert" field.
@@ -13050,7 +13087,7 @@ func (m *UserMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *UserMutation) Fields() []string {
-	fields := make([]string, 0, 10)
+	fields := make([]string, 0, 11)
 	if m.optional_int != nil {
 		fields = append(fields, user.FieldOptionalInt)
 	}
@@ -13077,6 +13114,9 @@ func (m *UserMutation) Fields() []string {
 	}
 	if m.role != nil {
 		fields = append(fields, user.FieldRole)
+	}
+	if m.employment != nil {
+		fields = append(fields, user.FieldEmployment)
 	}
 	if m._SSOCert != nil {
 		fields = append(fields, user.FieldSSOCert)
@@ -13107,6 +13147,8 @@ func (m *UserMutation) Field(name string) (ent.Value, bool) {
 		return m.Password()
 	case user.FieldRole:
 		return m.Role()
+	case user.FieldEmployment:
+		return m.Employment()
 	case user.FieldSSOCert:
 		return m.SSOCert()
 	}
@@ -13136,6 +13178,8 @@ func (m *UserMutation) OldField(ctx context.Context, name string) (ent.Value, er
 		return m.OldPassword(ctx)
 	case user.FieldRole:
 		return m.OldRole(ctx)
+	case user.FieldEmployment:
+		return m.OldEmployment(ctx)
 	case user.FieldSSOCert:
 		return m.OldSSOCert(ctx)
 	}
@@ -13209,6 +13253,13 @@ func (m *UserMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetRole(v)
+		return nil
+	case user.FieldEmployment:
+		v, ok := value.(user.Employment)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetEmployment(v)
 		return nil
 	case user.FieldSSOCert:
 		v, ok := value.(string)
@@ -13358,6 +13409,9 @@ func (m *UserMutation) ResetField(name string) error {
 		return nil
 	case user.FieldRole:
 		m.ResetRole()
+		return nil
+	case user.FieldEmployment:
+		m.ResetEmployment()
 		return nil
 	case user.FieldSSOCert:
 		m.ResetSSOCert()

--- a/entc/integration/ent/schema/user.go
+++ b/entc/integration/ent/schema/user.go
@@ -46,6 +46,9 @@ func (User) Fields() []ent.Field {
 		field.Enum("role").
 			Values("user", "admin", "free-user", "test user").
 			Default("user"),
+		field.Enum("employment").
+			Values("Full-Time", "Part-Time", "Contract").
+			Default("Full-Time"),
 		field.String("SSOCert").
 			Optional(),
 	}

--- a/entc/integration/ent/user.go
+++ b/entc/integration/ent/user.go
@@ -39,6 +39,8 @@ type User struct {
 	Password string `graphql:"-" json:"-"`
 	// Role holds the value of the "role" field.
 	Role user.Role `json:"role,omitempty"`
+	// Employment holds the value of the "employment" field.
+	Employment user.Employment `json:"employment,omitempty"`
 	// SSOCert holds the value of the "SSOCert" field.
 	SSOCert string `json:"SSOCert,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
@@ -204,7 +206,7 @@ func (*User) scanValues(columns []string) ([]interface{}, error) {
 		switch columns[i] {
 		case user.FieldID, user.FieldOptionalInt, user.FieldAge:
 			values[i] = new(sql.NullInt64)
-		case user.FieldName, user.FieldLast, user.FieldNickname, user.FieldAddress, user.FieldPhone, user.FieldPassword, user.FieldRole, user.FieldSSOCert:
+		case user.FieldName, user.FieldLast, user.FieldNickname, user.FieldAddress, user.FieldPhone, user.FieldPassword, user.FieldRole, user.FieldEmployment, user.FieldSSOCert:
 			values[i] = new(sql.NullString)
 		case user.ForeignKeys[0]: // group_blocked
 			values[i] = new(sql.NullInt64)
@@ -286,6 +288,12 @@ func (u *User) assignValues(columns []string, values []interface{}) error {
 				return fmt.Errorf("unexpected type %T for field role", values[i])
 			} else if value.Valid {
 				u.Role = user.Role(value.String)
+			}
+		case user.FieldEmployment:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field employment", values[i])
+			} else if value.Valid {
+				u.Employment = user.Employment(value.String)
 			}
 		case user.FieldSSOCert:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -414,6 +422,8 @@ func (u *User) String() string {
 	builder.WriteString(", password=<sensitive>")
 	builder.WriteString(", role=")
 	builder.WriteString(fmt.Sprintf("%v", u.Role))
+	builder.WriteString(", employment=")
+	builder.WriteString(fmt.Sprintf("%v", u.Employment))
 	builder.WriteString(", SSOCert=")
 	builder.WriteString(u.SSOCert)
 	builder.WriteByte(')')

--- a/entc/integration/ent/user/user.go
+++ b/entc/integration/ent/user/user.go
@@ -33,6 +33,8 @@ const (
 	FieldPassword = "password"
 	// FieldRole holds the string denoting the role field in the database.
 	FieldRole = "role"
+	// FieldEmployment holds the string denoting the employment field in the database.
+	FieldEmployment = "employment"
 	// FieldSSOCert holds the string denoting the ssocert field in the database.
 	FieldSSOCert = "sso_cert"
 	// EdgeCard holds the string denoting the card edge name in mutations.
@@ -124,6 +126,7 @@ var Columns = []string{
 	FieldPhone,
 	FieldPassword,
 	FieldRole,
+	FieldEmployment,
 	FieldSSOCert,
 }
 
@@ -202,9 +205,41 @@ func RoleValidator(r Role) error {
 	}
 }
 
+// Employment defines the type for the "employment" enum field.
+type Employment string
+
+// EmploymentFullTime is the default value of the Employment enum.
+const DefaultEmployment = EmploymentFullTime
+
+// Employment values.
+const (
+	EmploymentFullTime Employment = "Full-Time"
+	EmploymentPartTime Employment = "Part-Time"
+	EmploymentContract Employment = "Contract"
+)
+
+func (e Employment) String() string {
+	return string(e)
+}
+
+// EmploymentValidator is a validator for the "employment" field enum values. It is called by the builders before save.
+func EmploymentValidator(e Employment) error {
+	switch e {
+	case EmploymentFullTime, EmploymentPartTime, EmploymentContract:
+		return nil
+	default:
+		return fmt.Errorf("user: invalid enum value for employment field: %q", e)
+	}
+}
+
 // Ptr returns a new pointer to the enum value.
 func (r Role) Ptr() *Role {
 	return &r
+}
+
+// Ptr returns a new pointer to the enum value.
+func (e Employment) Ptr() *Employment {
+	return &e
 }
 
 // comment from another template.

--- a/entc/integration/ent/user/where.go
+++ b/entc/integration/ent/user/where.go
@@ -1094,6 +1094,54 @@ func RoleNotIn(vs ...Role) predicate.User {
 	})
 }
 
+// EmploymentEQ applies the EQ predicate on the "employment" field.
+func EmploymentEQ(v Employment) predicate.User {
+	return predicate.User(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldEmployment), v))
+	})
+}
+
+// EmploymentNEQ applies the NEQ predicate on the "employment" field.
+func EmploymentNEQ(v Employment) predicate.User {
+	return predicate.User(func(s *sql.Selector) {
+		s.Where(sql.NEQ(s.C(FieldEmployment), v))
+	})
+}
+
+// EmploymentIn applies the In predicate on the "employment" field.
+func EmploymentIn(vs ...Employment) predicate.User {
+	v := make([]interface{}, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.User(func(s *sql.Selector) {
+		// if not arguments were provided, append the FALSE constants,
+		// since we can't apply "IN ()". This will make this predicate falsy.
+		if len(v) == 0 {
+			s.Where(sql.False())
+			return
+		}
+		s.Where(sql.In(s.C(FieldEmployment), v...))
+	})
+}
+
+// EmploymentNotIn applies the NotIn predicate on the "employment" field.
+func EmploymentNotIn(vs ...Employment) predicate.User {
+	v := make([]interface{}, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.User(func(s *sql.Selector) {
+		// if not arguments were provided, append the FALSE constants,
+		// since we can't apply "IN ()". This will make this predicate falsy.
+		if len(v) == 0 {
+			s.Where(sql.False())
+			return
+		}
+		s.Where(sql.NotIn(s.C(FieldEmployment), v...))
+	})
+}
+
 // SSOCertEQ applies the EQ predicate on the "SSOCert" field.
 func SSOCertEQ(v string) predicate.User {
 	return predicate.User(func(s *sql.Selector) {

--- a/entc/integration/ent/user_create.go
+++ b/entc/integration/ent/user_create.go
@@ -139,6 +139,20 @@ func (uc *UserCreate) SetNillableRole(u *user.Role) *UserCreate {
 	return uc
 }
 
+// SetEmployment sets the "employment" field.
+func (uc *UserCreate) SetEmployment(u user.Employment) *UserCreate {
+	uc.mutation.SetEmployment(u)
+	return uc
+}
+
+// SetNillableEmployment sets the "employment" field if the given value is not nil.
+func (uc *UserCreate) SetNillableEmployment(u *user.Employment) *UserCreate {
+	if u != nil {
+		uc.SetEmployment(*u)
+	}
+	return uc
+}
+
 // SetSSOCert sets the "SSOCert" field.
 func (uc *UserCreate) SetSSOCert(s string) *UserCreate {
 	uc.mutation.SetSSOCert(s)
@@ -417,6 +431,10 @@ func (uc *UserCreate) defaults() {
 		v := user.DefaultRole
 		uc.mutation.SetRole(v)
 	}
+	if _, ok := uc.mutation.Employment(); !ok {
+		v := user.DefaultEmployment
+		uc.mutation.SetEmployment(v)
+	}
 }
 
 // check runs all checks and user-defined validators on the builder.
@@ -441,6 +459,14 @@ func (uc *UserCreate) check() error {
 	if v, ok := uc.mutation.Role(); ok {
 		if err := user.RoleValidator(v); err != nil {
 			return &ValidationError{Name: "role", err: fmt.Errorf(`ent: validator failed for field "User.role": %w`, err)}
+		}
+	}
+	if _, ok := uc.mutation.Employment(); !ok {
+		return &ValidationError{Name: "employment", err: errors.New(`ent: missing required field "User.employment"`)}
+	}
+	if v, ok := uc.mutation.Employment(); ok {
+		if err := user.EmploymentValidator(v); err != nil {
+			return &ValidationError{Name: "employment", err: fmt.Errorf(`ent: validator failed for field "User.employment": %w`, err)}
 		}
 	}
 	return nil
@@ -542,6 +568,14 @@ func (uc *UserCreate) createSpec() (*User, *sqlgraph.CreateSpec) {
 			Column: user.FieldRole,
 		})
 		_node.Role = value
+	}
+	if value, ok := uc.mutation.Employment(); ok {
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
+			Type:   field.TypeEnum,
+			Value:  value,
+			Column: user.FieldEmployment,
+		})
+		_node.Employment = value
 	}
 	if value, ok := uc.mutation.SSOCert(); ok {
 		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
@@ -966,6 +1000,18 @@ func (u *UserUpsert) UpdateRole() *UserUpsert {
 	return u
 }
 
+// SetEmployment sets the "employment" field.
+func (u *UserUpsert) SetEmployment(v user.Employment) *UserUpsert {
+	u.Set(user.FieldEmployment, v)
+	return u
+}
+
+// UpdateEmployment sets the "employment" field to the value that was provided on create.
+func (u *UserUpsert) UpdateEmployment() *UserUpsert {
+	u.SetExcluded(user.FieldEmployment)
+	return u
+}
+
 // SetSSOCert sets the "SSOCert" field.
 func (u *UserUpsert) SetSSOCert(v string) *UserUpsert {
 	u.Set(user.FieldSSOCert, v)
@@ -1198,6 +1244,20 @@ func (u *UserUpsertOne) SetRole(v user.Role) *UserUpsertOne {
 func (u *UserUpsertOne) UpdateRole() *UserUpsertOne {
 	return u.Update(func(s *UserUpsert) {
 		s.UpdateRole()
+	})
+}
+
+// SetEmployment sets the "employment" field.
+func (u *UserUpsertOne) SetEmployment(v user.Employment) *UserUpsertOne {
+	return u.Update(func(s *UserUpsert) {
+		s.SetEmployment(v)
+	})
+}
+
+// UpdateEmployment sets the "employment" field to the value that was provided on create.
+func (u *UserUpsertOne) UpdateEmployment() *UserUpsertOne {
+	return u.Update(func(s *UserUpsert) {
+		s.UpdateEmployment()
 	})
 }
 
@@ -1598,6 +1658,20 @@ func (u *UserUpsertBulk) SetRole(v user.Role) *UserUpsertBulk {
 func (u *UserUpsertBulk) UpdateRole() *UserUpsertBulk {
 	return u.Update(func(s *UserUpsert) {
 		s.UpdateRole()
+	})
+}
+
+// SetEmployment sets the "employment" field.
+func (u *UserUpsertBulk) SetEmployment(v user.Employment) *UserUpsertBulk {
+	return u.Update(func(s *UserUpsert) {
+		s.SetEmployment(v)
+	})
+}
+
+// UpdateEmployment sets the "employment" field to the value that was provided on create.
+func (u *UserUpsertBulk) UpdateEmployment() *UserUpsertBulk {
+	return u.Update(func(s *UserUpsert) {
+		s.UpdateEmployment()
 	})
 }
 

--- a/entc/integration/ent/user_update.go
+++ b/entc/integration/ent/user_update.go
@@ -189,6 +189,20 @@ func (uu *UserUpdate) SetNillableRole(u *user.Role) *UserUpdate {
 	return uu
 }
 
+// SetEmployment sets the "employment" field.
+func (uu *UserUpdate) SetEmployment(u user.Employment) *UserUpdate {
+	uu.mutation.SetEmployment(u)
+	return uu
+}
+
+// SetNillableEmployment sets the "employment" field if the given value is not nil.
+func (uu *UserUpdate) SetNillableEmployment(u *user.Employment) *UserUpdate {
+	if u != nil {
+		uu.SetEmployment(*u)
+	}
+	return uu
+}
+
 // SetSSOCert sets the "SSOCert" field.
 func (uu *UserUpdate) SetSSOCert(s string) *UserUpdate {
 	uu.mutation.SetSSOCert(s)
@@ -638,6 +652,11 @@ func (uu *UserUpdate) check() error {
 			return &ValidationError{Name: "role", err: fmt.Errorf(`ent: validator failed for field "User.role": %w`, err)}
 		}
 	}
+	if v, ok := uu.mutation.Employment(); ok {
+		if err := user.EmploymentValidator(v); err != nil {
+			return &ValidationError{Name: "employment", err: fmt.Errorf(`ent: validator failed for field "User.employment": %w`, err)}
+		}
+	}
 	return nil
 }
 
@@ -764,6 +783,13 @@ func (uu *UserUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Type:   field.TypeEnum,
 			Value:  value,
 			Column: user.FieldRole,
+		})
+	}
+	if value, ok := uu.mutation.Employment(); ok {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeEnum,
+			Value:  value,
+			Column: user.FieldEmployment,
 		})
 	}
 	if value, ok := uu.mutation.SSOCert(); ok {
@@ -1470,6 +1496,20 @@ func (uuo *UserUpdateOne) SetNillableRole(u *user.Role) *UserUpdateOne {
 	return uuo
 }
 
+// SetEmployment sets the "employment" field.
+func (uuo *UserUpdateOne) SetEmployment(u user.Employment) *UserUpdateOne {
+	uuo.mutation.SetEmployment(u)
+	return uuo
+}
+
+// SetNillableEmployment sets the "employment" field if the given value is not nil.
+func (uuo *UserUpdateOne) SetNillableEmployment(u *user.Employment) *UserUpdateOne {
+	if u != nil {
+		uuo.SetEmployment(*u)
+	}
+	return uuo
+}
+
 // SetSSOCert sets the "SSOCert" field.
 func (uuo *UserUpdateOne) SetSSOCert(s string) *UserUpdateOne {
 	uuo.mutation.SetSSOCert(s)
@@ -1926,6 +1966,11 @@ func (uuo *UserUpdateOne) check() error {
 			return &ValidationError{Name: "role", err: fmt.Errorf(`ent: validator failed for field "User.role": %w`, err)}
 		}
 	}
+	if v, ok := uuo.mutation.Employment(); ok {
+		if err := user.EmploymentValidator(v); err != nil {
+			return &ValidationError{Name: "employment", err: fmt.Errorf(`ent: validator failed for field "User.employment": %w`, err)}
+		}
+	}
 	return nil
 }
 
@@ -2069,6 +2114,13 @@ func (uuo *UserUpdateOne) sqlSave(ctx context.Context) (_node *User, err error) 
 			Type:   field.TypeEnum,
 			Value:  value,
 			Column: user.FieldRole,
+		})
+	}
+	if value, ok := uuo.mutation.Employment(); ok {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeEnum,
+			Value:  value,
+			Column: user.FieldEmployment,
 		})
 	}
 	if value, ok := uuo.mutation.SSOCert(); ok {

--- a/entc/integration/gremlin/ent/mutation.go
+++ b/entc/integration/gremlin/ent/mutation.go
@@ -11903,6 +11903,7 @@ type UserMutation struct {
 	phone            *string
 	password         *string
 	role             *user.Role
+	employment       *user.Employment
 	_SSOCert         *string
 	clearedFields    map[string]struct{}
 	card             *string
@@ -12446,6 +12447,42 @@ func (m *UserMutation) OldRole(ctx context.Context) (v user.Role, err error) {
 // ResetRole resets all changes to the "role" field.
 func (m *UserMutation) ResetRole() {
 	m.role = nil
+}
+
+// SetEmployment sets the "employment" field.
+func (m *UserMutation) SetEmployment(u user.Employment) {
+	m.employment = &u
+}
+
+// Employment returns the value of the "employment" field in the mutation.
+func (m *UserMutation) Employment() (r user.Employment, exists bool) {
+	v := m.employment
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldEmployment returns the old "employment" field's value of the User entity.
+// If the User object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *UserMutation) OldEmployment(ctx context.Context) (v user.Employment, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, fmt.Errorf("OldEmployment is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, fmt.Errorf("OldEmployment requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldEmployment: %w", err)
+	}
+	return oldValue.Employment, nil
+}
+
+// ResetEmployment resets all changes to the "employment" field.
+func (m *UserMutation) ResetEmployment() {
+	m.employment = nil
 }
 
 // SetSSOCert sets the "SSOCert" field.
@@ -13050,7 +13087,7 @@ func (m *UserMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *UserMutation) Fields() []string {
-	fields := make([]string, 0, 10)
+	fields := make([]string, 0, 11)
 	if m.optional_int != nil {
 		fields = append(fields, user.FieldOptionalInt)
 	}
@@ -13077,6 +13114,9 @@ func (m *UserMutation) Fields() []string {
 	}
 	if m.role != nil {
 		fields = append(fields, user.FieldRole)
+	}
+	if m.employment != nil {
+		fields = append(fields, user.FieldEmployment)
 	}
 	if m._SSOCert != nil {
 		fields = append(fields, user.FieldSSOCert)
@@ -13107,6 +13147,8 @@ func (m *UserMutation) Field(name string) (ent.Value, bool) {
 		return m.Password()
 	case user.FieldRole:
 		return m.Role()
+	case user.FieldEmployment:
+		return m.Employment()
 	case user.FieldSSOCert:
 		return m.SSOCert()
 	}
@@ -13136,6 +13178,8 @@ func (m *UserMutation) OldField(ctx context.Context, name string) (ent.Value, er
 		return m.OldPassword(ctx)
 	case user.FieldRole:
 		return m.OldRole(ctx)
+	case user.FieldEmployment:
+		return m.OldEmployment(ctx)
 	case user.FieldSSOCert:
 		return m.OldSSOCert(ctx)
 	}
@@ -13209,6 +13253,13 @@ func (m *UserMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetRole(v)
+		return nil
+	case user.FieldEmployment:
+		v, ok := value.(user.Employment)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetEmployment(v)
 		return nil
 	case user.FieldSSOCert:
 		v, ok := value.(string)
@@ -13358,6 +13409,9 @@ func (m *UserMutation) ResetField(name string) error {
 		return nil
 	case user.FieldRole:
 		m.ResetRole()
+		return nil
+	case user.FieldEmployment:
+		m.ResetEmployment()
 		return nil
 	case user.FieldSSOCert:
 		m.ResetSSOCert()

--- a/entc/integration/gremlin/ent/user.go
+++ b/entc/integration/gremlin/ent/user.go
@@ -39,6 +39,8 @@ type User struct {
 	Password string `graphql:"-" json:"-"`
 	// Role holds the value of the "role" field.
 	Role user.Role `json:"role,omitempty"`
+	// Employment holds the value of the "employment" field.
+	Employment user.Employment `json:"employment,omitempty"`
 	// SSOCert holds the value of the "SSOCert" field.
 	SSOCert string `json:"SSOCert,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
@@ -201,17 +203,18 @@ func (u *User) FromResponse(res *gremlin.Response) error {
 		return err
 	}
 	var scanu struct {
-		ID          string    `json:"id,omitempty"`
-		OptionalInt int       `json:"optional_int,omitempty"`
-		Age         int       `json:"age,omitempty"`
-		Name        string    `json:"name,omitempty"`
-		Last        string    `json:"last,omitempty"`
-		Nickname    string    `json:"nickname,omitempty"`
-		Address     string    `json:"address,omitempty"`
-		Phone       string    `json:"phone,omitempty"`
-		Password    string    `json:"password,omitempty"`
-		Role        user.Role `json:"role,omitempty"`
-		SSOCert     string    `json:"sso_cert,omitempty"`
+		ID          string          `json:"id,omitempty"`
+		OptionalInt int             `json:"optional_int,omitempty"`
+		Age         int             `json:"age,omitempty"`
+		Name        string          `json:"name,omitempty"`
+		Last        string          `json:"last,omitempty"`
+		Nickname    string          `json:"nickname,omitempty"`
+		Address     string          `json:"address,omitempty"`
+		Phone       string          `json:"phone,omitempty"`
+		Password    string          `json:"password,omitempty"`
+		Role        user.Role       `json:"role,omitempty"`
+		Employment  user.Employment `json:"employment,omitempty"`
+		SSOCert     string          `json:"sso_cert,omitempty"`
 	}
 	if err := vmap.Decode(&scanu); err != nil {
 		return err
@@ -226,6 +229,7 @@ func (u *User) FromResponse(res *gremlin.Response) error {
 	u.Phone = scanu.Phone
 	u.Password = scanu.Password
 	u.Role = scanu.Role
+	u.Employment = scanu.Employment
 	u.SSOCert = scanu.SSOCert
 	return nil
 }
@@ -325,6 +329,8 @@ func (u *User) String() string {
 	builder.WriteString(", password=<sensitive>")
 	builder.WriteString(", role=")
 	builder.WriteString(fmt.Sprintf("%v", u.Role))
+	builder.WriteString(", employment=")
+	builder.WriteString(fmt.Sprintf("%v", u.Employment))
 	builder.WriteString(", SSOCert=")
 	builder.WriteString(u.SSOCert)
 	builder.WriteByte(')')
@@ -341,17 +347,18 @@ func (u *Users) FromResponse(res *gremlin.Response) error {
 		return err
 	}
 	var scanu []struct {
-		ID          string    `json:"id,omitempty"`
-		OptionalInt int       `json:"optional_int,omitempty"`
-		Age         int       `json:"age,omitempty"`
-		Name        string    `json:"name,omitempty"`
-		Last        string    `json:"last,omitempty"`
-		Nickname    string    `json:"nickname,omitempty"`
-		Address     string    `json:"address,omitempty"`
-		Phone       string    `json:"phone,omitempty"`
-		Password    string    `json:"password,omitempty"`
-		Role        user.Role `json:"role,omitempty"`
-		SSOCert     string    `json:"sso_cert,omitempty"`
+		ID          string          `json:"id,omitempty"`
+		OptionalInt int             `json:"optional_int,omitempty"`
+		Age         int             `json:"age,omitempty"`
+		Name        string          `json:"name,omitempty"`
+		Last        string          `json:"last,omitempty"`
+		Nickname    string          `json:"nickname,omitempty"`
+		Address     string          `json:"address,omitempty"`
+		Phone       string          `json:"phone,omitempty"`
+		Password    string          `json:"password,omitempty"`
+		Role        user.Role       `json:"role,omitempty"`
+		Employment  user.Employment `json:"employment,omitempty"`
+		SSOCert     string          `json:"sso_cert,omitempty"`
 	}
 	if err := vmap.Decode(&scanu); err != nil {
 		return err
@@ -368,6 +375,7 @@ func (u *Users) FromResponse(res *gremlin.Response) error {
 			Phone:       v.Phone,
 			Password:    v.Password,
 			Role:        v.Role,
+			Employment:  v.Employment,
 			SSOCert:     v.SSOCert,
 		})
 	}

--- a/entc/integration/gremlin/ent/user/user.go
+++ b/entc/integration/gremlin/ent/user/user.go
@@ -33,6 +33,8 @@ const (
 	FieldPassword = "password"
 	// FieldRole holds the string denoting the role field in the database.
 	FieldRole = "role"
+	// FieldEmployment holds the string denoting the employment field in the database.
+	FieldEmployment = "employment"
 	// FieldSSOCert holds the string denoting the ssocert field in the database.
 	FieldSSOCert = "sso_cert"
 	// EdgeCard holds the string denoting the card edge name in mutations.
@@ -118,9 +120,41 @@ func RoleValidator(r Role) error {
 	}
 }
 
+// Employment defines the type for the "employment" enum field.
+type Employment string
+
+// EmploymentFullTime is the default value of the Employment enum.
+const DefaultEmployment = EmploymentFullTime
+
+// Employment values.
+const (
+	EmploymentFullTime Employment = "Full-Time"
+	EmploymentPartTime Employment = "Part-Time"
+	EmploymentContract Employment = "Contract"
+)
+
+func (e Employment) String() string {
+	return string(e)
+}
+
+// EmploymentValidator is a validator for the "employment" field enum values. It is called by the builders before save.
+func EmploymentValidator(e Employment) error {
+	switch e {
+	case EmploymentFullTime, EmploymentPartTime, EmploymentContract:
+		return nil
+	default:
+		return fmt.Errorf("user: invalid enum value for employment field: %q", e)
+	}
+}
+
 // Ptr returns a new pointer to the enum value.
 func (r Role) Ptr() *Role {
 	return &r
+}
+
+// Ptr returns a new pointer to the enum value.
+func (e Employment) Ptr() *Employment {
+	return &e
 }
 
 // comment from another template.

--- a/entc/integration/gremlin/ent/user/where.go
+++ b/entc/integration/gremlin/ent/user/where.go
@@ -891,6 +891,42 @@ func RoleNotIn(vs ...Role) predicate.User {
 	})
 }
 
+// EmploymentEQ applies the EQ predicate on the "employment" field.
+func EmploymentEQ(v Employment) predicate.User {
+	return predicate.User(func(t *dsl.Traversal) {
+		t.Has(Label, FieldEmployment, p.EQ(v))
+	})
+}
+
+// EmploymentNEQ applies the NEQ predicate on the "employment" field.
+func EmploymentNEQ(v Employment) predicate.User {
+	return predicate.User(func(t *dsl.Traversal) {
+		t.Has(Label, FieldEmployment, p.NEQ(v))
+	})
+}
+
+// EmploymentIn applies the In predicate on the "employment" field.
+func EmploymentIn(vs ...Employment) predicate.User {
+	v := make([]interface{}, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.User(func(t *dsl.Traversal) {
+		t.Has(Label, FieldEmployment, p.Within(v...))
+	})
+}
+
+// EmploymentNotIn applies the NotIn predicate on the "employment" field.
+func EmploymentNotIn(vs ...Employment) predicate.User {
+	v := make([]interface{}, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.User(func(t *dsl.Traversal) {
+		t.Has(Label, FieldEmployment, p.Without(v...))
+	})
+}
+
 // SSOCertEQ applies the EQ predicate on the "SSOCert" field.
 func SSOCertEQ(v string) predicate.User {
 	return predicate.User(func(t *dsl.Traversal) {

--- a/entc/integration/gremlin/ent/user_create.go
+++ b/entc/integration/gremlin/ent/user_create.go
@@ -136,6 +136,20 @@ func (uc *UserCreate) SetNillableRole(u *user.Role) *UserCreate {
 	return uc
 }
 
+// SetEmployment sets the "employment" field.
+func (uc *UserCreate) SetEmployment(u user.Employment) *UserCreate {
+	uc.mutation.SetEmployment(u)
+	return uc
+}
+
+// SetNillableEmployment sets the "employment" field if the given value is not nil.
+func (uc *UserCreate) SetNillableEmployment(u *user.Employment) *UserCreate {
+	if u != nil {
+		uc.SetEmployment(*u)
+	}
+	return uc
+}
+
 // SetSSOCert sets the "SSOCert" field.
 func (uc *UserCreate) SetSSOCert(s string) *UserCreate {
 	uc.mutation.SetSSOCert(s)
@@ -414,6 +428,10 @@ func (uc *UserCreate) defaults() {
 		v := user.DefaultRole
 		uc.mutation.SetRole(v)
 	}
+	if _, ok := uc.mutation.Employment(); !ok {
+		v := user.DefaultEmployment
+		uc.mutation.SetEmployment(v)
+	}
 }
 
 // check runs all checks and user-defined validators on the builder.
@@ -438,6 +456,14 @@ func (uc *UserCreate) check() error {
 	if v, ok := uc.mutation.Role(); ok {
 		if err := user.RoleValidator(v); err != nil {
 			return &ValidationError{Name: "role", err: fmt.Errorf(`ent: validator failed for field "User.role": %w`, err)}
+		}
+	}
+	if _, ok := uc.mutation.Employment(); !ok {
+		return &ValidationError{Name: "employment", err: errors.New(`ent: missing required field "User.employment"`)}
+	}
+	if v, ok := uc.mutation.Employment(); ok {
+		if err := user.EmploymentValidator(v); err != nil {
+			return &ValidationError{Name: "employment", err: fmt.Errorf(`ent: validator failed for field "User.employment": %w`, err)}
 		}
 	}
 	return nil
@@ -500,6 +526,9 @@ func (uc *UserCreate) gremlin() *dsl.Traversal {
 	}
 	if value, ok := uc.mutation.Role(); ok {
 		v.Property(dsl.Single, user.FieldRole, value)
+	}
+	if value, ok := uc.mutation.Employment(); ok {
+		v.Property(dsl.Single, user.FieldEmployment, value)
 	}
 	if value, ok := uc.mutation.SSOCert(); ok {
 		v.Property(dsl.Single, user.FieldSSOCert, value)

--- a/entc/integration/gremlin/ent/user_update.go
+++ b/entc/integration/gremlin/ent/user_update.go
@@ -187,6 +187,20 @@ func (uu *UserUpdate) SetNillableRole(u *user.Role) *UserUpdate {
 	return uu
 }
 
+// SetEmployment sets the "employment" field.
+func (uu *UserUpdate) SetEmployment(u user.Employment) *UserUpdate {
+	uu.mutation.SetEmployment(u)
+	return uu
+}
+
+// SetNillableEmployment sets the "employment" field if the given value is not nil.
+func (uu *UserUpdate) SetNillableEmployment(u *user.Employment) *UserUpdate {
+	if u != nil {
+		uu.SetEmployment(*u)
+	}
+	return uu
+}
+
 // SetSSOCert sets the "SSOCert" field.
 func (uu *UserUpdate) SetSSOCert(s string) *UserUpdate {
 	uu.mutation.SetSSOCert(s)
@@ -636,6 +650,11 @@ func (uu *UserUpdate) check() error {
 			return &ValidationError{Name: "role", err: fmt.Errorf(`ent: validator failed for field "User.role": %w`, err)}
 		}
 	}
+	if v, ok := uu.mutation.Employment(); ok {
+		if err := user.EmploymentValidator(v); err != nil {
+			return &ValidationError{Name: "employment", err: fmt.Errorf(`ent: validator failed for field "User.employment": %w`, err)}
+		}
+	}
 	return nil
 }
 
@@ -707,6 +726,9 @@ func (uu *UserUpdate) gremlin() *dsl.Traversal {
 	}
 	if value, ok := uu.mutation.Role(); ok {
 		v.Property(dsl.Single, user.FieldRole, value)
+	}
+	if value, ok := uu.mutation.Employment(); ok {
+		v.Property(dsl.Single, user.FieldEmployment, value)
 	}
 	if value, ok := uu.mutation.SSOCert(); ok {
 		v.Property(dsl.Single, user.FieldSSOCert, value)
@@ -1011,6 +1033,20 @@ func (uuo *UserUpdateOne) SetRole(u user.Role) *UserUpdateOne {
 func (uuo *UserUpdateOne) SetNillableRole(u *user.Role) *UserUpdateOne {
 	if u != nil {
 		uuo.SetRole(*u)
+	}
+	return uuo
+}
+
+// SetEmployment sets the "employment" field.
+func (uuo *UserUpdateOne) SetEmployment(u user.Employment) *UserUpdateOne {
+	uuo.mutation.SetEmployment(u)
+	return uuo
+}
+
+// SetNillableEmployment sets the "employment" field if the given value is not nil.
+func (uuo *UserUpdateOne) SetNillableEmployment(u *user.Employment) *UserUpdateOne {
+	if u != nil {
+		uuo.SetEmployment(*u)
 	}
 	return uuo
 }
@@ -1471,6 +1507,11 @@ func (uuo *UserUpdateOne) check() error {
 			return &ValidationError{Name: "role", err: fmt.Errorf(`ent: validator failed for field "User.role": %w`, err)}
 		}
 	}
+	if v, ok := uuo.mutation.Employment(); ok {
+		if err := user.EmploymentValidator(v); err != nil {
+			return &ValidationError{Name: "employment", err: fmt.Errorf(`ent: validator failed for field "User.employment": %w`, err)}
+		}
+	}
 	return nil
 }
 
@@ -1547,6 +1588,9 @@ func (uuo *UserUpdateOne) gremlin(id string) *dsl.Traversal {
 	}
 	if value, ok := uuo.mutation.Role(); ok {
 		v.Property(dsl.Single, user.FieldRole, value)
+	}
+	if value, ok := uuo.mutation.Employment(); ok {
+		v.Property(dsl.Single, user.FieldEmployment, value)
 	}
 	if value, ok := uuo.mutation.SSOCert(); ok {
 		v.Property(dsl.Single, user.FieldSSOCert, value)


### PR DESCRIPTION
Enum identifier needs to be formatted even if it's started with an upper-case letter.  

Fixed https://github.com/ent/ent/issues/1961