### PR TITLE
fix govet

### DIFF
--- a/entc/integration/template/ent/node.go
+++ b/entc/integration/template/ent/node.go
@@ -225,7 +225,7 @@ func (t *tables) Load(ctx context.Context, querier querier) ([]string, error) {
 	return tables, err
 }
 
-func (t *tables) load(ctx context.Context, querier querier) ([]string, error) {
+func (*tables) load(ctx context.Context, querier querier) ([]string, error) {
 	rows := &sql.Rows{}
 	query, args := sql.Select("type").
 		From(sql.Table(schema.TypeTable)).

--- a/entc/integration/template/ent/template/node.tmpl
+++ b/entc/integration/template/ent/template/node.tmpl
@@ -175,7 +175,7 @@ func (t *tables) Load(ctx context.Context, querier querier) ([]string, error) {
 
 {{/* An example of a local helper template. */}}
 {{ define "node/helper/loadtable" }}
-func (tables) load(ctx context.Context, querier querier) ([]string, error) {
+func (*tables) load(ctx context.Context, querier querier) ([]string, error) {
 	rows := &sql.Rows{}
 	query, args := sql.Select("type").
 		From(sql.Table(schema.TypeTable)).


### PR DESCRIPTION
I fixed issue `go vet` reports.

### go vet result
```console
...
# entgo.io/ent/entc/integration/template/ent
entc/integration/template/ent/node.go:228:7: load passes lock by value: entgo.io/ent/entc/integration/template/ent.tables contains sync.Once contains sync.Mutex
...
```