### PR TITLE
doc/website: remove deprecated script

### DIFF
--- a/doc/website/docusaurus.config.js
+++ b/doc/website/docusaurus.config.js
@@ -31,7 +31,6 @@ const config = {
   "organizationName": "ent",
   "projectName": "ent",
   "scripts": [
-    "https://cdnjs.cloudflare.com/ajax/libs/github-buttons/2.20.0/buttons.min.js",
     "https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js",
     "/js/code-block-buttons.js",
     "/js/custom.js"


### PR DESCRIPTION
There used to be a footer which used this script  https://github.com/ent/ent/commit/0ed36ba188b7a1d86781151f74726e77a4996e34#diff-477f5f899cf264176483a09cd8fe61787411f3b03fb1d8eb75beae4798efafe1R20

but it was deprecated on https://github.com/ent/ent/commit/d9faf21e05acbd638088459fc45792d4e5fe6176