### PR TITLE
Fix migrating Postgres fields with max character varchar custom type

### DIFF
--- a/dialect/sql/schema/inspect_test.go
+++ b/dialect/sql/schema/inspect_test.go
@@ -149,42 +149,42 @@ func TestInspector_Tables(t *testing.T) {
 							AddRow("pets").
 							AddRow("groups").
 							AddRow("user_groups"))
-					mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale" FROM "information_schema"."columns" WHERE "table_schema" = $1 AND "table_name" = $2`)).
+					mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length" FROM "information_schema"."columns" WHERE "table_schema" = $1 AND "table_name" = $2`)).
 						WithArgs("public", "users").
-						WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale"}).
-							AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil).
-							AddRow("name", "character", "YES", "NULL", "bpchar", nil, nil).
-							AddRow("text", "text", "YES", "NULL", "text", nil, nil).
-							AddRow("uuid", "uuid", "YES", "NULL", "uuid", nil, nil).
-							AddRow("price", "numeric", "NO", "NULL", "numeric", "6", "4"))
+						WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length"}).
+							AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil, nil).
+							AddRow("name", "character", "YES", "NULL", "bpchar", nil, nil, nil).
+							AddRow("text", "text", "YES", "NULL", "text", nil, nil, nil).
+							AddRow("uuid", "uuid", "YES", "NULL", "uuid", nil, nil, nil).
+							AddRow("price", "numeric", "NO", "NULL", "numeric", "6", "4", nil))
 					mock.ExpectQuery(escape(fmt.Sprintf(indexesQuery, "$1", "users"))).
 						WithArgs("public").
 						WillReturnRows(sqlmock.NewRows([]string{"index_name", "column_name", "primary", "unique", "seq_in_index"}).
 							AddRow("users_pkey", "id", "t", "t", 0))
-					mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale" FROM "information_schema"."columns" WHERE "table_schema" = $1 AND "table_name" = $2`)).
+					mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length" FROM "information_schema"."columns" WHERE "table_schema" = $1 AND "table_name" = $2`)).
 						WithArgs("public", "pets").
-						WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale"}).
-							AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil).
-							AddRow("name", "character", "YES", "NULL", "bpchar", nil, nil).
-							AddRow("user_pets", "bigint", "YES", "NULL", "int8", nil, nil))
+						WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length"}).
+							AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil, nil).
+							AddRow("name", "character", "YES", "NULL", "bpchar", nil, nil, nil).
+							AddRow("user_pets", "bigint", "YES", "NULL", "int8", nil, nil, nil))
 					mock.ExpectQuery(escape(fmt.Sprintf(indexesQuery, "$1", "pets"))).
 						WithArgs("public").
 						WillReturnRows(sqlmock.NewRows([]string{"index_name", "column_name", "primary", "unique", "seq_in_index"}).
 							AddRow("pets_pkey", "id", "t", "t", 0))
-					mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale" FROM "information_schema"."columns" WHERE "table_schema" = $1 AND "table_name" = $2`)).
+					mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length" FROM "information_schema"."columns" WHERE "table_schema" = $1 AND "table_name" = $2`)).
 						WithArgs("public", "groups").
-						WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale"}).
-							AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil).
-							AddRow("name", "character", "NO", "NULL", "bpchar", nil, nil))
+						WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length"}).
+							AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil, nil).
+							AddRow("name", "character", "NO", "NULL", "bpchar", nil, nil, nil))
 					mock.ExpectQuery(escape(fmt.Sprintf(indexesQuery, "$1", "groups"))).
 						WithArgs("public").
 						WillReturnRows(sqlmock.NewRows([]string{"index_name", "column_name", "primary", "unique", "seq_in_index"}).
 							AddRow("groups_pkey", "id", "t", "t", 0))
-					mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale" FROM "information_schema"."columns" WHERE "table_schema" = $1 AND "table_name" = $2`)).
+					mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length" FROM "information_schema"."columns" WHERE "table_schema" = $1 AND "table_name" = $2`)).
 						WithArgs("public", "user_groups").
-						WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale"}).
-							AddRow("user_id", "bigint", "NO", "NULL", "int8", nil, nil).
-							AddRow("group_id", "bigint", "NO", "NULL", "int8", nil, nil))
+						WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length"}).
+							AddRow("user_id", "bigint", "NO", "NULL", "int8", nil, nil, nil).
+							AddRow("group_id", "bigint", "NO", "NULL", "int8", nil, nil, nil))
 					mock.ExpectQuery(escape(fmt.Sprintf(indexesQuery, "$1", "user_groups"))).
 						WithArgs("public").
 						WillReturnRows(sqlmock.NewRows([]string{"index_name", "column_name", "primary", "unique", "seq_in_index"}))

