### PR TITLE
read time.Time into configured timezone

### DIFF
--- a/entc/gen/template/config.tmpl
+++ b/entc/gen/template/config.tmpl
@@ -49,6 +49,16 @@ type config struct {
 			{{- end }}
 		{{- end }}
 	{{- end }}
+
+	readIntoTz *time.Location
+}
+
+// timeInTz will convert the read time.Time into the configured timezone (if configured).
+func (c *config) timeInTz(t time.Time) time.TIme {
+	if c.readIntoTz != nil {
+		return t.In(c.readIntoTz)
+	}
+	return t
 }
 
 // hooks per client, for fast access.
@@ -86,6 +96,13 @@ func Log(fn func(...interface{})) Option {
 func Driver(driver dialect.Driver) Option {
 	return func(c *config) {
 		c.driver = driver
+	}
+}
+
+// ReadIntoTz sets the timezone to convert all time into when reading.
+func ReadIntoTz(loc *time.Location) Option {
+	return func(c *config) {
+		c.readIntoTz = loc
 	}
 }
 

--- a/entc/gen/template/dialect/sql/decode.tmpl
+++ b/entc/gen/template/dialect/sql/decode.tmpl
@@ -111,13 +111,25 @@ func ({{ $receiver }} *{{ $.Name }}) assignValues(columns []string, values []int
 			} else if value.Valid {
 				{{- if $f.NillableValue }}
 					{{ $ret }}.{{ $field }} = new({{ $f.Type }})
-					*{{ $ret }}.{{ $field }} = {{ $f.ScanTypeField "value" }}
+					{{- if eq $f.Type.String "time.Time" }}
+						*{{ $ret }}.{{ $field }} = {{ $ret }}.config.timeInTz({{ $f.ScanTypeField "value" }})
+					{{- else }}
+						*{{ $ret }}.{{ $field }} = {{ $f.ScanTypeField "value" }}
+					{{- end }}
 				{{- else }}
-					{{ $ret }}.{{ $field }} = {{ $f.ScanTypeField "value" }}
+					{{- if eq $f.Type.String "time.Time" }}
+						{{ $ret }}.{{ $field }} = {{ $ret }}.config.timeInTz({{ $f.ScanTypeField "value" }})
+					{{- else }}
+						{{ $ret }}.{{ $field }} = {{ $f.ScanTypeField "value" }}
+					{{- end }}
 				{{- end }}
 		{{- else }}
 			} else if value != nil {
-				{{ $ret }}.{{ $field }} = {{ if and (not $f.Nillable) (not $f.Type.RType.IsPtr) }}*{{ end }}value
+				{{- if eq $f.Type.String "time.Time" }}
+					{{ $ret }}.{{ $field }} = {{ $ret }}.config.timeInTz({{ if and (not $f.Nillable) (not $f.Type.RType.IsPtr) }}*{{ end }}value)
+				{{- else }}
+					{{ $ret }}.{{ $field }} = {{ if and (not $f.Nillable) (not $f.Type.RType.IsPtr) }}*{{ end }}value
+				{{- end }}
 		{{- end }}
 		}
 	{{- end }}

--- a/entc/integration/cascadelete/ent/config.go
+++ b/entc/integration/cascadelete/ent/config.go
@@ -7,6 +7,8 @@
 package ent
 
 import (
+	"time"
+
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
 )
@@ -24,6 +26,16 @@ type config struct {
 	log func(...interface{})
 	// hooks to execute on mutations.
 	hooks *hooks
+
+	readIntoTz *time.Location
+}
+
+// timeInTz will convert the read time.Time into the configured timezone (if configured).
+func (c *config) timeInTz(t time.Time) time.TIme {
+	if c.readIntoTz != nil {
+		return t.In(c.readIntoTz)
+	}
+	return t
 }
 
 // hooks per client, for fast access.
@@ -61,5 +73,12 @@ func Log(fn func(...interface{})) Option {
 func Driver(driver dialect.Driver) Option {
 	return func(c *config) {
 		c.driver = driver
+	}
+}
+
+// ReadIntoTz sets the timezone to convert all time into when reading.
+func ReadIntoTz(loc *time.Location) Option {
+	return func(c *config) {
+		c.readIntoTz = loc
 	}
 }

--- a/entc/integration/config/ent/config.go
+++ b/entc/integration/config/ent/config.go
@@ -7,6 +7,8 @@
 package ent
 
 import (
+	"time"
+
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
 )
@@ -24,6 +26,16 @@ type config struct {
 	log func(...interface{})
 	// hooks to execute on mutations.
 	hooks *hooks
+
+	readIntoTz *time.Location
+}
+
+// timeInTz will convert the read time.Time into the configured timezone (if configured).
+func (c *config) timeInTz(t time.Time) time.TIme {
+	if c.readIntoTz != nil {
+		return t.In(c.readIntoTz)
+	}
+	return t
 }
 
 // hooks per client, for fast access.
@@ -59,5 +71,12 @@ func Log(fn func(...interface{})) Option {
 func Driver(driver dialect.Driver) Option {
 	return func(c *config) {
 		c.driver = driver
+	}
+}
+
+// ReadIntoTz sets the timezone to convert all time into when reading.
+func ReadIntoTz(loc *time.Location) Option {
+	return func(c *config) {
+		c.readIntoTz = loc
 	}
 }

--- a/entc/integration/customid/ent/config.go
+++ b/entc/integration/customid/ent/config.go
@@ -7,6 +7,8 @@
 package ent
 
 import (
+	"time"
+
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
 )
@@ -24,6 +26,16 @@ type config struct {
 	log func(...interface{})
 	// hooks to execute on mutations.
 	hooks *hooks
+
+	readIntoTz *time.Location
+}
+
+// timeInTz will convert the read time.Time into the configured timezone (if configured).
+func (c *config) timeInTz(t time.Time) time.TIme {
+	if c.readIntoTz != nil {
+		return t.In(c.readIntoTz)
+	}
+	return t
 }
 
 // hooks per client, for fast access.
@@ -68,5 +80,12 @@ func Log(fn func(...interface{})) Option {
 func Driver(driver dialect.Driver) Option {
 	return func(c *config) {
 		c.driver = driver
+	}
+}
+
+// ReadIntoTz sets the timezone to convert all time into when reading.
+func ReadIntoTz(loc *time.Location) Option {
+	return func(c *config) {
+		c.readIntoTz = loc
 	}
 }

--- a/entc/integration/edgefield/ent/config.go
+++ b/entc/integration/edgefield/ent/config.go
@@ -7,6 +7,8 @@
 package ent
 
 import (
+	"time"
+
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
 )
@@ -24,6 +26,16 @@ type config struct {
 	log func(...interface{})
 	// hooks to execute on mutations.
 	hooks *hooks
+
+	readIntoTz *time.Location
+}
+
+// timeInTz will convert the read time.Time into the configured timezone (if configured).
+func (c *config) timeInTz(t time.Time) time.TIme {
+	if c.readIntoTz != nil {
+		return t.In(c.readIntoTz)
+	}
+	return t
 }
 
 // hooks per client, for fast access.
@@ -67,5 +79,12 @@ func Log(fn func(...interface{})) Option {
 func Driver(driver dialect.Driver) Option {
 	return func(c *config) {
 		c.driver = driver
+	}
+}
+
+// ReadIntoTz sets the timezone to convert all time into when reading.
+func ReadIntoTz(loc *time.Location) Option {
+	return func(c *config) {
+		c.readIntoTz = loc
 	}
 }

--- a/entc/integration/edgefield/ent/rental.go
+++ b/entc/integration/edgefield/ent/rental.go
@@ -109,7 +109,7 @@ func (r *Rental) assignValues(columns []string, values []interface{}) error {
 			if value, ok := values[i].(*sql.NullTime); !ok {
 				return fmt.Errorf("unexpected type %T for field date", values[i])
 			} else if value.Valid {
-				r.Date = value.Time
+				r.Date = r.config.timeInTz(value.Time)
 			}
 		case rental.FieldUserID:
 			if value, ok := values[i].(*sql.NullInt64); !ok {

--- a/entc/integration/ent/card.go
+++ b/entc/integration/ent/card.go
@@ -115,13 +115,13 @@ func (c *Card) assignValues(columns []string, values []interface{}) error {
 			if value, ok := values[i].(*sql.NullTime); !ok {
 				return fmt.Errorf("unexpected type %T for field create_time", values[i])
 			} else if value.Valid {
-				c.CreateTime = value.Time
+				c.CreateTime = c.config.timeInTz(value.Time)
 			}
 		case card.FieldUpdateTime:
 			if value, ok := values[i].(*sql.NullTime); !ok {
 				return fmt.Errorf("unexpected type %T for field update_time", values[i])
 			} else if value.Valid {
-				c.UpdateTime = value.Time
+				c.UpdateTime = c.config.timeInTz(value.Time)
 			}
 		case card.FieldBalance:
 			if value, ok := values[i].(*sql.NullFloat64); !ok {

--- a/entc/integration/ent/config.go
+++ b/entc/integration/ent/config.go
@@ -7,6 +7,8 @@
 package ent
 
 import (
+	"time"
+
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
 )
@@ -24,6 +26,16 @@ type config struct {
 	log func(...interface{})
 	// hooks to execute on mutations.
 	hooks *hooks
+
+	readIntoTz *time.Location
+}
+
+// timeInTz will convert the read time.Time into the configured timezone (if configured).
+func (c *config) timeInTz(t time.Time) time.TIme {
+	if c.readIntoTz != nil {
+		return t.In(c.readIntoTz)
+	}
+	return t
 }
 
 // hooks per client, for fast access.
@@ -72,5 +84,12 @@ func Log(fn func(...interface{})) Option {
 func Driver(driver dialect.Driver) Option {
 	return func(c *config) {
 		c.driver = driver
+	}
+}
+
+// ReadIntoTz sets the timezone to convert all time into when reading.
+func ReadIntoTz(loc *time.Location) Option {
+	return func(c *config) {
+		c.readIntoTz = loc
 	}
 }

--- a/entc/integration/ent/fieldtype.go
+++ b/entc/integration/ent/fieldtype.go
@@ -386,7 +386,7 @@ func (ft *FieldType) assignValues(columns []string, values []interface{}) error 
 			if value, ok := values[i].(*sql.NullTime); !ok {
 				return fmt.Errorf("unexpected type %T for field datetime", values[i])
 			} else if value.Valid {
-				ft.Datetime = value.Time
+				ft.Datetime = ft.config.timeInTz(value.Time)
 			}
 		case fieldtype.FieldDecimal:
 			if value, ok := values[i].(*sql.NullFloat64); !ok {

--- a/entc/integration/ent/group.go
+++ b/entc/integration/ent/group.go
@@ -140,7 +140,7 @@ func (gr *Group) assignValues(columns []string, values []interface{}) error {
 			if value, ok := values[i].(*sql.NullTime); !ok {
 				return fmt.Errorf("unexpected type %T for field expire", values[i])
 			} else if value.Valid {
-				gr.Expire = value.Time
+				gr.Expire = gr.config.timeInTz(value.Time)
 			}
 		case group.FieldType:
 			if value, ok := values[i].(*sql.NullString); !ok {

--- a/entc/integration/gremlin/ent/config.go
+++ b/entc/integration/gremlin/ent/config.go
@@ -7,6 +7,8 @@
 package ent
 
 import (
+	"time"
+
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
 )
@@ -24,6 +26,16 @@ type config struct {
 	log func(...interface{})
 	// hooks to execute on mutations.
 	hooks *hooks
+
+	readIntoTz *time.Location
+}
+
+// timeInTz will convert the read time.Time into the configured timezone (if configured).
+func (c *config) timeInTz(t time.Time) time.TIme {
+	if c.readIntoTz != nil {
+		return t.In(c.readIntoTz)
+	}
+	return t
 }
 
 // hooks per client, for fast access.
@@ -72,5 +84,12 @@ func Log(fn func(...interface{})) Option {
 func Driver(driver dialect.Driver) Option {
 	return func(c *config) {
 		c.driver = driver
+	}
+}
+
+// ReadIntoTz sets the timezone to convert all time into when reading.
+func ReadIntoTz(loc *time.Location) Option {
+	return func(c *config) {
+		c.readIntoTz = loc
 	}
 }

--- a/entc/integration/hooks/ent/card.go
+++ b/entc/integration/hooks/ent/card.go
@@ -110,7 +110,7 @@ func (c *Card) assignValues(columns []string, values []interface{}) error {
 			if value, ok := values[i].(*sql.NullTime); !ok {
 				return fmt.Errorf("unexpected type %T for field created_at", values[i])
 			} else if value.Valid {
-				c.CreatedAt = value.Time
+				c.CreatedAt = c.config.timeInTz(value.Time)
 			}
 		case card.FieldInHook:
 			if value, ok := values[i].(*sql.NullString); !ok {

--- a/entc/integration/hooks/ent/config.go
+++ b/entc/integration/hooks/ent/config.go
@@ -7,6 +7,8 @@
 package ent
 
 import (
+	"time"
+
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
 )
@@ -24,6 +26,16 @@ type config struct {
 	log func(...interface{})
 	// hooks to execute on mutations.
 	hooks *hooks
+
+	readIntoTz *time.Location
+}
+
+// timeInTz will convert the read time.Time into the configured timezone (if configured).
+func (c *config) timeInTz(t time.Time) time.TIme {
+	if c.readIntoTz != nil {
+		return t.In(c.readIntoTz)
+	}
+	return t
 }
 
 // hooks per client, for fast access.
@@ -60,5 +72,12 @@ func Log(fn func(...interface{})) Option {
 func Driver(driver dialect.Driver) Option {
 	return func(c *config) {
 		c.driver = driver
+	}
+}
+
+// ReadIntoTz sets the timezone to convert all time into when reading.
+func ReadIntoTz(loc *time.Location) Option {
+	return func(c *config) {
+		c.readIntoTz = loc
 	}
 }

--- a/entc/integration/idtype/ent/config.go
+++ b/entc/integration/idtype/ent/config.go
@@ -7,6 +7,8 @@
 package ent
 
 import (
+	"time"
+
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
 )
@@ -24,6 +26,16 @@ type config struct {
 	log func(...interface{})
 	// hooks to execute on mutations.
 	hooks *hooks
+
+	readIntoTz *time.Location
+}
+
+// timeInTz will convert the read time.Time into the configured timezone (if configured).
+func (c *config) timeInTz(t time.Time) time.TIme {
+	if c.readIntoTz != nil {
+		return t.In(c.readIntoTz)
+	}
+	return t
 }
 
 // hooks per client, for fast access.
@@ -59,5 +71,12 @@ func Log(fn func(...interface{})) Option {
 func Driver(driver dialect.Driver) Option {
 	return func(c *config) {
 		c.driver = driver
+	}
+}
+
+// ReadIntoTz sets the timezone to convert all time into when reading.
+func ReadIntoTz(loc *time.Location) Option {
+	return func(c *config) {
+		c.readIntoTz = loc
 	}
 }

--- a/entc/integration/json/ent/config.go
+++ b/entc/integration/json/ent/config.go
@@ -7,6 +7,8 @@
 package ent
 
 import (
+	"time"
+
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
 )
@@ -24,6 +26,16 @@ type config struct {
 	log func(...interface{})
 	// hooks to execute on mutations.
 	hooks *hooks
+
+	readIntoTz *time.Location
+}
+
+// timeInTz will convert the read time.Time into the configured timezone (if configured).
+func (c *config) timeInTz(t time.Time) time.TIme {
+	if c.readIntoTz != nil {
+		return t.In(c.readIntoTz)
+	}
+	return t
 }
 
 // hooks per client, for fast access.
@@ -59,5 +71,12 @@ func Log(fn func(...interface{})) Option {
 func Driver(driver dialect.Driver) Option {
 	return func(c *config) {
 		c.driver = driver
+	}
+}
+
+// ReadIntoTz sets the timezone to convert all time into when reading.
+func ReadIntoTz(loc *time.Location) Option {
+	return func(c *config) {
+		c.readIntoTz = loc
 	}
 }

--- a/entc/integration/migrate/entv1/config.go
+++ b/entc/integration/migrate/entv1/config.go
@@ -7,6 +7,8 @@
 package entv1
 
 import (
+	"time"
+
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
 )
@@ -24,6 +26,16 @@ type config struct {
 	log func(...interface{})
 	// hooks to execute on mutations.
 	hooks *hooks
+
+	readIntoTz *time.Location
+}
+
+// timeInTz will convert the read time.Time into the configured timezone (if configured).
+func (c *config) timeInTz(t time.Time) time.TIme {
+	if c.readIntoTz != nil {
+		return t.In(c.readIntoTz)
+	}
+	return t
 }
 
 // hooks per client, for fast access.
@@ -62,5 +74,12 @@ func Log(fn func(...interface{})) Option {
 func Driver(driver dialect.Driver) Option {
 	return func(c *config) {
 		c.driver = driver
+	}
+}
+
+// ReadIntoTz sets the timezone to convert all time into when reading.
+func ReadIntoTz(loc *time.Location) Option {
+	return func(c *config) {
+		c.readIntoTz = loc
 	}
 }

--- a/entc/integration/migrate/entv2/config.go
+++ b/entc/integration/migrate/entv2/config.go
@@ -7,6 +7,8 @@
 package entv2
 
 import (
+	"time"
+
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
 )
@@ -24,6 +26,16 @@ type config struct {
 	log func(...interface{})
 	// hooks to execute on mutations.
 	hooks *hooks
+
+	readIntoTz *time.Location
+}
+
+// timeInTz will convert the read time.Time into the configured timezone (if configured).
+func (c *config) timeInTz(t time.Time) time.TIme {
+	if c.readIntoTz != nil {
+		return t.In(c.readIntoTz)
+	}
+	return t
 }
 
 // hooks per client, for fast access.
@@ -65,5 +77,12 @@ func Log(fn func(...interface{})) Option {
 func Driver(driver dialect.Driver) Option {
 	return func(c *config) {
 		c.driver = driver
+	}
+}
+
+// ReadIntoTz sets the timezone to convert all time into when reading.
+func ReadIntoTz(loc *time.Location) Option {
+	return func(c *config) {
+		c.readIntoTz = loc
 	}
 }

--- a/entc/integration/migrate/entv2/user.go
+++ b/entc/integration/migrate/entv2/user.go
@@ -223,7 +223,7 @@ func (u *User) assignValues(columns []string, values []interface{}) error {
 			if value, ok := values[i].(*sql.NullTime); !ok {
 				return fmt.Errorf("unexpected type %T for field created_at", values[i])
 			} else if value.Valid {
-				u.CreatedAt = value.Time
+				u.CreatedAt = u.config.timeInTz(value.Time)
 			}
 		}
 	}

--- a/entc/integration/multischema/ent/config.go
+++ b/entc/integration/multischema/ent/config.go
@@ -8,6 +8,7 @@ package ent
 
 import (
 	"context"
+	"time"
 
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
@@ -29,6 +30,16 @@ type config struct {
 	hooks *hooks
 
 	schemaConfig SchemaConfig
+
+	readIntoTz *time.Location
+}
+
+// timeInTz will convert the read time.Time into the configured timezone (if configured).
+func (c *config) timeInTz(t time.Time) time.TIme {
+	if c.readIntoTz != nil {
+		return t.In(c.readIntoTz)
+	}
+	return t
 }
 
 // hooks per client, for fast access.
@@ -66,6 +77,13 @@ func Log(fn func(...interface{})) Option {
 func Driver(driver dialect.Driver) Option {
 	return func(c *config) {
 		c.driver = driver
+	}
+}
+
+// ReadIntoTz sets the timezone to convert all time into when reading.
+func ReadIntoTz(loc *time.Location) Option {
+	return func(c *config) {
+		c.readIntoTz = loc
 	}
 }
 

--- a/entc/integration/privacy/ent/config.go
+++ b/entc/integration/privacy/ent/config.go
@@ -7,6 +7,8 @@
 package ent
 
 import (
+	"time"
+
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
 )
@@ -24,6 +26,16 @@ type config struct {
 	log func(...interface{})
 	// hooks to execute on mutations.
 	hooks *hooks
+
+	readIntoTz *time.Location
+}
+
+// timeInTz will convert the read time.Time into the configured timezone (if configured).
+func (c *config) timeInTz(t time.Time) time.TIme {
+	if c.readIntoTz != nil {
+		return t.In(c.readIntoTz)
+	}
+	return t
 }
 
 // hooks per client, for fast access.
@@ -61,5 +73,12 @@ func Log(fn func(...interface{})) Option {
 func Driver(driver dialect.Driver) Option {
 	return func(c *config) {
 		c.driver = driver
+	}
+}
+
+// ReadIntoTz sets the timezone to convert all time into when reading.
+func ReadIntoTz(loc *time.Location) Option {
+	return func(c *config) {
+		c.readIntoTz = loc
 	}
 }

--- a/entc/integration/template/ent/config.go
+++ b/entc/integration/template/ent/config.go
@@ -8,6 +8,7 @@ package ent
 
 import (
 	"net/http"
+	"time"
 
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
@@ -28,6 +29,16 @@ type config struct {
 	hooks *hooks
 	// HTTPClient field added by a test template.
 	HTTPClient *http.Client
+
+	readIntoTz *time.Location
+}
+
+// timeInTz will convert the read time.Time into the configured timezone (if configured).
+func (c *config) timeInTz(t time.Time) time.TIme {
+	if c.readIntoTz != nil {
+		return t.In(c.readIntoTz)
+	}
+	return t
 }
 
 // hooks per client, for fast access.
@@ -65,6 +76,13 @@ func Log(fn func(...interface{})) Option {
 func Driver(driver dialect.Driver) Option {
 	return func(c *config) {
 		c.driver = driver
+	}
+}
+
+// ReadIntoTz sets the timezone to convert all time into when reading.
+func ReadIntoTz(loc *time.Location) Option {
+	return func(c *config) {
+		c.readIntoTz = loc
 	}
 }
 

--- a/entc/integration/template/ent/pet.go
+++ b/entc/integration/template/ent/pet.go
@@ -96,7 +96,7 @@ func (pe *Pet) assignValues(columns []string, values []interface{}) error {
 				return fmt.Errorf("unexpected type %T for field licensed_at", values[i])
 			} else if value.Valid {
 				pe.LicensedAt = new(time.Time)
-				*pe.LicensedAt = value.Time
+				*pe.LicensedAt = pe.config.timeInTz(value.Time)
 			}
 		case pet.ForeignKeys[0]:
 			if value, ok := values[i].(*sql.NullInt64); !ok {

--- a/examples/edgeindex/ent/config.go
+++ b/examples/edgeindex/ent/config.go
@@ -7,6 +7,8 @@
 package ent
 
 import (
+	"time"
+
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
 )
@@ -24,6 +26,16 @@ type config struct {
 	log func(...interface{})
 	// hooks to execute on mutations.
 	hooks *hooks
+
+	readIntoTz *time.Location
+}
+
+// timeInTz will convert the read time.Time into the configured timezone (if configured).
+func (c *config) timeInTz(t time.Time) time.TIme {
+	if c.readIntoTz != nil {
+		return t.In(c.readIntoTz)
+	}
+	return t
 }
 
 // hooks per client, for fast access.
@@ -60,5 +72,12 @@ func Log(fn func(...interface{})) Option {
 func Driver(driver dialect.Driver) Option {
 	return func(c *config) {
 		c.driver = driver
+	}
+}
+
+// ReadIntoTz sets the timezone to convert all time into when reading.
+func ReadIntoTz(loc *time.Location) Option {
+	return func(c *config) {
+		c.readIntoTz = loc
 	}
 }

--- a/examples/entcpkg/ent/config.go
+++ b/examples/entcpkg/ent/config.go
@@ -9,6 +9,7 @@ package ent
 import (
 	"io"
 	"net/http"
+	"time"
 
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
@@ -29,6 +30,16 @@ type config struct {
 	hooks      *hooks
 	HTTPClient *http.Client
 	Writer     io.Writer
+
+	readIntoTz *time.Location
+}
+
+// timeInTz will convert the read time.Time into the configured timezone (if configured).
+func (c *config) timeInTz(t time.Time) time.TIme {
+	if c.readIntoTz != nil {
+		return t.In(c.readIntoTz)
+	}
+	return t
 }
 
 // hooks per client, for fast access.
@@ -64,6 +75,13 @@ func Log(fn func(...interface{})) Option {
 func Driver(driver dialect.Driver) Option {
 	return func(c *config) {
 		c.driver = driver
+	}
+}
+
+// ReadIntoTz sets the timezone to convert all time into when reading.
+func ReadIntoTz(loc *time.Location) Option {
+	return func(c *config) {
+		c.readIntoTz = loc
 	}
 }
 

--- a/examples/fs/ent/config.go
+++ b/examples/fs/ent/config.go
@@ -7,6 +7,8 @@
 package ent
 
 import (
+	"time"
+
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
 )
@@ -24,6 +26,16 @@ type config struct {
 	log func(...interface{})
 	// hooks to execute on mutations.
 	hooks *hooks
+
+	readIntoTz *time.Location
+}
+
+// timeInTz will convert the read time.Time into the configured timezone (if configured).
+func (c *config) timeInTz(t time.Time) time.TIme {
+	if c.readIntoTz != nil {
+		return t.In(c.readIntoTz)
+	}
+	return t
 }
 
 // hooks per client, for fast access.
@@ -59,5 +71,12 @@ func Log(fn func(...interface{})) Option {
 func Driver(driver dialect.Driver) Option {
 	return func(c *config) {
 		c.driver = driver
+	}
+}
+
+// ReadIntoTz sets the timezone to convert all time into when reading.
+func ReadIntoTz(loc *time.Location) Option {
+	return func(c *config) {
+		c.readIntoTz = loc
 	}
 }

--- a/examples/m2m2types/ent/config.go
+++ b/examples/m2m2types/ent/config.go
@@ -7,6 +7,8 @@
 package ent
 
 import (
+	"time"
+
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
 )
@@ -24,6 +26,16 @@ type config struct {
 	log func(...interface{})
 	// hooks to execute on mutations.
 	hooks *hooks
+
+	readIntoTz *time.Location
+}
+
+// timeInTz will convert the read time.Time into the configured timezone (if configured).
+func (c *config) timeInTz(t time.Time) time.TIme {
+	if c.readIntoTz != nil {
+		return t.In(c.readIntoTz)
+	}
+	return t
 }
 
 // hooks per client, for fast access.
@@ -60,5 +72,12 @@ func Log(fn func(...interface{})) Option {
 func Driver(driver dialect.Driver) Option {
 	return func(c *config) {
 		c.driver = driver
+	}
+}
+
+// ReadIntoTz sets the timezone to convert all time into when reading.
+func ReadIntoTz(loc *time.Location) Option {
+	return func(c *config) {
+		c.readIntoTz = loc
 	}
 }

--- a/examples/m2mbidi/ent/config.go
+++ b/examples/m2mbidi/ent/config.go
@@ -7,6 +7,8 @@
 package ent
 
 import (
+	"time"
+
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
 )
@@ -24,6 +26,16 @@ type config struct {
 	log func(...interface{})
 	// hooks to execute on mutations.
 	hooks *hooks
+
+	readIntoTz *time.Location
+}
+
+// timeInTz will convert the read time.Time into the configured timezone (if configured).
+func (c *config) timeInTz(t time.Time) time.TIme {
+	if c.readIntoTz != nil {
+		return t.In(c.readIntoTz)
+	}
+	return t
 }
 
 // hooks per client, for fast access.
@@ -59,5 +71,12 @@ func Log(fn func(...interface{})) Option {
 func Driver(driver dialect.Driver) Option {
 	return func(c *config) {
 		c.driver = driver
+	}
+}
+
+// ReadIntoTz sets the timezone to convert all time into when reading.
+func ReadIntoTz(loc *time.Location) Option {
+	return func(c *config) {
+		c.readIntoTz = loc
 	}
 }

--- a/examples/m2mrecur/ent/config.go
+++ b/examples/m2mrecur/ent/config.go
@@ -7,6 +7,8 @@
 package ent
 
 import (
+	"time"
+
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
 )
@@ -24,6 +26,16 @@ type config struct {
 	log func(...interface{})
 	// hooks to execute on mutations.
 	hooks *hooks
+
+	readIntoTz *time.Location
+}
+
+// timeInTz will convert the read time.Time into the configured timezone (if configured).
+func (c *config) timeInTz(t time.Time) time.TIme {
+	if c.readIntoTz != nil {
+		return t.In(c.readIntoTz)
+	}
+	return t
 }
 
 // hooks per client, for fast access.
@@ -59,5 +71,12 @@ func Log(fn func(...interface{})) Option {
 func Driver(driver dialect.Driver) Option {
 	return func(c *config) {
 		c.driver = driver
+	}
+}
+
+// ReadIntoTz sets the timezone to convert all time into when reading.
+func ReadIntoTz(loc *time.Location) Option {
+	return func(c *config) {
+		c.readIntoTz = loc
 	}
 }

--- a/examples/o2m2types/ent/config.go
+++ b/examples/o2m2types/ent/config.go
@@ -7,6 +7,8 @@
 package ent
 
 import (
+	"time"
+
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
 )
@@ -24,6 +26,16 @@ type config struct {
 	log func(...interface{})
 	// hooks to execute on mutations.
 	hooks *hooks
+
+	readIntoTz *time.Location
+}
+
+// timeInTz will convert the read time.Time into the configured timezone (if configured).
+func (c *config) timeInTz(t time.Time) time.TIme {
+	if c.readIntoTz != nil {
+		return t.In(c.readIntoTz)
+	}
+	return t
 }
 
 // hooks per client, for fast access.
@@ -60,5 +72,12 @@ func Log(fn func(...interface{})) Option {
 func Driver(driver dialect.Driver) Option {
 	return func(c *config) {
 		c.driver = driver
+	}
+}
+
+// ReadIntoTz sets the timezone to convert all time into when reading.
+func ReadIntoTz(loc *time.Location) Option {
+	return func(c *config) {
+		c.readIntoTz = loc
 	}
 }

--- a/examples/o2mrecur/ent/config.go
+++ b/examples/o2mrecur/ent/config.go
@@ -7,6 +7,8 @@
 package ent
 
 import (
+	"time"
+
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
 )
@@ -24,6 +26,16 @@ type config struct {
 	log func(...interface{})
 	// hooks to execute on mutations.
 	hooks *hooks
+
+	readIntoTz *time.Location
+}
+
+// timeInTz will convert the read time.Time into the configured timezone (if configured).
+func (c *config) timeInTz(t time.Time) time.TIme {
+	if c.readIntoTz != nil {
+		return t.In(c.readIntoTz)
+	}
+	return t
 }
 
 // hooks per client, for fast access.
@@ -59,5 +71,12 @@ func Log(fn func(...interface{})) Option {
 func Driver(driver dialect.Driver) Option {
 	return func(c *config) {
 		c.driver = driver
+	}
+}
+
+// ReadIntoTz sets the timezone to convert all time into when reading.
+func ReadIntoTz(loc *time.Location) Option {
+	return func(c *config) {
+		c.readIntoTz = loc
 	}
 }

--- a/examples/o2o2types/ent/card.go
+++ b/examples/o2o2types/ent/card.go
@@ -92,7 +92,7 @@ func (c *Card) assignValues(columns []string, values []interface{}) error {
 			if value, ok := values[i].(*sql.NullTime); !ok {
 				return fmt.Errorf("unexpected type %T for field expired", values[i])
 			} else if value.Valid {
-				c.Expired = value.Time
+				c.Expired = c.config.timeInTz(value.Time)
 			}
 		case card.FieldNumber:
 			if value, ok := values[i].(*sql.NullString); !ok {

--- a/examples/o2o2types/ent/config.go
+++ b/examples/o2o2types/ent/config.go
@@ -7,6 +7,8 @@
 package ent
 
 import (
+	"time"
+
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
 )
@@ -24,6 +26,16 @@ type config struct {
 	log func(...interface{})
 	// hooks to execute on mutations.
 	hooks *hooks
+
+	readIntoTz *time.Location
+}
+
+// timeInTz will convert the read time.Time into the configured timezone (if configured).
+func (c *config) timeInTz(t time.Time) time.TIme {
+	if c.readIntoTz != nil {
+		return t.In(c.readIntoTz)
+	}
+	return t
 }
 
 // hooks per client, for fast access.
@@ -60,5 +72,12 @@ func Log(fn func(...interface{})) Option {
 func Driver(driver dialect.Driver) Option {
 	return func(c *config) {
 		c.driver = driver
+	}
+}
+
+// ReadIntoTz sets the timezone to convert all time into when reading.
+func ReadIntoTz(loc *time.Location) Option {
+	return func(c *config) {
+		c.readIntoTz = loc
 	}
 }

--- a/examples/o2obidi/ent/config.go
+++ b/examples/o2obidi/ent/config.go
@@ -7,6 +7,8 @@
 package ent
 
 import (
+	"time"
+
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
 )
@@ -24,6 +26,16 @@ type config struct {
 	log func(...interface{})
 	// hooks to execute on mutations.
 	hooks *hooks
+
+	readIntoTz *time.Location
+}
+
+// timeInTz will convert the read time.Time into the configured timezone (if configured).
+func (c *config) timeInTz(t time.Time) time.TIme {
+	if c.readIntoTz != nil {
+		return t.In(c.readIntoTz)
+	}
+	return t
 }
 
 // hooks per client, for fast access.
@@ -59,5 +71,12 @@ func Log(fn func(...interface{})) Option {
 func Driver(driver dialect.Driver) Option {
 	return func(c *config) {
 		c.driver = driver
+	}
+}
+
+// ReadIntoTz sets the timezone to convert all time into when reading.
+func ReadIntoTz(loc *time.Location) Option {
+	return func(c *config) {
+		c.readIntoTz = loc
 	}
 }

--- a/examples/o2orecur/ent/config.go
+++ b/examples/o2orecur/ent/config.go
@@ -7,6 +7,8 @@
 package ent
 
 import (
+	"time"
+
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
 )
@@ -24,6 +26,16 @@ type config struct {
 	log func(...interface{})
 	// hooks to execute on mutations.
 	hooks *hooks
+
+	readIntoTz *time.Location
+}
+
+// timeInTz will convert the read time.Time into the configured timezone (if configured).
+func (c *config) timeInTz(t time.Time) time.TIme {
+	if c.readIntoTz != nil {
+		return t.In(c.readIntoTz)
+	}
+	return t
 }
 
 // hooks per client, for fast access.
@@ -59,5 +71,12 @@ func Log(fn func(...interface{})) Option {
 func Driver(driver dialect.Driver) Option {
 	return func(c *config) {
 		c.driver = driver
+	}
+}
+
+// ReadIntoTz sets the timezone to convert all time into when reading.
+func ReadIntoTz(loc *time.Location) Option {
+	return func(c *config) {
+		c.readIntoTz = loc
 	}
 }

--- a/examples/privacyadmin/ent/config.go
+++ b/examples/privacyadmin/ent/config.go
@@ -7,6 +7,8 @@
 package ent
 
 import (
+	"time"
+
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
 )
@@ -24,6 +26,16 @@ type config struct {
 	log func(...interface{})
 	// hooks to execute on mutations.
 	hooks *hooks
+
+	readIntoTz *time.Location
+}
+
+// timeInTz will convert the read time.Time into the configured timezone (if configured).
+func (c *config) timeInTz(t time.Time) time.TIme {
+	if c.readIntoTz != nil {
+		return t.In(c.readIntoTz)
+	}
+	return t
 }
 
 // hooks per client, for fast access.
@@ -59,5 +71,12 @@ func Log(fn func(...interface{})) Option {
 func Driver(driver dialect.Driver) Option {
 	return func(c *config) {
 		c.driver = driver
+	}
+}
+
+// ReadIntoTz sets the timezone to convert all time into when reading.
+func ReadIntoTz(loc *time.Location) Option {
+	return func(c *config) {
+		c.readIntoTz = loc
 	}
 }

--- a/examples/privacytenant/ent/config.go
+++ b/examples/privacytenant/ent/config.go
@@ -7,6 +7,8 @@
 package ent
 
 import (
+	"time"
+
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
 )
@@ -24,6 +26,16 @@ type config struct {
 	log func(...interface{})
 	// hooks to execute on mutations.
 	hooks *hooks
+
+	readIntoTz *time.Location
+}
+
+// timeInTz will convert the read time.Time into the configured timezone (if configured).
+func (c *config) timeInTz(t time.Time) time.TIme {
+	if c.readIntoTz != nil {
+		return t.In(c.readIntoTz)
+	}
+	return t
 }
 
 // hooks per client, for fast access.
@@ -61,5 +73,12 @@ func Log(fn func(...interface{})) Option {
 func Driver(driver dialect.Driver) Option {
 	return func(c *config) {
 		c.driver = driver
+	}
+}
+
+// ReadIntoTz sets the timezone to convert all time into when reading.
+func ReadIntoTz(loc *time.Location) Option {
+	return func(c *config) {
+		c.readIntoTz = loc
 	}
 }

--- a/examples/start/ent/car.go
+++ b/examples/start/ent/car.go
@@ -98,7 +98,7 @@ func (c *Car) assignValues(columns []string, values []interface{}) error {
 			if value, ok := values[i].(*sql.NullTime); !ok {
 				return fmt.Errorf("unexpected type %T for field registered_at", values[i])
 			} else if value.Valid {
-				c.RegisteredAt = value.Time
+				c.RegisteredAt = c.config.timeInTz(value.Time)
 			}
 		case car.ForeignKeys[0]:
 			if value, ok := values[i].(*sql.NullInt64); !ok {

--- a/examples/start/ent/config.go
+++ b/examples/start/ent/config.go
@@ -7,6 +7,8 @@
 package ent
 
 import (
+	"time"
+
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
 )
@@ -24,6 +26,16 @@ type config struct {
 	log func(...interface{})
 	// hooks to execute on mutations.
 	hooks *hooks
+
+	readIntoTz *time.Location
+}
+
+// timeInTz will convert the read time.Time into the configured timezone (if configured).
+func (c *config) timeInTz(t time.Time) time.TIme {
+	if c.readIntoTz != nil {
+		return t.In(c.readIntoTz)
+	}
+	return t
 }
 
 // hooks per client, for fast access.
@@ -61,5 +73,12 @@ func Log(fn func(...interface{})) Option {
 func Driver(driver dialect.Driver) Option {
 	return func(c *config) {
 		c.driver = driver
+	}
+}
+
+// ReadIntoTz sets the timezone to convert all time into when reading.
+func ReadIntoTz(loc *time.Location) Option {
+	return func(c *config) {
+		c.readIntoTz = loc
 	}
 }

--- a/examples/traversal/ent/config.go
+++ b/examples/traversal/ent/config.go
@@ -7,6 +7,8 @@
 package ent
 
 import (
+	"time"
+
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
 )
@@ -24,6 +26,16 @@ type config struct {
 	log func(...interface{})
 	// hooks to execute on mutations.
 	hooks *hooks
+
+	readIntoTz *time.Location
+}
+
+// timeInTz will convert the read time.Time into the configured timezone (if configured).
+func (c *config) timeInTz(t time.Time) time.TIme {
+	if c.readIntoTz != nil {
+		return t.In(c.readIntoTz)
+	}
+	return t
 }
 
 // hooks per client, for fast access.
@@ -61,5 +73,12 @@ func Log(fn func(...interface{})) Option {
 func Driver(driver dialect.Driver) Option {
 	return func(c *config) {
 		c.driver = driver
+	}
+}
+
+// ReadIntoTz sets the timezone to convert all time into when reading.
+func ReadIntoTz(loc *time.Location) Option {
+	return func(c *config) {
+		c.readIntoTz = loc
 	}
 }

--- a/examples/version/ent/config.go
+++ b/examples/version/ent/config.go
@@ -7,6 +7,8 @@
 package ent
 
 import (
+	"time"
+
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
 )
@@ -24,6 +26,16 @@ type config struct {
 	log func(...interface{})
 	// hooks to execute on mutations.
 	hooks *hooks
+
+	readIntoTz *time.Location
+}
+
+// timeInTz will convert the read time.Time into the configured timezone (if configured).
+func (c *config) timeInTz(t time.Time) time.TIme {
+	if c.readIntoTz != nil {
+		return t.In(c.readIntoTz)
+	}
+	return t
 }
 
 // hooks per client, for fast access.
@@ -59,5 +71,12 @@ func Log(fn func(...interface{})) Option {
 func Driver(driver dialect.Driver) Option {
 	return func(c *config) {
 		c.driver = driver
+	}
+}
+
+// ReadIntoTz sets the timezone to convert all time into when reading.
+func ReadIntoTz(loc *time.Location) Option {
+	return func(c *config) {
+		c.readIntoTz = loc
 	}
 }


### PR DESCRIPTION
simpler version of https://github.com/ent/ent/pull/2258 after @masseelch pointed out that you can set `timezone=UTC` (postgres) or `loc=UTC` (mysql) to ensure that timestamps are stored in UTC and that when querying your passed in timestamp is converted to UTC.

only thing left now are the changes which convert a returned timestamp into a configured timezone, this would allow having a different / specific timezone returned while keeping UTC in the database (which afaik is considered best practice). 