### PR TITLE
Update gRPC Documentation for Service Method Generation Options

### DIFF
--- a/doc/md/tutorial-grpc-service-generation-options.md
+++ b/doc/md/tutorial-grpc-service-generation-options.md
@@ -1,0 +1,51 @@
+---
+id: grpc-service-generation-options
+title: Configuring Service Method Generation
+sidebar_label: Service Generation Options
+---
+By default, entproto will generate CRUD service methods for an `ent.Schema` annotated with `ent.Service()`. Method generation can be customized by including the argument `entproto.Methods()` in the `entproto.Service()` annotation. `entproto.Methods()` accepts bit flags to determine what service methods should be generated. The flags include:
+```go
+// Generates a Create gRPC service method for the entproto.Service.
+entproto.MethodCreate
+
+// Generates a Get gRPC service method for the entproto.Service.
+entproto.MethodGet
+
+// Generates an Update gRPC service method for the entproto.Service.
+entproto.MethodUpdate
+
+// Generates a Delete gRPC service method for the entproto.Service.
+entproto.MethodDelete
+
+// Generates all service methods for the entproto.Service.
+// This is the same behavior as not including entproto.Methods.
+entproto.MethodAll
+```
+To generate a service with multiple methods, bitwise OR the flags.
+
+
+To see this in action, we can modify our ent schema. Let's say we wanted to prevent our gRPC client from mutating entries. We can accomplish this by modifying `ent/schema/user.go`:
+```go
+func (User) Annotations() []schema.Annotation {
+	return []schema.Annotation{
+		entproto.Message(),
+		entproto.Service(
+			entproto.Methods(                   // <-- add this
+				entproto.MethodCreate |         // <-- ...
+                entproto.MethodGet              // <-- ...
+            ),                                  // <-- ...
+        ),
+	}
+}
+```
+
+Re-running `go generate ./...` will give us the following service definition in `entpb.proto`:
+```protobuf
+service UserService {
+  rpc Create ( CreateUserRequest ) returns ( User );
+
+  rpc Get ( GetUserRequest ) returns ( User );
+}
+```
+
+Notice that the service no longer includes `Update` and `Delete` methods. Perfect! 

--- a/doc/md/tutorial-grpc-service-generation-options.md
+++ b/doc/md/tutorial-grpc-service-generation-options.md
@@ -25,15 +25,15 @@ To generate a service with multiple methods, bitwise OR the flags.
 
 
 To see this in action, we can modify our ent schema. Let's say we wanted to prevent our gRPC client from mutating entries. We can accomplish this by modifying `ent/schema/user.go`:
-```go
+```go {5-8}
 func (User) Annotations() []schema.Annotation {
 	return []schema.Annotation{
 		entproto.Message(),
 		entproto.Service(
-			entproto.Methods(                   // <-- add this
-				entproto.MethodCreate |         // <-- ...
-                entproto.MethodGet              // <-- ...
-            ),                                  // <-- ...
+			entproto.Methods(
+				entproto.MethodCreate |
+                entproto.MethodGet
+            ),
         ),
 	}
 }

--- a/doc/website/sidebars.js
+++ b/doc/website/sidebars.js
@@ -103,6 +103,7 @@ module.exports = {
           'grpc-server-and-client',
           'grpc-edges',
           'grpc-optional-fields',
+          'grpc-service-generation-options',
       ]
     }
   ]


### PR DESCRIPTION
Updating ent site documentation for changes to gRPC service method generation caused by https://github.com/ent/contrib/pull/158