--- a/dialect/sql/schema/inspect_test.go
+++ b/dialect/sql/schema/inspect_test.go
@@ -67,7 +67,8 @@ func TestInspector_Tables(t *testing.T) {
 							AddRow("name", "varchar(255)", "YES", "YES", "NULL", "", "", "", nil, nil).
 							AddRow("text", "longtext", "YES", "YES", "NULL", "", "", "", nil, nil).
 							AddRow("uuid", "char(36)", "YES", "YES", "NULL", "", "", "utf8mb4_bin", nil, nil).
-							AddRow("price", "decimal(6, 4)", "NO", "YES", "NULL", "", "", "", "6", "4"))
+							AddRow("price", "decimal(6, 4)", "NO", "YES", "NULL", "", "", "", "6", "4").
+							AddRow("bank_id", "varchar(255)", "NO", "YES", "NULL", "", "", "", nil, nil))
 					mock.ExpectQuery(escape("SELECT `index_name`, `column_name`, `sub_part`, `non_unique`, `seq_in_index` FROM `INFORMATION_SCHEMA`.`STATISTICS` WHERE `TABLE_SCHEMA` = ? AND `TABLE_NAME` = ? ORDER BY `index_name`, `seq_in_index`")).
 						WithArgs("public", "users").
 						WillReturnRows(sqlmock.NewRows([]string{"index_name", "column_name", "sub_part", "non_unique", "seq_in_index"}).
@@ -115,7 +116,8 @@ func TestInspector_Tables(t *testing.T) {
 							AddRow("name", "varchar(255)", 0, "NULL", 0).
 							AddRow("text", "text", 0, "NULL", 0).
 							AddRow("uuid", "uuid", 0, "NULL", 0).
-							AddRow("price", "real", 1, "NULL", 0))
+							AddRow("price", "real", 1, "NULL", 0).
+							AddRow("bank_id", "varchar(255)", 1, "NULL", 0))
 					mock.ExpectQuery(escape("SELECT `name`, `unique`, `origin` FROM pragma_index_list('users')")).
 						WillReturnRows(sqlmock.NewRows([]string{"name", "unique", "unique"}))
 					mock.ExpectQuery(escape("SELECT `name`, `type`, `notnull`, `dflt_value`, `pk` FROM pragma_table_info('pets') ORDER BY `pk`")).
