### PR TITLE
dialect/sql: wraps the sql.Rows with ColumnScanner interface

### DIFF
--- a/dialect/sql/driver.go
+++ b/dialect/sql/driver.go
@@ -132,7 +132,7 @@ var _ dialect.Driver = (*Driver)(nil)
 
 type (
 	// Rows wraps the sql.Rows to avoid locks copy.
-	Rows struct{ *sql.Rows }
+	Rows struct{ ColumnScanner }
 	// Result is an alias to sql.Result.
 	Result = sql.Result
 	// NullBool is an alias to sql.NullBool.
@@ -164,4 +164,16 @@ func (n *NullScanner) Scan(value interface{}) error {
 		return n.S.Scan(value)
 	}
 	return nil
+}
+
+// ColumnScanner is the interface that wraps the standard
+// sql.Rows methods used for scanning database rows.
+type ColumnScanner interface {
+	Close() error
+	ColumnTypes() ([]*sql.ColumnType, error)
+	Columns() ([]string, error)
+	Err() error
+	Next() bool
+	NextResultSet() bool
+	Scan(dest ...interface{}) error
 }

--- a/dialect/sql/scan.go
+++ b/dialect/sql/scan.go
@@ -12,15 +12,6 @@ import (
 	"strings"
 )
 
-// ColumnScanner is the interface that wraps the
-// four sql.Rows methods used for scanning.
-type ColumnScanner interface {
-	Next() bool
-	Scan(...interface{}) error
-	Columns() ([]string, error)
-	Err() error
-}
-
 // ScanOne scans one row to the given value. It fails if the rows holds more than 1 row.
 func ScanOne(rows ColumnScanner, v interface{}) error {
 	columns, err := rows.Columns()


### PR DESCRIPTION
Wrapping the `*sql.Rows` comes with a little memory overhead, but it makes it easier to extend the driver and to provide customized rows scanning. I'll add more details and examples before merging this PR. 