### PR TITLE
dialect/sql/schema: support `time with time zone` and `time without time zone`

### DIFF
--- a/dialect/sql/schema/postgres.go
+++ b/dialect/sql/schema/postgres.go
@@ -272,7 +272,7 @@ func (d *Postgres) scanColumn(c *Column, rows *sql.Rows) error {
 			schemaType := fmt.Sprintf("varchar(%d)", characterMaximumLen.Int64)
 			c.SchemaType = map[string]string{dialect.Postgres: schemaType}
 		}
-	case "date", "time", "timestamp", "timestamp with time zone", "timestamp without time zone":
+	case "date", "time with time zone", "time without time zone", "timestamp with time zone", "timestamp without time zone":
 		c.Type = field.TypeTime
 	case "bytea":
 		c.Type = field.TypeBytes

--- a/dialect/sql/schema/postgres_test.go
+++ b/dialect/sql/schema/postgres_test.go
@@ -279,7 +279,7 @@ func TestPostgres_Create(t *testing.T) {
 						AddRow("name", "character varying", "YES", "NULL", "varchar", nil, nil, nil).
 						AddRow("uuid", "uuid", "YES", "NULL", "uuid", nil, nil, nil).
 						AddRow("created_at", "date", "NO", "CURRENT_DATE", "date", nil, nil, nil).
-						AddRow("updated_at", "timestamp", "YES", "NULL", "timestamptz", nil, nil, nil).
+						AddRow("updated_at", "timestamp with time zone", "YES", "NULL", "timestamptz", nil, nil, nil).
 						AddRow("deleted_at", "date", "YES", "NULL", "date", nil, nil, nil).
 						AddRow("text", "text", "YES", "NULL", "text", nil, nil, nil).
 						AddRow("cidr", "cidr", "NO", "NULL", "cidr", nil, nil, nil).

--- a/dialect/sql/schema/postgres_test.go
+++ b/dialect/sql/schema/postgres_test.go
@@ -290,7 +290,7 @@ func TestPostgres_Create(t *testing.T) {
 				mock.ExpectQuery(escape(fmt.Sprintf(indexesQuery, "CURRENT_SCHEMA()", "users"))).
 					WillReturnRows(sqlmock.NewRows([]string{"index_name", "column_name", "primary", "unique", "seq_in_index"}).
 						AddRow("users_pkey", "id", "t", "t", 0))
-				mock.ExpectExec(escape(`ALTER TABLE "users" ADD COLUMN "age" bigint NOT NULL, ALTER COLUMN "created_at" TYPE date, ALTER COLUMN "created_at" SET NOT NULL, ALTER COLUMN "created_at" SET DEFAULT CURRENT_DATE, ALTER COLUMN "updated_at" TYPE timestamp with time zone, ALTER COLUMN "updated_at" DROP NOT NULL, ALTER COLUMN "deleted_at" TYPE timestamp with time zone, ALTER COLUMN "deleted_at" DROP NOT NULL`)).
+				mock.ExpectExec(escape(`ALTER TABLE "users" ADD COLUMN "age" bigint NOT NULL, ALTER COLUMN "created_at" TYPE date, ALTER COLUMN "created_at" SET NOT NULL, ALTER COLUMN "created_at" SET DEFAULT CURRENT_DATE, ALTER COLUMN "deleted_at" TYPE timestamp with time zone, ALTER COLUMN "deleted_at" DROP NOT NULL`)).
 					WillReturnResult(sqlmock.NewResult(0, 1))
 				mock.ExpectCommit()
 			},


### PR DESCRIPTION
Fix #2244

8.5. Date/Time Types
https://www.postgresql.org/docs/14/datatype-datetime.html