@@ -156,7 +158,8 @@ func TestInspector_Tables(t *testing.T) {
 							AddRow("name", "character", "YES", "NULL", "bpchar", nil, nil, nil).
 							AddRow("text", "text", "YES", "NULL", "text", nil, nil, nil).
 							AddRow("uuid", "uuid", "YES", "NULL", "uuid", nil, nil, nil).
-							AddRow("price", "numeric", "NO", "NULL", "numeric", "6", "4", nil))
+							AddRow("price", "numeric", "NO", "NULL", "numeric", "6", "4", nil).
+							AddRow("bank_id", "character", "NO", "NULL", "bpchar", nil, nil, 20))
 					mock.ExpectQuery(escape(fmt.Sprintf(indexesQuery, "$1", "users"))).
 						WithArgs("public").
 						WillReturnRows(sqlmock.NewRows([]string{"index_name", "column_name", "primary", "unique", "seq_in_index"}).
@@ -211,6 +214,9 @@ func TestInspector_Tables(t *testing.T) {
 						{Name: "price", Type: field.TypeFloat64, SchemaType: map[string]string{
 							dialect.MySQL:    "decimal(6,4)",
 							dialect.Postgres: "numeric(6,4)",
+						}},
+						{Name: "bank_id", Type: field.TypeString, SchemaType: map[string]string{
+							dialect.Postgres: "varchar(20)",
 						}},
 					}
 					t1 = &Table{

--- a/dialect/sql/schema/postgres.go
+++ b/dialect/sql/schema/postgres.go
@@ -353,9 +353,9 @@ func (d *Postgres) cType(c *Column) (t string) {
 	case field.TypeUUID:
 		t = "uuid"
 	case field.TypeString:
-		t = "varchar"
+		t = c.scanTypeOr("varchar")
 		if c.Size > maxCharSize {
-			t = "text"
+			t = c.scanTypeOr("text")
 		}
 	case field.TypeTime:
 		t = c.scanTypeOr("timestamp with time zone")

--- a/dialect/sql/schema/postgres.go
+++ b/dialect/sql/schema/postgres.go
@@ -92,7 +92,7 @@ func (d *Postgres) table(ctx context.Context, tx dialect.Tx, name string) (*Tabl
 	query, args := sql.Dialect(dialect.Postgres).
 		Select(
 			"column_name", "data_type", "is_nullable", "column_default", "udt_name",
-			"numeric_precision", "numeric_scale",
+			"numeric_precision", "numeric_scale", "character_maximum_length",
 		).
 		From(sql.Table("columns").Schema("information_schema")).
 		Where(sql.And(
@@ -234,8 +234,9 @@ func (d *Postgres) scanColumn(c *Column, rows *sql.Rows) error {
 		udt              sql.NullString
 		numericPrecision sql.NullInt64
 		numericScale     sql.NullInt64
+		numericCharacterMaximumLength     sql.NullInt64
 	)
-	if err := rows.Scan(&c.Name, &c.typ, &nullable, &defaults, &udt, &numericPrecision, &numericScale); err != nil {
+	if err := rows.Scan(&c.Name, &c.typ, &nullable, &defaults, &udt, &numericPrecision, &numericScale, &numericCharacterMaximumLength); err != nil {
 		return fmt.Errorf("scanning column description: %w", err)
 	}
 	if nullable.Valid {
@@ -266,6 +267,9 @@ func (d *Postgres) scanColumn(c *Column, rows *sql.Rows) error {
 		c.Size = maxCharSize + 1
 	case "character", "character varying":
 		c.Type = field.TypeString
+		if numericCharacterMaximumLength.Valid {
+			c.Size = numericCharacterMaximumLength.Int64
+		}
 	case "date", "time", "timestamp", "timestamp with time zone", "timestamp without time zone":
 		c.Type = field.TypeTime
 	case "bytea":

--- a/dialect/sql/schema/postgres.go
+++ b/dialect/sql/schema/postgres.go
@@ -267,8 +267,10 @@ func (d *Postgres) scanColumn(c *Column, rows *sql.Rows) error {
 		c.Size = maxCharSize + 1
 	case "character", "character varying":
 		c.Type = field.TypeString
+		// If character maximum length is specified then we should take that into account.
 		if numericCharacterMaximumLength.Valid {
-			c.Size = numericCharacterMaximumLength.Int64
+			schemaType := fmt.Sprintf("%s(%d)", c.typ, numericCharacterMaximumLength.Int64)
+			c.SchemaType = map[string]string{dialect.Postgres: schemaType}
 		}
 	case "date", "time", "timestamp", "timestamp with time zone", "timestamp without time zone":
 		c.Type = field.TypeTime

--- a/dialect/sql/schema/postgres.go
+++ b/dialect/sql/schema/postgres.go
@@ -269,7 +269,7 @@ func (d *Postgres) scanColumn(c *Column, rows *sql.Rows) error {
 		c.Type = field.TypeString
 		// If character maximum length is specified then we should take that into account.
 		if numericCharacterMaximumLength.Valid {
-			schemaType := fmt.Sprintf("%s(%d)", c.typ, numericCharacterMaximumLength.Int64)
+			schemaType := fmt.Sprintf("varchar(%d)", numericCharacterMaximumLength.Int64)
 			c.SchemaType = map[string]string{dialect.Postgres: schemaType}
 		}
 	case "date", "time", "timestamp", "timestamp with time zone", "timestamp without time zone":

--- a/dialect/sql/schema/postgres.go
+++ b/dialect/sql/schema/postgres.go
@@ -229,14 +229,14 @@ const maxCharSize = 10 << 20
 // scanColumn scans the information a column from column description.
 func (d *Postgres) scanColumn(c *Column, rows *sql.Rows) error {
 	var (
-		nullable                      sql.NullString
-		defaults                      sql.NullString
-		udt                           sql.NullString
-		numericPrecision              sql.NullInt64
-		numericScale                  sql.NullInt64
-		numericCharacterMaximumLength sql.NullInt64
+		nullable            sql.NullString
+		defaults            sql.NullString
+		udt                 sql.NullString
+		numericPrecision    sql.NullInt64
+		numericScale        sql.NullInt64
+		characterMaximumLen sql.NullInt64
 	)
-	if err := rows.Scan(&c.Name, &c.typ, &nullable, &defaults, &udt, &numericPrecision, &numericScale, &numericCharacterMaximumLength); err != nil {
+	if err := rows.Scan(&c.Name, &c.typ, &nullable, &defaults, &udt, &numericPrecision, &numericScale, &characterMaximumLen); err != nil {
 		return fmt.Errorf("scanning column description: %w", err)
 	}
 	if nullable.Valid {
@@ -268,8 +268,8 @@ func (d *Postgres) scanColumn(c *Column, rows *sql.Rows) error {
 	case "character", "character varying":
 		c.Type = field.TypeString
 		// If character maximum length is specified then we should take that into account.
-		if numericCharacterMaximumLength.Valid {
-			schemaType := fmt.Sprintf("varchar(%d)", numericCharacterMaximumLength.Int64)
+		if characterMaximumLen.Valid {
+			schemaType := fmt.Sprintf("varchar(%d)", characterMaximumLen.Int64)
 			c.SchemaType = map[string]string{dialect.Postgres: schemaType}
 		}
 	case "date", "time", "timestamp", "timestamp with time zone", "timestamp without time zone":

--- a/dialect/sql/schema/postgres.go
+++ b/dialect/sql/schema/postgres.go
@@ -229,12 +229,12 @@ const maxCharSize = 10 << 20
 // scanColumn scans the information a column from column description.
 func (d *Postgres) scanColumn(c *Column, rows *sql.Rows) error {
 	var (
-		nullable         sql.NullString
-		defaults         sql.NullString
-		udt              sql.NullString
-		numericPrecision sql.NullInt64
-		numericScale     sql.NullInt64
-		numericCharacterMaximumLength     sql.NullInt64
+		nullable                      sql.NullString
+		defaults                      sql.NullString
+		udt                           sql.NullString
+		numericPrecision              sql.NullInt64
+		numericScale                  sql.NullInt64
+		numericCharacterMaximumLength sql.NullInt64
 	)
 	if err := rows.Scan(&c.Name, &c.typ, &nullable, &defaults, &udt, &numericPrecision, &numericScale, &numericCharacterMaximumLength); err != nil {
 		return fmt.Errorf("scanning column description: %w", err)

--- a/dialect/sql/schema/postgres.go
+++ b/dialect/sql/schema/postgres.go
@@ -353,9 +353,9 @@ func (d *Postgres) cType(c *Column) (t string) {
 	case field.TypeUUID:
 		t = "uuid"
 	case field.TypeString:
-		t = c.scanTypeOr("varchar")
+		t = "varchar"
 		if c.Size > maxCharSize {
-			t = c.scanTypeOr("text")
+			t = "text"
 		}
 	case field.TypeTime:
 		t = c.scanTypeOr("timestamp with time zone")

--- a/dialect/sql/schema/postgres_test.go
+++ b/dialect/sql/schema/postgres_test.go
@@ -201,11 +201,11 @@ func TestPostgres_Create(t *testing.T) {
 			before: func(mock pgMock) {
 				mock.start("120000")
 				mock.tableExists("users", true)
-				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
+				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
 					WithArgs("users").
-					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale"}).
-						AddRow("id", "bigint", "NO", "nextval('users_colname_seq'::regclass)", "int4", nil, nil).
-						AddRow("block_size", "bigint", "NO", "current_setting('block_size')::bigint", "int4", nil, nil))
+					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length"}).
+						AddRow("id", "bigint", "NO", "nextval('users_colname_seq'::regclass)", "int4", nil, nil, nil).
+						AddRow("block_size", "bigint", "NO", "current_setting('block_size')::bigint", "int4", nil, nil, nil))
 				mock.ExpectQuery(escape(fmt.Sprintf(indexesQuery, "CURRENT_SCHEMA()", "users"))).
 					WillReturnRows(sqlmock.NewRows([]string{"index_name", "column_name", "primary", "unique", "seq_in_index"}).
 						AddRow("users_pkey", "id", "t", "t", 0))
@@ -229,11 +229,11 @@ func TestPostgres_Create(t *testing.T) {
 			before: func(mock pgMock) {
 				mock.start("120000")
 				mock.tableExists("users", true)
-				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
+				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
 					WithArgs("users").
-					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale"}).
-						AddRow("id", "bigint", "NO", "nextval('users_colname_seq'::regclass)", "NULL", nil, nil).
-						AddRow("custom", "USER-DEFINED", "NO", "NULL", "customtype", nil, nil))
+					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length"}).
+						AddRow("id", "bigint", "NO", "nextval('users_colname_seq'::regclass)", "NULL", nil, nil, nil).
+						AddRow("custom", "USER-DEFINED", "NO", "NULL", "customtype", nil, nil, nil))
 				mock.ExpectQuery(escape(fmt.Sprintf(indexesQuery, "CURRENT_SCHEMA()", "users"))).
 					WillReturnRows(sqlmock.NewRows([]string{"index_name", "column_name", "primary", "unique", "seq_in_index"}).
 						AddRow("users_pkey", "id", "t", "t", 0))
@@ -268,21 +268,21 @@ func TestPostgres_Create(t *testing.T) {
 			before: func(mock pgMock) {
 				mock.start("120000")
 				mock.tableExists("users", true)
-				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
+				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
 					WithArgs("users").
-					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale"}).
-						AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil).
-						AddRow("name", "character varying", "YES", "NULL", "varchar", nil, nil).
-						AddRow("uuid", "uuid", "YES", "NULL", "uuid", nil, nil).
-						AddRow("created_at", "date", "NO", "CURRENT_DATE", "date", nil, nil).
-						AddRow("updated_at", "timestamp", "YES", "NULL", "timestamptz", nil, nil).
-						AddRow("deleted_at", "date", "YES", "NULL", "date", nil, nil).
-						AddRow("text", "text", "YES", "NULL", "text", nil, nil).
-						AddRow("cidr", "cidr", "NO", "NULL", "cidr", nil, nil).
-						AddRow("inet", "inet", "YES", "NULL", "inet", nil, nil).
-						AddRow("macaddr", "macaddr", "YES", "NULL", "macaddr", nil, nil).
-						AddRow("macaddr8", "macaddr8", "YES", "NULL", "macaddr8", nil, nil).
-						AddRow("strings", "ARRAY", "YES", "NULL", "_text", nil, nil))
+					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length"}).
+						AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil, nil).
+						AddRow("name", "character varying", "YES", "NULL", "varchar", nil, nil, nil).
+						AddRow("uuid", "uuid", "YES", "NULL", "uuid", nil, nil, nil).
+						AddRow("created_at", "date", "NO", "CURRENT_DATE", "date", nil, nil, nil).
+						AddRow("updated_at", "timestamp", "YES", "NULL", "timestamptz", nil, nil, nil).
+						AddRow("deleted_at", "date", "YES", "NULL", "date", nil, nil, nil).
+						AddRow("text", "text", "YES", "NULL", "text", nil, nil, nil).
+						AddRow("cidr", "cidr", "NO", "NULL", "cidr", nil, nil, nil).
+						AddRow("inet", "inet", "YES", "NULL", "inet", nil, nil, nil).
+						AddRow("macaddr", "macaddr", "YES", "NULL", "macaddr", nil, nil, nil).
+						AddRow("macaddr8", "macaddr8", "YES", "NULL", "macaddr8", nil, nil, nil).
+						AddRow("strings", "ARRAY", "YES", "NULL", "_text", nil, nil, nil))
 				mock.ExpectQuery(escape(fmt.Sprintf(indexesQuery, "CURRENT_SCHEMA()", "users"))).
 					WillReturnRows(sqlmock.NewRows([]string{"index_name", "column_name", "primary", "unique", "seq_in_index"}).
 						AddRow("users_pkey", "id", "t", "t", 0))
@@ -310,12 +310,12 @@ func TestPostgres_Create(t *testing.T) {
 			before: func(mock pgMock) {
 				mock.start("120000")
 				mock.tableExists("users", true)
-				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
+				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
 					WithArgs("users").
-					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale"}).
-						AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil).
-						AddRow("name", "character", "YES", "NULL", "bpchar", nil, nil).
-						AddRow("doc", "jsonb", "YES", "NULL", "jsonb", nil, nil))
+					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length"}).
+						AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil, nil).
+						AddRow("name", "character", "YES", "NULL", "bpchar", nil, nil, nil).
+						AddRow("doc", "jsonb", "YES", "NULL", "jsonb", nil, nil, nil))
 				mock.ExpectQuery(escape(fmt.Sprintf(indexesQuery, "CURRENT_SCHEMA()", "users"))).
 					WillReturnRows(sqlmock.NewRows([]string{"index_name", "column_name", "primary", "unique", "seq_in_index"}).
 						AddRow("users_pkey", "id", "t", "t", 0))
@@ -344,12 +344,12 @@ func TestPostgres_Create(t *testing.T) {
 			before: func(mock pgMock) {
 				mock.start("120000")
 				mock.tableExists("users", true)
-				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
+				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
 					WithArgs("users").
-					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale"}).
-						AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil).
-						AddRow("name", "character", "YES", "NULL", "bpchar", nil, nil).
-						AddRow("doc", "jsonb", "YES", "NULL", "jsonb", nil, nil))
+					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length"}).
+						AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil, nil).
+						AddRow("name", "character", "YES", "NULL", "bpchar", nil, nil, nil).
+						AddRow("doc", "jsonb", "YES", "NULL", "jsonb", nil, nil, nil))
 				mock.ExpectQuery(escape(fmt.Sprintf(indexesQuery, "CURRENT_SCHEMA()", "users"))).
 					WillReturnRows(sqlmock.NewRows([]string{"index_name", "column_name", "primary", "unique", "seq_in_index"}).
 						AddRow("users_pkey", "id", "t", "t", 0))
@@ -376,11 +376,11 @@ func TestPostgres_Create(t *testing.T) {
 			before: func(mock pgMock) {
 				mock.start("120000")
 				mock.tableExists("users", true)
-				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
+				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
 					WithArgs("users").
-					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale"}).
-						AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil).
-						AddRow("name", "character", "YES", "NULL", "bpchar", nil, nil))
+					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length"}).
+						AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil, nil).
+						AddRow("name", "character", "YES", "NULL", "bpchar", nil, nil, nil))
 				mock.ExpectQuery(escape(fmt.Sprintf(indexesQuery, "CURRENT_SCHEMA()", "users"))).
 					WillReturnRows(sqlmock.NewRows([]string{"index_name", "column_name", "primary", "unique", "seq_in_index"}).
 						AddRow("users_pkey", "id", "t", "t", 0))
@@ -407,11 +407,11 @@ func TestPostgres_Create(t *testing.T) {
 			before: func(mock pgMock) {
 				mock.start("120000")
 				mock.tableExists("users", true)
-				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
+				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
 					WithArgs("users").
-					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale"}).
-						AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil).
-						AddRow("name", "character", "YES", "NULL", "bpchar", nil, nil))
+					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length"}).
+						AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil, nil).
+						AddRow("name", "character", "YES", "NULL", "bpchar", nil, nil, nil))
 				mock.ExpectQuery(escape(fmt.Sprintf(indexesQuery, "CURRENT_SCHEMA()", "users"))).
 					WillReturnRows(sqlmock.NewRows([]string{"index_name", "column_name", "primary", "unique", "seq_in_index"}).
 						AddRow("users_pkey", "id", "t", "t", 0))
@@ -438,11 +438,11 @@ func TestPostgres_Create(t *testing.T) {
 			before: func(mock pgMock) {
 				mock.start("120000")
 				mock.tableExists("users", true)
-				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
+				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
 					WithArgs("users").
-					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale"}).
-						AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil).
-						AddRow("name", "character", "YES", "NULL", "bpchar", nil, nil))
+					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length"}).
+						AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil, nil).
+						AddRow("name", "character", "YES", "NULL", "bpchar", nil, nil, nil))
 				mock.ExpectQuery(escape(fmt.Sprintf(indexesQuery, "CURRENT_SCHEMA()", "users"))).
 					WillReturnRows(sqlmock.NewRows([]string{"index_name", "column_name", "primary", "unique", "seq_in_index"}).
 						AddRow("users_pkey", "id", "t", "t", 0))
@@ -468,11 +468,11 @@ func TestPostgres_Create(t *testing.T) {
 			before: func(mock pgMock) {
 				mock.start("120000")
 				mock.tableExists("users", true)
-				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
+				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
 					WithArgs("users").
-					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale"}).
-						AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil).
-						AddRow("name", "character", "YES", "NULL", "bpchar", nil, nil))
+					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length"}).
+						AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil, nil).
+						AddRow("name", "character", "YES", "NULL", "bpchar", nil, nil, nil))
 				mock.ExpectQuery(escape(fmt.Sprintf(indexesQuery, "CURRENT_SCHEMA()", "users"))).
 					WillReturnRows(sqlmock.NewRows([]string{"index_name", "column_name", "primary", "unique", "seq_in_index"}).
 						AddRow("users_pkey", "id", "t", "t", 0))
@@ -498,11 +498,11 @@ func TestPostgres_Create(t *testing.T) {
 			before: func(mock pgMock) {
 				mock.start("120000")
 				mock.tableExists("users", true)
-				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
+				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
 					WithArgs("users").
-					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale"}).
-						AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil).
-						AddRow("name", "character", "NO", "NULL", "bpchar", nil, nil))
+					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length"}).
+						AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil, nil).
+						AddRow("name", "character", "NO", "NULL", "bpchar", nil, nil, nil))
 				mock.ExpectQuery(escape(fmt.Sprintf(indexesQuery, "CURRENT_SCHEMA()", "users"))).
 					WillReturnRows(sqlmock.NewRows([]string{"index_name", "column_name", "primary", "unique", "seq_in_index"}).
 						AddRow("users_pkey", "id", "t", "t", 0))
@@ -528,11 +528,11 @@ func TestPostgres_Create(t *testing.T) {
 			before: func(mock pgMock) {
 				mock.start("120000")
 				mock.tableExists("users", true)
-				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
+				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
 					WithArgs("users").
-					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale"}).
-						AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil).
-						AddRow("age", "bigint", "NO", "NULL", "int8", nil, nil))
+					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length"}).
+						AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil, nil).
+						AddRow("age", "bigint", "NO", "NULL", "int8", nil, nil, nil))
 				mock.ExpectQuery(escape(fmt.Sprintf(indexesQuery, "CURRENT_SCHEMA()", "users"))).
 					WillReturnRows(sqlmock.NewRows([]string{"index_name", "column_name", "primary", "unique", "seq_in_index"}).
 						AddRow("users_pkey", "id", "t", "t", 0))
@@ -558,11 +558,11 @@ func TestPostgres_Create(t *testing.T) {
 			before: func(mock pgMock) {
 				mock.start("120000")
 				mock.tableExists("users", true)
-				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
+				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
 					WithArgs("users").
-					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale"}).
-						AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil).
-						AddRow("age", "bigint", "NO", "NULL", "int8", nil, nil))
+					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length"}).
+						AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil, nil).
+						AddRow("age", "bigint", "NO", "NULL", "int8", nil, nil, nil))
 				mock.ExpectQuery(escape(fmt.Sprintf(indexesQuery, "CURRENT_SCHEMA()", "users"))).
 					WillReturnRows(sqlmock.NewRows([]string{"index_name", "column_name", "primary", "unique", "seq_in_index"}).
 						AddRow("users_pkey", "id", "t", "t", 0).
@@ -588,11 +588,11 @@ func TestPostgres_Create(t *testing.T) {
 			before: func(mock pgMock) {
 				mock.start("120000")
 				mock.tableExists("users", true)
-				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
+				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
 					WithArgs("users").
-					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale"}).
-						AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil).
-						AddRow("age", "bigint", "NO", "NULL", "int8", nil, nil))
+					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length"}).
+						AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil, nil).
+						AddRow("age", "bigint", "NO", "NULL", "int8", nil, nil, nil))
 				mock.ExpectQuery(escape(fmt.Sprintf(indexesQuery, "CURRENT_SCHEMA()", "users"))).
 					WillReturnRows(sqlmock.NewRows([]string{"index_name", "column_name", "primary", "unique", "seq_in_index"}).
 						AddRow("users_pkey", "id", "t", "t", 0).
@@ -645,12 +645,12 @@ func TestPostgres_Create(t *testing.T) {
 			before: func(mock pgMock) {
 				mock.start("120000")
 				mock.tableExists("users", true)
-				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
+				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
 					WithArgs("users").
-					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale"}).
-						AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil).
-						AddRow("age", "bigint", "NO", "NULL", "int8", nil, nil).
-						AddRow("score", "bigint", "NO", "NULL", "int8", nil, nil))
+					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length"}).
+						AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil, nil).
+						AddRow("age", "bigint", "NO", "NULL", "int8", nil, nil, nil).
+						AddRow("score", "bigint", "NO", "NULL", "int8", nil, nil, nil))
 				mock.ExpectQuery(escape(fmt.Sprintf(indexesQuery, "CURRENT_SCHEMA()", "users"))).
 					WillReturnRows(sqlmock.NewRows([]string{"index_name", "column_name", "primary", "unique", "seq_in_index"}).
 						AddRow("users_pkey", "id", "t", "t", 0).
@@ -666,12 +666,12 @@ func TestPostgres_Create(t *testing.T) {
 				mock.ExpectExec(escape(`CREATE UNIQUE INDEX IF NOT EXISTS "user_score" ON "users"("score")`)).
 					WillReturnResult(sqlmock.NewResult(0, 1))
 				mock.tableExists("equipment", true)
-				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
+				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
 					WithArgs("equipment").
-					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale"}).
-						AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil).
-						AddRow("score", "bigint", "NO", "NULL", "int8", nil, nil).
-						AddRow("email", "character varying", "YES", "NULL", "varchar", nil, nil))
+					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length"}).
+						AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil, nil).
+						AddRow("score", "bigint", "NO", "NULL", "int8", nil, nil, nil).
+						AddRow("email", "character varying", "YES", "NULL", "varchar", nil, nil, nil))
 				mock.ExpectQuery(escape(fmt.Sprintf(indexesQuery, "CURRENT_SCHEMA()", "equipment"))).
 					WillReturnRows(sqlmock.NewRows([]string{"index_name", "column_name", "primary", "unique", "seq_in_index"}).
 						AddRow("users_pkey", "id", "t", "t", 0).
@@ -709,11 +709,11 @@ func TestPostgres_Create(t *testing.T) {
 			before: func(mock pgMock) {
 				mock.start("120000")
 				mock.tableExists("users", true)
-				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
+				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
 					WithArgs("users").
-					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale"}).
-						AddRow("id", "bigint", "YES", "NULL", "int8", nil, nil).
-						AddRow("name", "character", "YES", "NULL", "bpchar", nil, nil))
+					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length"}).
+						AddRow("id", "bigint", "YES", "NULL", "int8", nil, nil, nil).
+						AddRow("name", "character", "YES", "NULL", "bpchar", nil, nil, nil))
 				mock.ExpectQuery(escape(fmt.Sprintf(indexesQuery, "CURRENT_SCHEMA()", "users"))).
 					WillReturnRows(sqlmock.NewRows([]string{"index_name", "column_name", "primary", "unique", "seq_in_index"}).
 						AddRow("users_pkey", "id", "t", "t", 0))
@@ -775,10 +775,10 @@ func TestPostgres_Create(t *testing.T) {
 				// query users table.
 				mock.tableExists("users", true)
 				// users table has no changes.
-				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
+				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
 					WithArgs("users").
-					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale"}).
-						AddRow("id", "bigint", "YES", "NULL", "int8", nil, nil))
+					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length"}).
+						AddRow("id", "bigint", "YES", "NULL", "int8", nil, nil, nil))
 				mock.ExpectQuery(escape(fmt.Sprintf(indexesQuery, "CURRENT_SCHEMA()", "users"))).
 					WillReturnRows(sqlmock.NewRows([]string{"index_name", "column_name", "primary", "unique", "seq_in_index"}).
 						AddRow("users_pkey", "id", "t", "t", 0))
