### PR TITLE
doc/website: generate atom/rss feeds from the blog

### DIFF
--- a/doc/website/docusaurus.config.js
+++ b/doc/website/docusaurus.config.js
@@ -62,6 +62,10 @@ const config = {
           sidebarPath: require.resolve('./sidebars.js'),
         },
         "blog": {
+          "feedOptions": {
+            "type": 'all',
+            "copyright": `Copyright © ${new Date().getFullYear()}, The Ent Authors.`,
+          },
           "path": "blog",
           "blogSidebarCount": 'ALL',
           "blogSidebarTitle": 'All our posts',


### PR DESCRIPTION
To make the Ent blog consumable by Rss / Feed Readers, applying the `feedOptions` configuration to the blog.

See [docs](https://docusaurus.io/docs/blog#feed)