### PR TITLE
doc/md: fix highlighting in tutorial-grpc-service-generation-options.md

### DIFF
--- a/doc/md/tutorial-grpc-service-generation-options.md
+++ b/doc/md/tutorial-grpc-service-generation-options.md
@@ -25,7 +25,7 @@ To generate a service with multiple methods, bitwise OR the flags.
 
 
 To see this in action, we can modify our ent schema. Let's say we wanted to prevent our gRPC client from mutating entries. We can accomplish this by modifying `ent/schema/user.go`:
-```go {5-8}
+```go {5}
 func (User) Annotations() []schema.Annotation {
 	return []schema.Annotation{
 		entproto.Message(),


### PR DESCRIPTION
Highlighting needs updating due to commit 2e3aca1

![image](https://user-images.githubusercontent.com/9276415/142286847-9e2301ee-379e-4565-8801-11455f18301e.png)