@@ -845,11 +845,11 @@ func TestPostgres_Create(t *testing.T) {
 			before: func(mock pgMock) {
 				mock.start("120000")
 				mock.tableExists("users", true)
-				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
+				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
 					WithArgs("users").
-					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale"}).
-						AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil).
-						AddRow("price", "numeric", "NO", "NULL", "numeric", "6", "4"))
+					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length"}).
+						AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil, nil).
+						AddRow("price", "numeric", "NO", "NULL", "numeric", "6", "4", nil))
 				mock.ExpectQuery(escape(fmt.Sprintf(indexesQuery, "CURRENT_SCHEMA()", "users"))).
 					WillReturnRows(sqlmock.NewRows([]string{"index_name", "column_name", "primary", "unique", "seq_in_index"}).
 						AddRow("users_pkey", "id", "t", "t", 0))
@@ -873,11 +873,11 @@ func TestPostgres_Create(t *testing.T) {
 			before: func(mock pgMock) {
 				mock.start("120000")
 				mock.tableExists("users", true)
-				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
+				mock.ExpectQuery(escape(`SELECT "column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length" FROM "information_schema"."columns" WHERE "table_schema" = CURRENT_SCHEMA() AND "table_name" = $1`)).
 					WithArgs("users").
-					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale"}).
-						AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil).
-						AddRow("price", "numeric", "NO", "NULL", "numeric", "5", "4"))
+					WillReturnRows(sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "udt_name", "numeric_precision", "numeric_scale", "character_maximum_length"}).
+						AddRow("id", "bigint", "NO", "NULL", "int8", nil, nil, nil).
+						AddRow("price", "numeric", "NO", "NULL", "numeric", "5", "4", nil))
 				mock.ExpectQuery(escape(fmt.Sprintf(indexesQuery, "CURRENT_SCHEMA()", "users"))).
 					WillReturnRows(sqlmock.NewRows([]string{"index_name", "column_name", "primary", "unique", "seq_in_index"}).
 						AddRow("users_pkey", "id", "t", "t", 0))


### PR DESCRIPTION
Right now if we define in postgres field with max character varchar custom type
```
field.String("name", json.RawMessage{}).
			SchemaType(map[string]string{
				dialect.Postgres: "varchar(100)",
			}),
```
then first migration works as expected.
However the second time, migration operates and column already exists in the database, the migration fails with the following error:
```
sql/schema: creating changeset for \"my_table\": changing column type for \"name\" is invalid (varchar(100) != varchar):
```

This PR fixes the issue