### PR TITLE
Fix typo in tutorial-grpc-generating-proto.md

### DIFF
--- a/doc/md/tutorial-grpc-generating-proto.md
+++ b/doc/md/tutorial-grpc-generating-proto.md
@@ -131,7 +131,7 @@ func TestUserProto(t *testing.T) {
 To run it:
 
 ```console
-go get -u./... # install deps of the generated package
+go get -u ./... # install deps of the generated package
 go test ./...
 ```
 


### PR DESCRIPTION
Found a VERY TINY typo when going through the gRPC tutorial :)