### PR TITLE
ent/doc: load github buttons from cdnjs

### DIFF
--- a/doc/website/docusaurus.config.js
+++ b/doc/website/docusaurus.config.js
@@ -31,7 +31,7 @@ const config = {
   "organizationName": "ent",
   "projectName": "ent",
   "scripts": [
-    "https://buttons.github.io/buttons.js",
+    "https://cdnjs.cloudflare.com/ajax/libs/github-buttons/2.20.0/buttons.min.js",
     "https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js",
     "/js/code-block-buttons.js",
     "/js/custom.js"


### PR DESCRIPTION
Looks like loading the script from GH pages may be slow at times.  
cdnjs should be the right tool for the task.  
If this doesn't help, consider adding `async: true` (see [docs](https://docusaurus.io/docs/api/docusaurus-config#scripts))