### PR TITLE
entc/gen: don't rely on descriptor when retrieving enum values or nam…

### DIFF
--- a/entc/gen/type.go
+++ b/entc/gen/type.go
@@ -896,7 +896,7 @@ func (f Field) StructField() string {
 
 // EnumNames returns the enum values of a field.
 func (f Field) EnumNames() []string {
-	names := make([]string, 0, len(f.def.Enums))
+	names := make([]string, 0, len(f.Enums))
 	for _, e := range f.Enums {
 		names = append(names, e.Name)
 	}
@@ -905,7 +905,7 @@ func (f Field) EnumNames() []string {
 
 // EnumValues returns the values of the enum field.
 func (f Field) EnumValues() []string {
-	values := make([]string, 0, len(f.def.Enums))
+	values := make([]string, 0, len(f.Enums))
 	for _, e := range f.Enums {
 		values = append(values, e.Value)
 	}


### PR DESCRIPTION
…es to ease extension testibility

Trying to add tests to some extensions and this is complicating things a lot because `Field.def` is unexported. Not taking the length of `def.Enums` but `Enums` directly fixes this. It technically is also more correct, because `f.Enums` could be greater than `f.def.Enums`.