### PR TITLE
docs: use go get -d for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ with large data-models.
 
 ## Quick Installation
 ```console
-go get entgo.io/ent/cmd/ent
+go get -d entgo.io/ent/cmd/ent
 ```
 
 For proper installation using [Go modules], visit [entgo.io website][entgo instal].

--- a/README_jp.md
+++ b/README_jp.md
@@ -19,7 +19,7 @@ src="https://s3.eu-central-1.amazonaws.com/entgo.io/assets/gopher_graph.png"/>
 
 ## クイックインストール
 ```console
-go get entgo.io/ent/cmd/ent
+go get -d entgo.io/ent/cmd/ent
 ```
 
 [Go modules]を使ったインストールについては、[entgo.io website][entgo instal]をご覧ください。

--- a/README_zh.md
+++ b/README_zh.md
@@ -17,7 +17,7 @@ ent是一个简单而又功能强大的Go语言实体框架，ent易于构建和
 
 ## 快速安装
 ```console
-go get entgo.io/ent/cmd/ent
+go get -d entgo.io/ent/cmd/ent
 ```
 
 请访问[entgo.io website][entgo instal]以使用[Go modules]进行正确安装。

--- a/doc/md/code-gen.md
+++ b/doc/md/code-gen.md
@@ -9,7 +9,7 @@ The project comes with a codegen tool called `ent`. In order to install
 `ent` run the following command:
 
 ```bash
-go get entgo.io/ent/cmd/ent
+go get -d entgo.io/ent/cmd/ent
 ``` 
 
 ## Initialize A New Schema
@@ -60,7 +60,7 @@ go mod init <project>
 And then, re-run the following command in order to add `ent` to your `go.mod` file:
 
 ```console
-go get entgo.io/ent/cmd/ent
+go get -d entgo.io/ent/cmd/ent
 ```
 
 Add a `generate.go` file to your project under `<project>/ent`:

--- a/doc/md/getting-started.md
+++ b/doc/md/getting-started.md
@@ -29,7 +29,7 @@ go mod init <project>
 ## Installation
 
 ```console
-go get entgo.io/ent/cmd/ent
+go get -d entgo.io/ent/cmd/ent
 ```
 
 After installing `ent` codegen tool, you should have it in your `PATH`.

--- a/doc/md/tutorial-setup.md
+++ b/doc/md/tutorial-setup.md
@@ -25,7 +25,7 @@ go mod init todo
 Run the following Go commands to install Ent, and tell it to initialize the project structure along with a `Todo` schema.
 
 ```console
-go get entgo.io/ent/cmd/ent
+go get -d entgo.io/ent/cmd/ent
 ```
 
 ```console


### PR DESCRIPTION
https://golang.org/doc/go-get-install-deprecation

```console 
$ go get entgo.io/ent/cmd/ent
go get: installing executables with 'go get' in module mode is deprecated.
        To adjust and download dependencies of the current module, use 'go get -d'.
        To install using requirements of the current module, use 'go install'.
        To install ignoring the current module, use 'go install' with a version,
        like 'go install example.com/cmd@latest'.
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'
```