### PR TITLE
Update tutorial-grpc-setting-up.md

### DIFF
--- a/doc/md/tutorial-grpc-setting-up.md
+++ b/doc/md/tutorial-grpc-setting-up.md
@@ -43,7 +43,7 @@ package schema
 
 import (
 	"entgo.io/ent"
-	"entgo.io/ent/schema"
+	"entgo.io/ent/schema/field"
 )
 
 // User holds the schema definition for the User entity.


### PR DESCRIPTION
Update import to remove this error: "[Sticking to the "Quick Instruction" by "undeclared name: field" error #1931 ](https://github.com/ent/ent/issues/1931)"