### PR TITLE
dialect/sql/schema: fix for #2254

### DIFF
--- a/dialect/sql/schema/migrate.go
+++ b/dialect/sql/schema/migrate.go
@@ -9,7 +9,6 @@ import (
 	"crypto/md5"
 	"fmt"
 	"math"
-	"sort"
 
 	"entgo.io/ent/dialect"
 	"entgo.io/ent/dialect/sql"
@@ -322,10 +321,12 @@ func (m *Migrate) changeSet(curr, new *Table) (*changes, error) {
 	if len(curr.PrimaryKey) != len(new.PrimaryKey) {
 		return nil, fmt.Errorf("cannot change primary key for table: %q", curr.Name)
 	}
-	sort.Slice(new.PrimaryKey, func(i, j int) bool { return new.PrimaryKey[i].Name < new.PrimaryKey[j].Name })
-	sort.Slice(curr.PrimaryKey, func(i, j int) bool { return curr.PrimaryKey[i].Name < curr.PrimaryKey[j].Name })
-	for i := range curr.PrimaryKey {
-		if curr.PrimaryKey[i].Name != new.PrimaryKey[i].Name {
+	currPK := make([]*Column, len(curr.PrimaryKey))
+	copy(currPK, curr.PrimaryKey)
+	newPK := make([]*Column, len(new.PrimaryKey))
+	copy(newPK, new.PrimaryKey)
+	for i := range currPK {
+		if currPK[i].Name != newPK[i].Name {
 			return nil, fmt.Errorf("cannot change primary key for table: %q", curr.Name)
 		}
 	}


### PR DESCRIPTION
A fix for 2254 before landing 2254 (will rebase and land 2254).
We stay with the sorting here (which is bad), but we do not mutate the generate `ent/migrate.Schema` object.