### PR TITLE
update elk doc

### DIFF
--- a/doc/website/blog/2021-07-29-generate-a-fully-working-go-crud-http-api-with-ent.md
+++ b/doc/website/blog/2021-07-29-generate-a-fully-working-go-crud-http-api-with-ent.md
@@ -85,7 +85,9 @@ import (
 )
 
 func main() {
-	ex, err := elk.NewExtension()
+	ex, err := elk.NewExtension(
+		elk.GenerateSpec("openapi.json"),
+		elk.GenerateHandlers()))
 	if err != nil {
 		log.Fatalf("creating elk extension: %v", err)
 	}

--- a/doc/website/blog/2021-07-29-generate-a-fully-working-go-crud-http-api-with-ent.md
+++ b/doc/website/blog/2021-07-29-generate-a-fully-working-go-crud-http-api-with-ent.md
@@ -87,7 +87,8 @@ import (
 func main() {
 	ex, err := elk.NewExtension(
 		elk.GenerateSpec("openapi.json"),
-		elk.GenerateHandlers()))
+		elk.GenerateHandlers(),
+	)
 	if err != nil {
 		log.Fatalf("creating elk extension: %v", err)
 	}


### PR DESCRIPTION
I guess that the API have changed. When I run the current example I get:

```
$ go generate .
go: finding module for package github.com/masseelch/elk
go: downloading github.com/masseelch/elk v0.4.8
go: downloading entgo.io/ent v0.9.2-0.20210822190728-d84ac191b1c7
go: downloading github.com/mailru/easyjson v0.7.7
go: downloading github.com/stoewer/go-strcase v1.2.0
2021/10/04 21:35:46 creating elk extension: no generator enabled: enable one by providing either "GenerateSpec()" or "GenerateHandlers()" to "NewExtension()"
exit status 1
be/ent/generate.go:4: running "go": exit status 1
```