### PR TITLE
add WhereIf API for conditional query

### DIFF
--- a/entc/gen/template/builder/delete.tmpl
+++ b/entc/gen/template/builder/delete.tmpl
@@ -34,6 +34,14 @@ func ({{ $receiver }} *{{ $builder }}) Where(ps ...predicate.{{ $.Name }}) *{{ $
 	return {{ $receiver }}
 }
 
+// WhereIf appends a list predicates to the {{ $builder }} builder if b is true.
+func ({{ $receiver }} *{{ $builder }}) WhereIf(b bool, ps ...predicate.{{ $.Name }}) *{{ $builder }} {
+	if b {
+	    {{ $mutation }}.Where(ps...)
+	}
+	return {{ $receiver }}
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func ({{ $receiver}} *{{ $builder }}) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/gen/template/builder/query.tmpl
+++ b/entc/gen/template/builder/query.tmpl
@@ -53,6 +53,14 @@ func ({{ $receiver }} *{{ $builder }}) Where(ps ...predicate.{{ $.Name }}) *{{ $
 	return {{ $receiver }}
 }
 
+// WhereIf adds a new predicates to the {{ $builder }} builder if b is true.
+func ({{ $receiver }} *{{ $builder }}) WhereIf(b bool, ps ...predicate.{{ $.Name }}) *{{ $builder }} {
+	if b {
+	    {{ $receiver}}.predicates = append({{ $receiver }}.predicates, ps...)
+	}
+	return {{ $receiver }}
+}
+
 // Limit adds a limit step to the query.
 func ({{ $receiver }} *{{ $builder }}) Limit(limit int) *{{ $builder }} {
 	{{ $receiver }}.limit = &limit

--- a/entc/gen/template/builder/update.tmpl
+++ b/entc/gen/template/builder/update.tmpl
@@ -36,6 +36,14 @@ func ({{ $receiver}} *{{ $builder }}) Where(ps ...predicate.{{ $.Name }}) *{{ $b
 	return {{ $receiver }}
 }
 
+// WhereIf appends a list predicates to the {{ $builder }} builder if b is true.
+func ({{ $receiver}} *{{ $builder }}) WhereIf(b bool, ps ...predicate.{{ $.Name }}) *{{ $builder }} {
+	if b {
+	    {{ $mutation }}.Where(ps...)
+	}
+	return {{ $receiver }}
+}
+
 {{ with extend $ "Builder" $builder }}
 	{{ template "setter" . }}
 {{ end }}

--- a/entc/integration/cascadelete/ent/comment_delete.go
+++ b/entc/integration/cascadelete/ent/comment_delete.go
@@ -30,6 +30,14 @@ func (cd *CommentDelete) Where(ps ...predicate.Comment) *CommentDelete {
 	return cd
 }
 
+// WhereIf appends a list predicates to the CommentDelete builder if b is true.
+func (cd *CommentDelete) WhereIf(b bool, ps ...predicate.Comment) *CommentDelete {
+	if b {
+		cd.mutation.Where(ps...)
+	}
+	return cd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (cd *CommentDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/cascadelete/ent/comment_query.go
+++ b/entc/integration/cascadelete/ent/comment_query.go
@@ -42,6 +42,14 @@ func (cq *CommentQuery) Where(ps ...predicate.Comment) *CommentQuery {
 	return cq
 }
 
+// WhereIf adds a new predicates to the CommentQuery builder if b is true.
+func (cq *CommentQuery) WhereIf(b bool, ps ...predicate.Comment) *CommentQuery {
+	if b {
+		cq.predicates = append(cq.predicates, ps...)
+	}
+	return cq
+}
+
 // Limit adds a limit step to the query.
 func (cq *CommentQuery) Limit(limit int) *CommentQuery {
 	cq.limit = &limit

--- a/entc/integration/cascadelete/ent/comment_update.go
+++ b/entc/integration/cascadelete/ent/comment_update.go
@@ -32,6 +32,14 @@ func (cu *CommentUpdate) Where(ps ...predicate.Comment) *CommentUpdate {
 	return cu
 }
 
+// WhereIf appends a list predicates to the CommentUpdate builder if b is true.
+func (cu *CommentUpdate) WhereIf(b bool, ps ...predicate.Comment) *CommentUpdate {
+	if b {
+		cu.mutation.Where(ps...)
+	}
+	return cu
+}
+
 // SetText sets the "text" field.
 func (cu *CommentUpdate) SetText(s string) *CommentUpdate {
 	cu.mutation.SetText(s)

--- a/entc/integration/cascadelete/ent/post_delete.go
+++ b/entc/integration/cascadelete/ent/post_delete.go
@@ -30,6 +30,14 @@ func (pd *PostDelete) Where(ps ...predicate.Post) *PostDelete {
 	return pd
 }
 
+// WhereIf appends a list predicates to the PostDelete builder if b is true.
+func (pd *PostDelete) WhereIf(b bool, ps ...predicate.Post) *PostDelete {
+	if b {
+		pd.mutation.Where(ps...)
+	}
+	return pd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (pd *PostDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/cascadelete/ent/post_query.go
+++ b/entc/integration/cascadelete/ent/post_query.go
@@ -45,6 +45,14 @@ func (pq *PostQuery) Where(ps ...predicate.Post) *PostQuery {
 	return pq
 }
 
+// WhereIf adds a new predicates to the PostQuery builder if b is true.
+func (pq *PostQuery) WhereIf(b bool, ps ...predicate.Post) *PostQuery {
+	if b {
+		pq.predicates = append(pq.predicates, ps...)
+	}
+	return pq
+}
+
 // Limit adds a limit step to the query.
 func (pq *PostQuery) Limit(limit int) *PostQuery {
 	pq.limit = &limit

--- a/entc/integration/cascadelete/ent/post_update.go
+++ b/entc/integration/cascadelete/ent/post_update.go
@@ -33,6 +33,14 @@ func (pu *PostUpdate) Where(ps ...predicate.Post) *PostUpdate {
 	return pu
 }
 
+// WhereIf appends a list predicates to the PostUpdate builder if b is true.
+func (pu *PostUpdate) WhereIf(b bool, ps ...predicate.Post) *PostUpdate {
+	if b {
+		pu.mutation.Where(ps...)
+	}
+	return pu
+}
+
 // SetText sets the "text" field.
 func (pu *PostUpdate) SetText(s string) *PostUpdate {
 	pu.mutation.SetText(s)

--- a/entc/integration/cascadelete/ent/user_delete.go
+++ b/entc/integration/cascadelete/ent/user_delete.go
@@ -30,6 +30,14 @@ func (ud *UserDelete) Where(ps ...predicate.User) *UserDelete {
 	return ud
 }
 
+// WhereIf appends a list predicates to the UserDelete builder if b is true.
+func (ud *UserDelete) WhereIf(b bool, ps ...predicate.User) *UserDelete {
+	if b {
+		ud.mutation.Where(ps...)
+	}
+	return ud
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (ud *UserDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/cascadelete/ent/user_query.go
+++ b/entc/integration/cascadelete/ent/user_query.go
@@ -43,6 +43,14 @@ func (uq *UserQuery) Where(ps ...predicate.User) *UserQuery {
 	return uq
 }
 
+// WhereIf adds a new predicates to the UserQuery builder if b is true.
+func (uq *UserQuery) WhereIf(b bool, ps ...predicate.User) *UserQuery {
+	if b {
+		uq.predicates = append(uq.predicates, ps...)
+	}
+	return uq
+}
+
 // Limit adds a limit step to the query.
 func (uq *UserQuery) Limit(limit int) *UserQuery {
 	uq.limit = &limit

--- a/entc/integration/cascadelete/ent/user_update.go
+++ b/entc/integration/cascadelete/ent/user_update.go
@@ -32,6 +32,14 @@ func (uu *UserUpdate) Where(ps ...predicate.User) *UserUpdate {
 	return uu
 }
 
+// WhereIf appends a list predicates to the UserUpdate builder if b is true.
+func (uu *UserUpdate) WhereIf(b bool, ps ...predicate.User) *UserUpdate {
+	if b {
+		uu.mutation.Where(ps...)
+	}
+	return uu
+}
+
 // SetName sets the "name" field.
 func (uu *UserUpdate) SetName(s string) *UserUpdate {
 	uu.mutation.SetName(s)

--- a/entc/integration/config/ent/user_delete.go
+++ b/entc/integration/config/ent/user_delete.go
@@ -30,6 +30,14 @@ func (ud *UserDelete) Where(ps ...predicate.User) *UserDelete {
 	return ud
 }
 
+// WhereIf appends a list predicates to the UserDelete builder if b is true.
+func (ud *UserDelete) WhereIf(b bool, ps ...predicate.User) *UserDelete {
+	if b {
+		ud.mutation.Where(ps...)
+	}
+	return ud
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (ud *UserDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/config/ent/user_query.go
+++ b/entc/integration/config/ent/user_query.go
@@ -39,6 +39,14 @@ func (uq *UserQuery) Where(ps ...predicate.User) *UserQuery {
 	return uq
 }
 
+// WhereIf adds a new predicates to the UserQuery builder if b is true.
+func (uq *UserQuery) WhereIf(b bool, ps ...predicate.User) *UserQuery {
+	if b {
+		uq.predicates = append(uq.predicates, ps...)
+	}
+	return uq
+}
+
 // Limit adds a limit step to the query.
 func (uq *UserQuery) Limit(limit int) *UserQuery {
 	uq.limit = &limit

--- a/entc/integration/config/ent/user_update.go
+++ b/entc/integration/config/ent/user_update.go
@@ -31,6 +31,14 @@ func (uu *UserUpdate) Where(ps ...predicate.User) *UserUpdate {
 	return uu
 }
 
+// WhereIf appends a list predicates to the UserUpdate builder if b is true.
+func (uu *UserUpdate) WhereIf(b bool, ps ...predicate.User) *UserUpdate {
+	if b {
+		uu.mutation.Where(ps...)
+	}
+	return uu
+}
+
 // SetName sets the "name" field.
 func (uu *UserUpdate) SetName(s string) *UserUpdate {
 	uu.mutation.SetName(s)

--- a/entc/integration/customid/ent/blob_delete.go
+++ b/entc/integration/customid/ent/blob_delete.go
@@ -30,6 +30,14 @@ func (bd *BlobDelete) Where(ps ...predicate.Blob) *BlobDelete {
 	return bd
 }
 
+// WhereIf appends a list predicates to the BlobDelete builder if b is true.
+func (bd *BlobDelete) WhereIf(b bool, ps ...predicate.Blob) *BlobDelete {
+	if b {
+		bd.mutation.Where(ps...)
+	}
+	return bd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (bd *BlobDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/customid/ent/blob_query.go
+++ b/entc/integration/customid/ent/blob_query.go
@@ -45,6 +45,14 @@ func (bq *BlobQuery) Where(ps ...predicate.Blob) *BlobQuery {
 	return bq
 }
 
+// WhereIf adds a new predicates to the BlobQuery builder if b is true.
+func (bq *BlobQuery) WhereIf(b bool, ps ...predicate.Blob) *BlobQuery {
+	if b {
+		bq.predicates = append(bq.predicates, ps...)
+	}
+	return bq
+}
+
 // Limit adds a limit step to the query.
 func (bq *BlobQuery) Limit(limit int) *BlobQuery {
 	bq.limit = &limit

--- a/entc/integration/customid/ent/blob_update.go
+++ b/entc/integration/customid/ent/blob_update.go
@@ -32,6 +32,14 @@ func (bu *BlobUpdate) Where(ps ...predicate.Blob) *BlobUpdate {
 	return bu
 }
 
+// WhereIf appends a list predicates to the BlobUpdate builder if b is true.
+func (bu *BlobUpdate) WhereIf(b bool, ps ...predicate.Blob) *BlobUpdate {
+	if b {
+		bu.mutation.Where(ps...)
+	}
+	return bu
+}
+
 // SetUUID sets the "uuid" field.
 func (bu *BlobUpdate) SetUUID(u uuid.UUID) *BlobUpdate {
 	bu.mutation.SetUUID(u)

--- a/entc/integration/customid/ent/car_delete.go
+++ b/entc/integration/customid/ent/car_delete.go
@@ -30,6 +30,14 @@ func (cd *CarDelete) Where(ps ...predicate.Car) *CarDelete {
 	return cd
 }
 
+// WhereIf appends a list predicates to the CarDelete builder if b is true.
+func (cd *CarDelete) WhereIf(b bool, ps ...predicate.Car) *CarDelete {
+	if b {
+		cd.mutation.Where(ps...)
+	}
+	return cd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (cd *CarDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/customid/ent/car_query.go
+++ b/entc/integration/customid/ent/car_query.go
@@ -43,6 +43,14 @@ func (cq *CarQuery) Where(ps ...predicate.Car) *CarQuery {
 	return cq
 }
 
+// WhereIf adds a new predicates to the CarQuery builder if b is true.
+func (cq *CarQuery) WhereIf(b bool, ps ...predicate.Car) *CarQuery {
+	if b {
+		cq.predicates = append(cq.predicates, ps...)
+	}
+	return cq
+}
+
 // Limit adds a limit step to the query.
 func (cq *CarQuery) Limit(limit int) *CarQuery {
 	cq.limit = &limit

--- a/entc/integration/customid/ent/car_update.go
+++ b/entc/integration/customid/ent/car_update.go
@@ -32,6 +32,14 @@ func (cu *CarUpdate) Where(ps ...predicate.Car) *CarUpdate {
 	return cu
 }
 
+// WhereIf appends a list predicates to the CarUpdate builder if b is true.
+func (cu *CarUpdate) WhereIf(b bool, ps ...predicate.Car) *CarUpdate {
+	if b {
+		cu.mutation.Where(ps...)
+	}
+	return cu
+}
+
 // SetBeforeID sets the "before_id" field.
 func (cu *CarUpdate) SetBeforeID(f float64) *CarUpdate {
 	cu.mutation.ResetBeforeID()

--- a/entc/integration/customid/ent/device_delete.go
+++ b/entc/integration/customid/ent/device_delete.go
@@ -30,6 +30,14 @@ func (dd *DeviceDelete) Where(ps ...predicate.Device) *DeviceDelete {
 	return dd
 }
 
+// WhereIf appends a list predicates to the DeviceDelete builder if b is true.
+func (dd *DeviceDelete) WhereIf(b bool, ps ...predicate.Device) *DeviceDelete {
+	if b {
+		dd.mutation.Where(ps...)
+	}
+	return dd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (dd *DeviceDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/customid/ent/device_query.go
+++ b/entc/integration/customid/ent/device_query.go
@@ -46,6 +46,14 @@ func (dq *DeviceQuery) Where(ps ...predicate.Device) *DeviceQuery {
 	return dq
 }
 
+// WhereIf adds a new predicates to the DeviceQuery builder if b is true.
+func (dq *DeviceQuery) WhereIf(b bool, ps ...predicate.Device) *DeviceQuery {
+	if b {
+		dq.predicates = append(dq.predicates, ps...)
+	}
+	return dq
+}
+
 // Limit adds a limit step to the query.
 func (dq *DeviceQuery) Limit(limit int) *DeviceQuery {
 	dq.limit = &limit

--- a/entc/integration/customid/ent/device_update.go
+++ b/entc/integration/customid/ent/device_update.go
@@ -33,6 +33,14 @@ func (du *DeviceUpdate) Where(ps ...predicate.Device) *DeviceUpdate {
 	return du
 }
 
+// WhereIf appends a list predicates to the DeviceUpdate builder if b is true.
+func (du *DeviceUpdate) WhereIf(b bool, ps ...predicate.Device) *DeviceUpdate {
+	if b {
+		du.mutation.Where(ps...)
+	}
+	return du
+}
+
 // SetActiveSessionID sets the "active_session" edge to the Session entity by ID.
 func (du *DeviceUpdate) SetActiveSessionID(id schema.ID) *DeviceUpdate {
 	du.mutation.SetActiveSessionID(id)

--- a/entc/integration/customid/ent/doc_delete.go
+++ b/entc/integration/customid/ent/doc_delete.go
@@ -30,6 +30,14 @@ func (dd *DocDelete) Where(ps ...predicate.Doc) *DocDelete {
 	return dd
 }
 
+// WhereIf appends a list predicates to the DocDelete builder if b is true.
+func (dd *DocDelete) WhereIf(b bool, ps ...predicate.Doc) *DocDelete {
+	if b {
+		dd.mutation.Where(ps...)
+	}
+	return dd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (dd *DocDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/customid/ent/doc_query.go
+++ b/entc/integration/customid/ent/doc_query.go
@@ -45,6 +45,14 @@ func (dq *DocQuery) Where(ps ...predicate.Doc) *DocQuery {
 	return dq
 }
 
+// WhereIf adds a new predicates to the DocQuery builder if b is true.
+func (dq *DocQuery) WhereIf(b bool, ps ...predicate.Doc) *DocQuery {
+	if b {
+		dq.predicates = append(dq.predicates, ps...)
+	}
+	return dq
+}
+
 // Limit adds a limit step to the query.
 func (dq *DocQuery) Limit(limit int) *DocQuery {
 	dq.limit = &limit

--- a/entc/integration/customid/ent/doc_update.go
+++ b/entc/integration/customid/ent/doc_update.go
@@ -32,6 +32,14 @@ func (du *DocUpdate) Where(ps ...predicate.Doc) *DocUpdate {
 	return du
 }
 
+// WhereIf appends a list predicates to the DocUpdate builder if b is true.
+func (du *DocUpdate) WhereIf(b bool, ps ...predicate.Doc) *DocUpdate {
+	if b {
+		du.mutation.Where(ps...)
+	}
+	return du
+}
+
 // SetText sets the "text" field.
 func (du *DocUpdate) SetText(s string) *DocUpdate {
 	du.mutation.SetText(s)

--- a/entc/integration/customid/ent/group_delete.go
+++ b/entc/integration/customid/ent/group_delete.go
@@ -30,6 +30,14 @@ func (gd *GroupDelete) Where(ps ...predicate.Group) *GroupDelete {
 	return gd
 }
 
+// WhereIf appends a list predicates to the GroupDelete builder if b is true.
+func (gd *GroupDelete) WhereIf(b bool, ps ...predicate.Group) *GroupDelete {
+	if b {
+		gd.mutation.Where(ps...)
+	}
+	return gd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (gd *GroupDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/customid/ent/group_query.go
+++ b/entc/integration/customid/ent/group_query.go
@@ -43,6 +43,14 @@ func (gq *GroupQuery) Where(ps ...predicate.Group) *GroupQuery {
 	return gq
 }
 
+// WhereIf adds a new predicates to the GroupQuery builder if b is true.
+func (gq *GroupQuery) WhereIf(b bool, ps ...predicate.Group) *GroupQuery {
+	if b {
+		gq.predicates = append(gq.predicates, ps...)
+	}
+	return gq
+}
+
 // Limit adds a limit step to the query.
 func (gq *GroupQuery) Limit(limit int) *GroupQuery {
 	gq.limit = &limit

--- a/entc/integration/customid/ent/group_update.go
+++ b/entc/integration/customid/ent/group_update.go
@@ -32,6 +32,14 @@ func (gu *GroupUpdate) Where(ps ...predicate.Group) *GroupUpdate {
 	return gu
 }
 
+// WhereIf appends a list predicates to the GroupUpdate builder if b is true.
+func (gu *GroupUpdate) WhereIf(b bool, ps ...predicate.Group) *GroupUpdate {
+	if b {
+		gu.mutation.Where(ps...)
+	}
+	return gu
+}
+
 // AddUserIDs adds the "users" edge to the User entity by IDs.
 func (gu *GroupUpdate) AddUserIDs(ids ...int) *GroupUpdate {
 	gu.mutation.AddUserIDs(ids...)

--- a/entc/integration/customid/ent/mixinid_delete.go
+++ b/entc/integration/customid/ent/mixinid_delete.go
@@ -30,6 +30,14 @@ func (mid *MixinIDDelete) Where(ps ...predicate.MixinID) *MixinIDDelete {
 	return mid
 }
 
+// WhereIf appends a list predicates to the MixinIDDelete builder if b is true.
+func (mid *MixinIDDelete) WhereIf(b bool, ps ...predicate.MixinID) *MixinIDDelete {
+	if b {
+		mid.mutation.Where(ps...)
+	}
+	return mid
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (mid *MixinIDDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/customid/ent/mixinid_query.go
+++ b/entc/integration/customid/ent/mixinid_query.go
@@ -40,6 +40,14 @@ func (miq *MixinIDQuery) Where(ps ...predicate.MixinID) *MixinIDQuery {
 	return miq
 }
 
+// WhereIf adds a new predicates to the MixinIDQuery builder if b is true.
+func (miq *MixinIDQuery) WhereIf(b bool, ps ...predicate.MixinID) *MixinIDQuery {
+	if b {
+		miq.predicates = append(miq.predicates, ps...)
+	}
+	return miq
+}
+
 // Limit adds a limit step to the query.
 func (miq *MixinIDQuery) Limit(limit int) *MixinIDQuery {
 	miq.limit = &limit

--- a/entc/integration/customid/ent/mixinid_update.go
+++ b/entc/integration/customid/ent/mixinid_update.go
@@ -31,6 +31,14 @@ func (miu *MixinIDUpdate) Where(ps ...predicate.MixinID) *MixinIDUpdate {
 	return miu
 }
 
+// WhereIf appends a list predicates to the MixinIDUpdate builder if b is true.
+func (miu *MixinIDUpdate) WhereIf(b bool, ps ...predicate.MixinID) *MixinIDUpdate {
+	if b {
+		miu.mutation.Where(ps...)
+	}
+	return miu
+}
+
 // SetSomeField sets the "some_field" field.
 func (miu *MixinIDUpdate) SetSomeField(s string) *MixinIDUpdate {
 	miu.mutation.SetSomeField(s)

--- a/entc/integration/customid/ent/note_delete.go
+++ b/entc/integration/customid/ent/note_delete.go
@@ -30,6 +30,14 @@ func (nd *NoteDelete) Where(ps ...predicate.Note) *NoteDelete {
 	return nd
 }
 
+// WhereIf appends a list predicates to the NoteDelete builder if b is true.
+func (nd *NoteDelete) WhereIf(b bool, ps ...predicate.Note) *NoteDelete {
+	if b {
+		nd.mutation.Where(ps...)
+	}
+	return nd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (nd *NoteDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/customid/ent/note_query.go
+++ b/entc/integration/customid/ent/note_query.go
@@ -45,6 +45,14 @@ func (nq *NoteQuery) Where(ps ...predicate.Note) *NoteQuery {
 	return nq
 }
 
+// WhereIf adds a new predicates to the NoteQuery builder if b is true.
+func (nq *NoteQuery) WhereIf(b bool, ps ...predicate.Note) *NoteQuery {
+	if b {
+		nq.predicates = append(nq.predicates, ps...)
+	}
+	return nq
+}
+
 // Limit adds a limit step to the query.
 func (nq *NoteQuery) Limit(limit int) *NoteQuery {
 	nq.limit = &limit

--- a/entc/integration/customid/ent/note_update.go
+++ b/entc/integration/customid/ent/note_update.go
@@ -32,6 +32,14 @@ func (nu *NoteUpdate) Where(ps ...predicate.Note) *NoteUpdate {
 	return nu
 }
 
+// WhereIf appends a list predicates to the NoteUpdate builder if b is true.
+func (nu *NoteUpdate) WhereIf(b bool, ps ...predicate.Note) *NoteUpdate {
+	if b {
+		nu.mutation.Where(ps...)
+	}
+	return nu
+}
+
 // SetText sets the "text" field.
 func (nu *NoteUpdate) SetText(s string) *NoteUpdate {
 	nu.mutation.SetText(s)

--- a/entc/integration/customid/ent/pet_delete.go
+++ b/entc/integration/customid/ent/pet_delete.go
@@ -30,6 +30,14 @@ func (pd *PetDelete) Where(ps ...predicate.Pet) *PetDelete {
 	return pd
 }
 
+// WhereIf appends a list predicates to the PetDelete builder if b is true.
+func (pd *PetDelete) WhereIf(b bool, ps ...predicate.Pet) *PetDelete {
+	if b {
+		pd.mutation.Where(ps...)
+	}
+	return pd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (pd *PetDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/customid/ent/pet_query.go
+++ b/entc/integration/customid/ent/pet_query.go
@@ -48,6 +48,14 @@ func (pq *PetQuery) Where(ps ...predicate.Pet) *PetQuery {
 	return pq
 }
 
+// WhereIf adds a new predicates to the PetQuery builder if b is true.
+func (pq *PetQuery) WhereIf(b bool, ps ...predicate.Pet) *PetQuery {
+	if b {
+		pq.predicates = append(pq.predicates, ps...)
+	}
+	return pq
+}
+
 // Limit adds a limit step to the query.
 func (pq *PetQuery) Limit(limit int) *PetQuery {
 	pq.limit = &limit

--- a/entc/integration/customid/ent/pet_update.go
+++ b/entc/integration/customid/ent/pet_update.go
@@ -33,6 +33,14 @@ func (pu *PetUpdate) Where(ps ...predicate.Pet) *PetUpdate {
 	return pu
 }
 
+// WhereIf appends a list predicates to the PetUpdate builder if b is true.
+func (pu *PetUpdate) WhereIf(b bool, ps ...predicate.Pet) *PetUpdate {
+	if b {
+		pu.mutation.Where(ps...)
+	}
+	return pu
+}
+
 // SetOwnerID sets the "owner" edge to the User entity by ID.
 func (pu *PetUpdate) SetOwnerID(id int) *PetUpdate {
 	pu.mutation.SetOwnerID(id)

--- a/entc/integration/customid/ent/session_delete.go
+++ b/entc/integration/customid/ent/session_delete.go
@@ -30,6 +30,14 @@ func (sd *SessionDelete) Where(ps ...predicate.Session) *SessionDelete {
 	return sd
 }
 
+// WhereIf appends a list predicates to the SessionDelete builder if b is true.
+func (sd *SessionDelete) WhereIf(b bool, ps ...predicate.Session) *SessionDelete {
+	if b {
+		sd.mutation.Where(ps...)
+	}
+	return sd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (sd *SessionDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/customid/ent/session_query.go
+++ b/entc/integration/customid/ent/session_query.go
@@ -44,6 +44,14 @@ func (sq *SessionQuery) Where(ps ...predicate.Session) *SessionQuery {
 	return sq
 }
 
+// WhereIf adds a new predicates to the SessionQuery builder if b is true.
+func (sq *SessionQuery) WhereIf(b bool, ps ...predicate.Session) *SessionQuery {
+	if b {
+		sq.predicates = append(sq.predicates, ps...)
+	}
+	return sq
+}
+
 // Limit adds a limit step to the query.
 func (sq *SessionQuery) Limit(limit int) *SessionQuery {
 	sq.limit = &limit

--- a/entc/integration/customid/ent/session_update.go
+++ b/entc/integration/customid/ent/session_update.go
@@ -33,6 +33,14 @@ func (su *SessionUpdate) Where(ps ...predicate.Session) *SessionUpdate {
 	return su
 }
 
+// WhereIf appends a list predicates to the SessionUpdate builder if b is true.
+func (su *SessionUpdate) WhereIf(b bool, ps ...predicate.Session) *SessionUpdate {
+	if b {
+		su.mutation.Where(ps...)
+	}
+	return su
+}
+
 // SetDeviceID sets the "device" edge to the Device entity by ID.
 func (su *SessionUpdate) SetDeviceID(id schema.ID) *SessionUpdate {
 	su.mutation.SetDeviceID(id)

--- a/entc/integration/customid/ent/user_delete.go
+++ b/entc/integration/customid/ent/user_delete.go
@@ -30,6 +30,14 @@ func (ud *UserDelete) Where(ps ...predicate.User) *UserDelete {
 	return ud
 }
 
+// WhereIf appends a list predicates to the UserDelete builder if b is true.
+func (ud *UserDelete) WhereIf(b bool, ps ...predicate.User) *UserDelete {
+	if b {
+		ud.mutation.Where(ps...)
+	}
+	return ud
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (ud *UserDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/customid/ent/user_query.go
+++ b/entc/integration/customid/ent/user_query.go
@@ -48,6 +48,14 @@ func (uq *UserQuery) Where(ps ...predicate.User) *UserQuery {
 	return uq
 }
 
+// WhereIf adds a new predicates to the UserQuery builder if b is true.
+func (uq *UserQuery) WhereIf(b bool, ps ...predicate.User) *UserQuery {
+	if b {
+		uq.predicates = append(uq.predicates, ps...)
+	}
+	return uq
+}
+
 // Limit adds a limit step to the query.
 func (uq *UserQuery) Limit(limit int) *UserQuery {
 	uq.limit = &limit

--- a/entc/integration/customid/ent/user_update.go
+++ b/entc/integration/customid/ent/user_update.go
@@ -33,6 +33,14 @@ func (uu *UserUpdate) Where(ps ...predicate.User) *UserUpdate {
 	return uu
 }
 
+// WhereIf appends a list predicates to the UserUpdate builder if b is true.
+func (uu *UserUpdate) WhereIf(b bool, ps ...predicate.User) *UserUpdate {
+	if b {
+		uu.mutation.Where(ps...)
+	}
+	return uu
+}
+
 // AddGroupIDs adds the "groups" edge to the Group entity by IDs.
 func (uu *UserUpdate) AddGroupIDs(ids ...int) *UserUpdate {
 	uu.mutation.AddGroupIDs(ids...)

--- a/entc/integration/edgefield/ent/car_delete.go
+++ b/entc/integration/edgefield/ent/car_delete.go
@@ -30,6 +30,14 @@ func (cd *CarDelete) Where(ps ...predicate.Car) *CarDelete {
 	return cd
 }
 
+// WhereIf appends a list predicates to the CarDelete builder if b is true.
+func (cd *CarDelete) WhereIf(b bool, ps ...predicate.Car) *CarDelete {
+	if b {
+		cd.mutation.Where(ps...)
+	}
+	return cd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (cd *CarDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/edgefield/ent/car_query.go
+++ b/entc/integration/edgefield/ent/car_query.go
@@ -44,6 +44,14 @@ func (cq *CarQuery) Where(ps ...predicate.Car) *CarQuery {
 	return cq
 }
 
+// WhereIf adds a new predicates to the CarQuery builder if b is true.
+func (cq *CarQuery) WhereIf(b bool, ps ...predicate.Car) *CarQuery {
+	if b {
+		cq.predicates = append(cq.predicates, ps...)
+	}
+	return cq
+}
+
 // Limit adds a limit step to the query.
 func (cq *CarQuery) Limit(limit int) *CarQuery {
 	cq.limit = &limit

--- a/entc/integration/edgefield/ent/car_update.go
+++ b/entc/integration/edgefield/ent/car_update.go
@@ -32,6 +32,14 @@ func (cu *CarUpdate) Where(ps ...predicate.Car) *CarUpdate {
 	return cu
 }
 
+// WhereIf appends a list predicates to the CarUpdate builder if b is true.
+func (cu *CarUpdate) WhereIf(b bool, ps ...predicate.Car) *CarUpdate {
+	if b {
+		cu.mutation.Where(ps...)
+	}
+	return cu
+}
+
 // SetNumber sets the "number" field.
 func (cu *CarUpdate) SetNumber(s string) *CarUpdate {
 	cu.mutation.SetNumber(s)

--- a/entc/integration/edgefield/ent/card_delete.go
+++ b/entc/integration/edgefield/ent/card_delete.go
@@ -30,6 +30,14 @@ func (cd *CardDelete) Where(ps ...predicate.Card) *CardDelete {
 	return cd
 }
 
+// WhereIf appends a list predicates to the CardDelete builder if b is true.
+func (cd *CardDelete) WhereIf(b bool, ps ...predicate.Card) *CardDelete {
+	if b {
+		cd.mutation.Where(ps...)
+	}
+	return cd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (cd *CardDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/edgefield/ent/card_query.go
+++ b/entc/integration/edgefield/ent/card_query.go
@@ -42,6 +42,14 @@ func (cq *CardQuery) Where(ps ...predicate.Card) *CardQuery {
 	return cq
 }
 
+// WhereIf adds a new predicates to the CardQuery builder if b is true.
+func (cq *CardQuery) WhereIf(b bool, ps ...predicate.Card) *CardQuery {
+	if b {
+		cq.predicates = append(cq.predicates, ps...)
+	}
+	return cq
+}
+
 // Limit adds a limit step to the query.
 func (cq *CardQuery) Limit(limit int) *CardQuery {
 	cq.limit = &limit

--- a/entc/integration/edgefield/ent/card_update.go
+++ b/entc/integration/edgefield/ent/card_update.go
@@ -32,6 +32,14 @@ func (cu *CardUpdate) Where(ps ...predicate.Card) *CardUpdate {
 	return cu
 }
 
+// WhereIf appends a list predicates to the CardUpdate builder if b is true.
+func (cu *CardUpdate) WhereIf(b bool, ps ...predicate.Card) *CardUpdate {
+	if b {
+		cu.mutation.Where(ps...)
+	}
+	return cu
+}
+
 // SetNumber sets the "number" field.
 func (cu *CardUpdate) SetNumber(s string) *CardUpdate {
 	cu.mutation.SetNumber(s)

--- a/entc/integration/edgefield/ent/info_delete.go
+++ b/entc/integration/edgefield/ent/info_delete.go
@@ -30,6 +30,14 @@ func (id *InfoDelete) Where(ps ...predicate.Info) *InfoDelete {
 	return id
 }
 
+// WhereIf appends a list predicates to the InfoDelete builder if b is true.
+func (id *InfoDelete) WhereIf(b bool, ps ...predicate.Info) *InfoDelete {
+	if b {
+		id.mutation.Where(ps...)
+	}
+	return id
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (id *InfoDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/edgefield/ent/info_query.go
+++ b/entc/integration/edgefield/ent/info_query.go
@@ -42,6 +42,14 @@ func (iq *InfoQuery) Where(ps ...predicate.Info) *InfoQuery {
 	return iq
 }
 
+// WhereIf adds a new predicates to the InfoQuery builder if b is true.
+func (iq *InfoQuery) WhereIf(b bool, ps ...predicate.Info) *InfoQuery {
+	if b {
+		iq.predicates = append(iq.predicates, ps...)
+	}
+	return iq
+}
+
 // Limit adds a limit step to the query.
 func (iq *InfoQuery) Limit(limit int) *InfoQuery {
 	iq.limit = &limit

--- a/entc/integration/edgefield/ent/info_update.go
+++ b/entc/integration/edgefield/ent/info_update.go
@@ -33,6 +33,14 @@ func (iu *InfoUpdate) Where(ps ...predicate.Info) *InfoUpdate {
 	return iu
 }
 
+// WhereIf appends a list predicates to the InfoUpdate builder if b is true.
+func (iu *InfoUpdate) WhereIf(b bool, ps ...predicate.Info) *InfoUpdate {
+	if b {
+		iu.mutation.Where(ps...)
+	}
+	return iu
+}
+
 // SetContent sets the "content" field.
 func (iu *InfoUpdate) SetContent(jm json.RawMessage) *InfoUpdate {
 	iu.mutation.SetContent(jm)

--- a/entc/integration/edgefield/ent/metadata_delete.go
+++ b/entc/integration/edgefield/ent/metadata_delete.go
@@ -30,6 +30,14 @@ func (md *MetadataDelete) Where(ps ...predicate.Metadata) *MetadataDelete {
 	return md
 }
 
+// WhereIf appends a list predicates to the MetadataDelete builder if b is true.
+func (md *MetadataDelete) WhereIf(b bool, ps ...predicate.Metadata) *MetadataDelete {
+	if b {
+		md.mutation.Where(ps...)
+	}
+	return md
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (md *MetadataDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/edgefield/ent/metadata_query.go
+++ b/entc/integration/edgefield/ent/metadata_query.go
@@ -45,6 +45,14 @@ func (mq *MetadataQuery) Where(ps ...predicate.Metadata) *MetadataQuery {
 	return mq
 }
 
+// WhereIf adds a new predicates to the MetadataQuery builder if b is true.
+func (mq *MetadataQuery) WhereIf(b bool, ps ...predicate.Metadata) *MetadataQuery {
+	if b {
+		mq.predicates = append(mq.predicates, ps...)
+	}
+	return mq
+}
+
 // Limit adds a limit step to the query.
 func (mq *MetadataQuery) Limit(limit int) *MetadataQuery {
 	mq.limit = &limit

--- a/entc/integration/edgefield/ent/metadata_update.go
+++ b/entc/integration/edgefield/ent/metadata_update.go
@@ -32,6 +32,14 @@ func (mu *MetadataUpdate) Where(ps ...predicate.Metadata) *MetadataUpdate {
 	return mu
 }
 
+// WhereIf appends a list predicates to the MetadataUpdate builder if b is true.
+func (mu *MetadataUpdate) WhereIf(b bool, ps ...predicate.Metadata) *MetadataUpdate {
+	if b {
+		mu.mutation.Where(ps...)
+	}
+	return mu
+}
+
 // SetAge sets the "age" field.
 func (mu *MetadataUpdate) SetAge(i int) *MetadataUpdate {
 	mu.mutation.ResetAge()

--- a/entc/integration/edgefield/ent/node_delete.go
+++ b/entc/integration/edgefield/ent/node_delete.go
@@ -30,6 +30,14 @@ func (nd *NodeDelete) Where(ps ...predicate.Node) *NodeDelete {
 	return nd
 }
 
+// WhereIf appends a list predicates to the NodeDelete builder if b is true.
+func (nd *NodeDelete) WhereIf(b bool, ps ...predicate.Node) *NodeDelete {
+	if b {
+		nd.mutation.Where(ps...)
+	}
+	return nd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (nd *NodeDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/edgefield/ent/node_query.go
+++ b/entc/integration/edgefield/ent/node_query.go
@@ -43,6 +43,14 @@ func (nq *NodeQuery) Where(ps ...predicate.Node) *NodeQuery {
 	return nq
 }
 
+// WhereIf adds a new predicates to the NodeQuery builder if b is true.
+func (nq *NodeQuery) WhereIf(b bool, ps ...predicate.Node) *NodeQuery {
+	if b {
+		nq.predicates = append(nq.predicates, ps...)
+	}
+	return nq
+}
+
 // Limit adds a limit step to the query.
 func (nq *NodeQuery) Limit(limit int) *NodeQuery {
 	nq.limit = &limit

--- a/entc/integration/edgefield/ent/node_update.go
+++ b/entc/integration/edgefield/ent/node_update.go
@@ -31,6 +31,14 @@ func (nu *NodeUpdate) Where(ps ...predicate.Node) *NodeUpdate {
 	return nu
 }
 
+// WhereIf appends a list predicates to the NodeUpdate builder if b is true.
+func (nu *NodeUpdate) WhereIf(b bool, ps ...predicate.Node) *NodeUpdate {
+	if b {
+		nu.mutation.Where(ps...)
+	}
+	return nu
+}
+
 // SetValue sets the "value" field.
 func (nu *NodeUpdate) SetValue(i int) *NodeUpdate {
 	nu.mutation.ResetValue()

--- a/entc/integration/edgefield/ent/pet_delete.go
+++ b/entc/integration/edgefield/ent/pet_delete.go
@@ -30,6 +30,14 @@ func (pd *PetDelete) Where(ps ...predicate.Pet) *PetDelete {
 	return pd
 }
 
+// WhereIf appends a list predicates to the PetDelete builder if b is true.
+func (pd *PetDelete) WhereIf(b bool, ps ...predicate.Pet) *PetDelete {
+	if b {
+		pd.mutation.Where(ps...)
+	}
+	return pd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (pd *PetDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/edgefield/ent/pet_query.go
+++ b/entc/integration/edgefield/ent/pet_query.go
@@ -42,6 +42,14 @@ func (pq *PetQuery) Where(ps ...predicate.Pet) *PetQuery {
 	return pq
 }
 
+// WhereIf adds a new predicates to the PetQuery builder if b is true.
+func (pq *PetQuery) WhereIf(b bool, ps ...predicate.Pet) *PetQuery {
+	if b {
+		pq.predicates = append(pq.predicates, ps...)
+	}
+	return pq
+}
+
 // Limit adds a limit step to the query.
 func (pq *PetQuery) Limit(limit int) *PetQuery {
 	pq.limit = &limit

--- a/entc/integration/edgefield/ent/pet_update.go
+++ b/entc/integration/edgefield/ent/pet_update.go
@@ -32,6 +32,14 @@ func (pu *PetUpdate) Where(ps ...predicate.Pet) *PetUpdate {
 	return pu
 }
 
+// WhereIf appends a list predicates to the PetUpdate builder if b is true.
+func (pu *PetUpdate) WhereIf(b bool, ps ...predicate.Pet) *PetUpdate {
+	if b {
+		pu.mutation.Where(ps...)
+	}
+	return pu
+}
+
 // SetOwnerID sets the "owner_id" field.
 func (pu *PetUpdate) SetOwnerID(i int) *PetUpdate {
 	pu.mutation.SetOwnerID(i)

--- a/entc/integration/edgefield/ent/post_delete.go
+++ b/entc/integration/edgefield/ent/post_delete.go
@@ -30,6 +30,14 @@ func (pd *PostDelete) Where(ps ...predicate.Post) *PostDelete {
 	return pd
 }
 
+// WhereIf appends a list predicates to the PostDelete builder if b is true.
+func (pd *PostDelete) WhereIf(b bool, ps ...predicate.Post) *PostDelete {
+	if b {
+		pd.mutation.Where(ps...)
+	}
+	return pd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (pd *PostDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/edgefield/ent/post_query.go
+++ b/entc/integration/edgefield/ent/post_query.go
@@ -42,6 +42,14 @@ func (pq *PostQuery) Where(ps ...predicate.Post) *PostQuery {
 	return pq
 }
 
+// WhereIf adds a new predicates to the PostQuery builder if b is true.
+func (pq *PostQuery) WhereIf(b bool, ps ...predicate.Post) *PostQuery {
+	if b {
+		pq.predicates = append(pq.predicates, ps...)
+	}
+	return pq
+}
+
 // Limit adds a limit step to the query.
 func (pq *PostQuery) Limit(limit int) *PostQuery {
 	pq.limit = &limit

--- a/entc/integration/edgefield/ent/post_update.go
+++ b/entc/integration/edgefield/ent/post_update.go
@@ -32,6 +32,14 @@ func (pu *PostUpdate) Where(ps ...predicate.Post) *PostUpdate {
 	return pu
 }
 
+// WhereIf appends a list predicates to the PostUpdate builder if b is true.
+func (pu *PostUpdate) WhereIf(b bool, ps ...predicate.Post) *PostUpdate {
+	if b {
+		pu.mutation.Where(ps...)
+	}
+	return pu
+}
+
 // SetText sets the "text" field.
 func (pu *PostUpdate) SetText(s string) *PostUpdate {
 	pu.mutation.SetText(s)

--- a/entc/integration/edgefield/ent/rental_delete.go
+++ b/entc/integration/edgefield/ent/rental_delete.go
@@ -30,6 +30,14 @@ func (rd *RentalDelete) Where(ps ...predicate.Rental) *RentalDelete {
 	return rd
 }
 
+// WhereIf appends a list predicates to the RentalDelete builder if b is true.
+func (rd *RentalDelete) WhereIf(b bool, ps ...predicate.Rental) *RentalDelete {
+	if b {
+		rd.mutation.Where(ps...)
+	}
+	return rd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (rd *RentalDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/edgefield/ent/rental_query.go
+++ b/entc/integration/edgefield/ent/rental_query.go
@@ -45,6 +45,14 @@ func (rq *RentalQuery) Where(ps ...predicate.Rental) *RentalQuery {
 	return rq
 }
 
+// WhereIf adds a new predicates to the RentalQuery builder if b is true.
+func (rq *RentalQuery) WhereIf(b bool, ps ...predicate.Rental) *RentalQuery {
+	if b {
+		rq.predicates = append(rq.predicates, ps...)
+	}
+	return rq
+}
+
 // Limit adds a limit step to the query.
 func (rq *RentalQuery) Limit(limit int) *RentalQuery {
 	rq.limit = &limit

--- a/entc/integration/edgefield/ent/rental_update.go
+++ b/entc/integration/edgefield/ent/rental_update.go
@@ -35,6 +35,14 @@ func (ru *RentalUpdate) Where(ps ...predicate.Rental) *RentalUpdate {
 	return ru
 }
 
+// WhereIf appends a list predicates to the RentalUpdate builder if b is true.
+func (ru *RentalUpdate) WhereIf(b bool, ps ...predicate.Rental) *RentalUpdate {
+	if b {
+		ru.mutation.Where(ps...)
+	}
+	return ru
+}
+
 // SetDate sets the "date" field.
 func (ru *RentalUpdate) SetDate(t time.Time) *RentalUpdate {
 	ru.mutation.SetDate(t)

--- a/entc/integration/edgefield/ent/user_delete.go
+++ b/entc/integration/edgefield/ent/user_delete.go
@@ -30,6 +30,14 @@ func (ud *UserDelete) Where(ps ...predicate.User) *UserDelete {
 	return ud
 }
 
+// WhereIf appends a list predicates to the UserDelete builder if b is true.
+func (ud *UserDelete) WhereIf(b bool, ps ...predicate.User) *UserDelete {
+	if b {
+		ud.mutation.Where(ps...)
+	}
+	return ud
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (ud *UserDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/edgefield/ent/user_query.go
+++ b/entc/integration/edgefield/ent/user_query.go
@@ -54,6 +54,14 @@ func (uq *UserQuery) Where(ps ...predicate.User) *UserQuery {
 	return uq
 }
 
+// WhereIf adds a new predicates to the UserQuery builder if b is true.
+func (uq *UserQuery) WhereIf(b bool, ps ...predicate.User) *UserQuery {
+	if b {
+		uq.predicates = append(uq.predicates, ps...)
+	}
+	return uq
+}
+
 // Limit adds a limit step to the query.
 func (uq *UserQuery) Limit(limit int) *UserQuery {
 	uq.limit = &limit

--- a/entc/integration/edgefield/ent/user_update.go
+++ b/entc/integration/edgefield/ent/user_update.go
@@ -36,6 +36,14 @@ func (uu *UserUpdate) Where(ps ...predicate.User) *UserUpdate {
 	return uu
 }
 
+// WhereIf appends a list predicates to the UserUpdate builder if b is true.
+func (uu *UserUpdate) WhereIf(b bool, ps ...predicate.User) *UserUpdate {
+	if b {
+		uu.mutation.Where(ps...)
+	}
+	return uu
+}
+
 // SetParentID sets the "parent_id" field.
 func (uu *UserUpdate) SetParentID(i int) *UserUpdate {
 	uu.mutation.SetParentID(i)

--- a/entc/integration/ent/card_delete.go
+++ b/entc/integration/ent/card_delete.go
@@ -30,6 +30,14 @@ func (cd *CardDelete) Where(ps ...predicate.Card) *CardDelete {
 	return cd
 }
 
+// WhereIf appends a list predicates to the CardDelete builder if b is true.
+func (cd *CardDelete) WhereIf(b bool, ps ...predicate.Card) *CardDelete {
+	if b {
+		cd.mutation.Where(ps...)
+	}
+	return cd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (cd *CardDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/ent/card_query.go
+++ b/entc/integration/ent/card_query.go
@@ -48,6 +48,14 @@ func (cq *CardQuery) Where(ps ...predicate.Card) *CardQuery {
 	return cq
 }
 
+// WhereIf adds a new predicates to the CardQuery builder if b is true.
+func (cq *CardQuery) WhereIf(b bool, ps ...predicate.Card) *CardQuery {
+	if b {
+		cq.predicates = append(cq.predicates, ps...)
+	}
+	return cq
+}
+
 // Limit adds a limit step to the query.
 func (cq *CardQuery) Limit(limit int) *CardQuery {
 	cq.limit = &limit

--- a/entc/integration/ent/card_update.go
+++ b/entc/integration/ent/card_update.go
@@ -34,6 +34,14 @@ func (cu *CardUpdate) Where(ps ...predicate.Card) *CardUpdate {
 	return cu
 }
 
+// WhereIf appends a list predicates to the CardUpdate builder if b is true.
+func (cu *CardUpdate) WhereIf(b bool, ps ...predicate.Card) *CardUpdate {
+	if b {
+		cu.mutation.Where(ps...)
+	}
+	return cu
+}
+
 // SetUpdateTime sets the "update_time" field.
 func (cu *CardUpdate) SetUpdateTime(t time.Time) *CardUpdate {
 	cu.mutation.SetUpdateTime(t)

--- a/entc/integration/ent/comment_delete.go
+++ b/entc/integration/ent/comment_delete.go
@@ -30,6 +30,14 @@ func (cd *CommentDelete) Where(ps ...predicate.Comment) *CommentDelete {
 	return cd
 }
 
+// WhereIf appends a list predicates to the CommentDelete builder if b is true.
+func (cd *CommentDelete) WhereIf(b bool, ps ...predicate.Comment) *CommentDelete {
+	if b {
+		cd.mutation.Where(ps...)
+	}
+	return cd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (cd *CommentDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/ent/comment_query.go
+++ b/entc/integration/ent/comment_query.go
@@ -41,6 +41,14 @@ func (cq *CommentQuery) Where(ps ...predicate.Comment) *CommentQuery {
 	return cq
 }
 
+// WhereIf adds a new predicates to the CommentQuery builder if b is true.
+func (cq *CommentQuery) WhereIf(b bool, ps ...predicate.Comment) *CommentQuery {
+	if b {
+		cq.predicates = append(cq.predicates, ps...)
+	}
+	return cq
+}
+
 // Limit adds a limit step to the query.
 func (cq *CommentQuery) Limit(limit int) *CommentQuery {
 	cq.limit = &limit

--- a/entc/integration/ent/comment_update.go
+++ b/entc/integration/ent/comment_update.go
@@ -31,6 +31,14 @@ func (cu *CommentUpdate) Where(ps ...predicate.Comment) *CommentUpdate {
 	return cu
 }
 
+// WhereIf appends a list predicates to the CommentUpdate builder if b is true.
+func (cu *CommentUpdate) WhereIf(b bool, ps ...predicate.Comment) *CommentUpdate {
+	if b {
+		cu.mutation.Where(ps...)
+	}
+	return cu
+}
+
 // SetUniqueInt sets the "unique_int" field.
 func (cu *CommentUpdate) SetUniqueInt(i int) *CommentUpdate {
 	cu.mutation.ResetUniqueInt()

--- a/entc/integration/ent/fieldtype_delete.go
+++ b/entc/integration/ent/fieldtype_delete.go
@@ -30,6 +30,14 @@ func (ftd *FieldTypeDelete) Where(ps ...predicate.FieldType) *FieldTypeDelete {
 	return ftd
 }
 
+// WhereIf appends a list predicates to the FieldTypeDelete builder if b is true.
+func (ftd *FieldTypeDelete) WhereIf(b bool, ps ...predicate.FieldType) *FieldTypeDelete {
+	if b {
+		ftd.mutation.Where(ps...)
+	}
+	return ftd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (ftd *FieldTypeDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/ent/fieldtype_query.go
+++ b/entc/integration/ent/fieldtype_query.go
@@ -42,6 +42,14 @@ func (ftq *FieldTypeQuery) Where(ps ...predicate.FieldType) *FieldTypeQuery {
 	return ftq
 }
 
+// WhereIf adds a new predicates to the FieldTypeQuery builder if b is true.
+func (ftq *FieldTypeQuery) WhereIf(b bool, ps ...predicate.FieldType) *FieldTypeQuery {
+	if b {
+		ftq.predicates = append(ftq.predicates, ps...)
+	}
+	return ftq
+}
+
 // Limit adds a limit step to the query.
 func (ftq *FieldTypeQuery) Limit(limit int) *FieldTypeQuery {
 	ftq.limit = &limit

--- a/entc/integration/ent/fieldtype_update.go
+++ b/entc/integration/ent/fieldtype_update.go
@@ -37,6 +37,14 @@ func (ftu *FieldTypeUpdate) Where(ps ...predicate.FieldType) *FieldTypeUpdate {
 	return ftu
 }
 
+// WhereIf appends a list predicates to the FieldTypeUpdate builder if b is true.
+func (ftu *FieldTypeUpdate) WhereIf(b bool, ps ...predicate.FieldType) *FieldTypeUpdate {
+	if b {
+		ftu.mutation.Where(ps...)
+	}
+	return ftu
+}
+
 // SetInt sets the "int" field.
 func (ftu *FieldTypeUpdate) SetInt(i int) *FieldTypeUpdate {
 	ftu.mutation.ResetInt()

--- a/entc/integration/ent/file_delete.go
+++ b/entc/integration/ent/file_delete.go
@@ -30,6 +30,14 @@ func (fd *FileDelete) Where(ps ...predicate.File) *FileDelete {
 	return fd
 }
 
+// WhereIf appends a list predicates to the FileDelete builder if b is true.
+func (fd *FileDelete) WhereIf(b bool, ps ...predicate.File) *FileDelete {
+	if b {
+		fd.mutation.Where(ps...)
+	}
+	return fd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (fd *FileDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/ent/file_query.go
+++ b/entc/integration/ent/file_query.go
@@ -50,6 +50,14 @@ func (fq *FileQuery) Where(ps ...predicate.File) *FileQuery {
 	return fq
 }
 
+// WhereIf adds a new predicates to the FileQuery builder if b is true.
+func (fq *FileQuery) WhereIf(b bool, ps ...predicate.File) *FileQuery {
+	if b {
+		fq.predicates = append(fq.predicates, ps...)
+	}
+	return fq
+}
+
 // Limit adds a limit step to the query.
 func (fq *FileQuery) Limit(limit int) *FileQuery {
 	fq.limit = &limit

--- a/entc/integration/ent/file_update.go
+++ b/entc/integration/ent/file_update.go
@@ -34,6 +34,14 @@ func (fu *FileUpdate) Where(ps ...predicate.File) *FileUpdate {
 	return fu
 }
 
+// WhereIf appends a list predicates to the FileUpdate builder if b is true.
+func (fu *FileUpdate) WhereIf(b bool, ps ...predicate.File) *FileUpdate {
+	if b {
+		fu.mutation.Where(ps...)
+	}
+	return fu
+}
+
 // SetSize sets the "size" field.
 func (fu *FileUpdate) SetSize(i int) *FileUpdate {
 	fu.mutation.ResetSize()

--- a/entc/integration/ent/filetype_delete.go
+++ b/entc/integration/ent/filetype_delete.go
@@ -30,6 +30,14 @@ func (ftd *FileTypeDelete) Where(ps ...predicate.FileType) *FileTypeDelete {
 	return ftd
 }
 
+// WhereIf appends a list predicates to the FileTypeDelete builder if b is true.
+func (ftd *FileTypeDelete) WhereIf(b bool, ps ...predicate.FileType) *FileTypeDelete {
+	if b {
+		ftd.mutation.Where(ps...)
+	}
+	return ftd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (ftd *FileTypeDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/ent/filetype_query.go
+++ b/entc/integration/ent/filetype_query.go
@@ -45,6 +45,14 @@ func (ftq *FileTypeQuery) Where(ps ...predicate.FileType) *FileTypeQuery {
 	return ftq
 }
 
+// WhereIf adds a new predicates to the FileTypeQuery builder if b is true.
+func (ftq *FileTypeQuery) WhereIf(b bool, ps ...predicate.FileType) *FileTypeQuery {
+	if b {
+		ftq.predicates = append(ftq.predicates, ps...)
+	}
+	return ftq
+}
+
 // Limit adds a limit step to the query.
 func (ftq *FileTypeQuery) Limit(limit int) *FileTypeQuery {
 	ftq.limit = &limit

--- a/entc/integration/ent/filetype_update.go
+++ b/entc/integration/ent/filetype_update.go
@@ -32,6 +32,14 @@ func (ftu *FileTypeUpdate) Where(ps ...predicate.FileType) *FileTypeUpdate {
 	return ftu
 }
 
+// WhereIf appends a list predicates to the FileTypeUpdate builder if b is true.
+func (ftu *FileTypeUpdate) WhereIf(b bool, ps ...predicate.FileType) *FileTypeUpdate {
+	if b {
+		ftu.mutation.Where(ps...)
+	}
+	return ftu
+}
+
 // SetName sets the "name" field.
 func (ftu *FileTypeUpdate) SetName(s string) *FileTypeUpdate {
 	ftu.mutation.SetName(s)

--- a/entc/integration/ent/goods_delete.go
+++ b/entc/integration/ent/goods_delete.go
@@ -30,6 +30,14 @@ func (gd *GoodsDelete) Where(ps ...predicate.Goods) *GoodsDelete {
 	return gd
 }
 
+// WhereIf appends a list predicates to the GoodsDelete builder if b is true.
+func (gd *GoodsDelete) WhereIf(b bool, ps ...predicate.Goods) *GoodsDelete {
+	if b {
+		gd.mutation.Where(ps...)
+	}
+	return gd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (gd *GoodsDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/ent/goods_query.go
+++ b/entc/integration/ent/goods_query.go
@@ -41,6 +41,14 @@ func (gq *GoodsQuery) Where(ps ...predicate.Goods) *GoodsQuery {
 	return gq
 }
 
+// WhereIf adds a new predicates to the GoodsQuery builder if b is true.
+func (gq *GoodsQuery) WhereIf(b bool, ps ...predicate.Goods) *GoodsQuery {
+	if b {
+		gq.predicates = append(gq.predicates, ps...)
+	}
+	return gq
+}
+
 // Limit adds a limit step to the query.
 func (gq *GoodsQuery) Limit(limit int) *GoodsQuery {
 	gq.limit = &limit

--- a/entc/integration/ent/goods_update.go
+++ b/entc/integration/ent/goods_update.go
@@ -31,6 +31,14 @@ func (gu *GoodsUpdate) Where(ps ...predicate.Goods) *GoodsUpdate {
 	return gu
 }
 
+// WhereIf appends a list predicates to the GoodsUpdate builder if b is true.
+func (gu *GoodsUpdate) WhereIf(b bool, ps ...predicate.Goods) *GoodsUpdate {
+	if b {
+		gu.mutation.Where(ps...)
+	}
+	return gu
+}
+
 // Mutation returns the GoodsMutation object of the builder.
 func (gu *GoodsUpdate) Mutation() *GoodsMutation {
 	return gu.mutation

--- a/entc/integration/ent/group_delete.go
+++ b/entc/integration/ent/group_delete.go
@@ -30,6 +30,14 @@ func (gd *GroupDelete) Where(ps ...predicate.Group) *GroupDelete {
 	return gd
 }
 
+// WhereIf appends a list predicates to the GroupDelete builder if b is true.
+func (gd *GroupDelete) WhereIf(b bool, ps ...predicate.Group) *GroupDelete {
+	if b {
+		gd.mutation.Where(ps...)
+	}
+	return gd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (gd *GroupDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/ent/group_query.go
+++ b/entc/integration/ent/group_query.go
@@ -51,6 +51,14 @@ func (gq *GroupQuery) Where(ps ...predicate.Group) *GroupQuery {
 	return gq
 }
 
+// WhereIf adds a new predicates to the GroupQuery builder if b is true.
+func (gq *GroupQuery) WhereIf(b bool, ps ...predicate.Group) *GroupQuery {
+	if b {
+		gq.predicates = append(gq.predicates, ps...)
+	}
+	return gq
+}
+
 // Limit adds a limit step to the query.
 func (gq *GroupQuery) Limit(limit int) *GroupQuery {
 	gq.limit = &limit

--- a/entc/integration/ent/group_update.go
+++ b/entc/integration/ent/group_update.go
@@ -35,6 +35,14 @@ func (gu *GroupUpdate) Where(ps ...predicate.Group) *GroupUpdate {
 	return gu
 }
 
+// WhereIf appends a list predicates to the GroupUpdate builder if b is true.
+func (gu *GroupUpdate) WhereIf(b bool, ps ...predicate.Group) *GroupUpdate {
+	if b {
+		gu.mutation.Where(ps...)
+	}
+	return gu
+}
+
 // SetActive sets the "active" field.
 func (gu *GroupUpdate) SetActive(b bool) *GroupUpdate {
 	gu.mutation.SetActive(b)

--- a/entc/integration/ent/groupinfo_delete.go
+++ b/entc/integration/ent/groupinfo_delete.go
@@ -30,6 +30,14 @@ func (gid *GroupInfoDelete) Where(ps ...predicate.GroupInfo) *GroupInfoDelete {
 	return gid
 }
 
+// WhereIf appends a list predicates to the GroupInfoDelete builder if b is true.
+func (gid *GroupInfoDelete) WhereIf(b bool, ps ...predicate.GroupInfo) *GroupInfoDelete {
+	if b {
+		gid.mutation.Where(ps...)
+	}
+	return gid
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (gid *GroupInfoDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/ent/groupinfo_query.go
+++ b/entc/integration/ent/groupinfo_query.go
@@ -45,6 +45,14 @@ func (giq *GroupInfoQuery) Where(ps ...predicate.GroupInfo) *GroupInfoQuery {
 	return giq
 }
 
+// WhereIf adds a new predicates to the GroupInfoQuery builder if b is true.
+func (giq *GroupInfoQuery) WhereIf(b bool, ps ...predicate.GroupInfo) *GroupInfoQuery {
+	if b {
+		giq.predicates = append(giq.predicates, ps...)
+	}
+	return giq
+}
+
 // Limit adds a limit step to the query.
 func (giq *GroupInfoQuery) Limit(limit int) *GroupInfoQuery {
 	giq.limit = &limit

--- a/entc/integration/ent/groupinfo_update.go
+++ b/entc/integration/ent/groupinfo_update.go
@@ -32,6 +32,14 @@ func (giu *GroupInfoUpdate) Where(ps ...predicate.GroupInfo) *GroupInfoUpdate {
 	return giu
 }
 
+// WhereIf appends a list predicates to the GroupInfoUpdate builder if b is true.
+func (giu *GroupInfoUpdate) WhereIf(b bool, ps ...predicate.GroupInfo) *GroupInfoUpdate {
+	if b {
+		giu.mutation.Where(ps...)
+	}
+	return giu
+}
+
 // SetDesc sets the "desc" field.
 func (giu *GroupInfoUpdate) SetDesc(s string) *GroupInfoUpdate {
 	giu.mutation.SetDesc(s)

--- a/entc/integration/ent/item_delete.go
+++ b/entc/integration/ent/item_delete.go
@@ -30,6 +30,14 @@ func (id *ItemDelete) Where(ps ...predicate.Item) *ItemDelete {
 	return id
 }
 
+// WhereIf appends a list predicates to the ItemDelete builder if b is true.
+func (id *ItemDelete) WhereIf(b bool, ps ...predicate.Item) *ItemDelete {
+	if b {
+		id.mutation.Where(ps...)
+	}
+	return id
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (id *ItemDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/ent/item_query.go
+++ b/entc/integration/ent/item_query.go
@@ -41,6 +41,14 @@ func (iq *ItemQuery) Where(ps ...predicate.Item) *ItemQuery {
 	return iq
 }
 
+// WhereIf adds a new predicates to the ItemQuery builder if b is true.
+func (iq *ItemQuery) WhereIf(b bool, ps ...predicate.Item) *ItemQuery {
+	if b {
+		iq.predicates = append(iq.predicates, ps...)
+	}
+	return iq
+}
+
 // Limit adds a limit step to the query.
 func (iq *ItemQuery) Limit(limit int) *ItemQuery {
 	iq.limit = &limit

--- a/entc/integration/ent/item_update.go
+++ b/entc/integration/ent/item_update.go
@@ -31,6 +31,14 @@ func (iu *ItemUpdate) Where(ps ...predicate.Item) *ItemUpdate {
 	return iu
 }
 
+// WhereIf appends a list predicates to the ItemUpdate builder if b is true.
+func (iu *ItemUpdate) WhereIf(b bool, ps ...predicate.Item) *ItemUpdate {
+	if b {
+		iu.mutation.Where(ps...)
+	}
+	return iu
+}
+
 // SetText sets the "text" field.
 func (iu *ItemUpdate) SetText(s string) *ItemUpdate {
 	iu.mutation.SetText(s)

--- a/entc/integration/ent/node_delete.go
+++ b/entc/integration/ent/node_delete.go
@@ -30,6 +30,14 @@ func (nd *NodeDelete) Where(ps ...predicate.Node) *NodeDelete {
 	return nd
 }
 
+// WhereIf appends a list predicates to the NodeDelete builder if b is true.
+func (nd *NodeDelete) WhereIf(b bool, ps ...predicate.Node) *NodeDelete {
+	if b {
+		nd.mutation.Where(ps...)
+	}
+	return nd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (nd *NodeDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/ent/node_query.go
+++ b/entc/integration/ent/node_query.go
@@ -46,6 +46,14 @@ func (nq *NodeQuery) Where(ps ...predicate.Node) *NodeQuery {
 	return nq
 }
 
+// WhereIf adds a new predicates to the NodeQuery builder if b is true.
+func (nq *NodeQuery) WhereIf(b bool, ps ...predicate.Node) *NodeQuery {
+	if b {
+		nq.predicates = append(nq.predicates, ps...)
+	}
+	return nq
+}
+
 // Limit adds a limit step to the query.
 func (nq *NodeQuery) Limit(limit int) *NodeQuery {
 	nq.limit = &limit

--- a/entc/integration/ent/node_update.go
+++ b/entc/integration/ent/node_update.go
@@ -31,6 +31,14 @@ func (nu *NodeUpdate) Where(ps ...predicate.Node) *NodeUpdate {
 	return nu
 }
 
+// WhereIf appends a list predicates to the NodeUpdate builder if b is true.
+func (nu *NodeUpdate) WhereIf(b bool, ps ...predicate.Node) *NodeUpdate {
+	if b {
+		nu.mutation.Where(ps...)
+	}
+	return nu
+}
+
 // SetValue sets the "value" field.
 func (nu *NodeUpdate) SetValue(i int) *NodeUpdate {
 	nu.mutation.ResetValue()

--- a/entc/integration/ent/pet_delete.go
+++ b/entc/integration/ent/pet_delete.go
@@ -30,6 +30,14 @@ func (pd *PetDelete) Where(ps ...predicate.Pet) *PetDelete {
 	return pd
 }
 
+// WhereIf appends a list predicates to the PetDelete builder if b is true.
+func (pd *PetDelete) WhereIf(b bool, ps ...predicate.Pet) *PetDelete {
+	if b {
+		pd.mutation.Where(ps...)
+	}
+	return pd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (pd *PetDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/ent/pet_query.go
+++ b/entc/integration/ent/pet_query.go
@@ -46,6 +46,14 @@ func (pq *PetQuery) Where(ps ...predicate.Pet) *PetQuery {
 	return pq
 }
 
+// WhereIf adds a new predicates to the PetQuery builder if b is true.
+func (pq *PetQuery) WhereIf(b bool, ps ...predicate.Pet) *PetQuery {
+	if b {
+		pq.predicates = append(pq.predicates, ps...)
+	}
+	return pq
+}
+
 // Limit adds a limit step to the query.
 func (pq *PetQuery) Limit(limit int) *PetQuery {
 	pq.limit = &limit

--- a/entc/integration/ent/pet_update.go
+++ b/entc/integration/ent/pet_update.go
@@ -33,6 +33,14 @@ func (pu *PetUpdate) Where(ps ...predicate.Pet) *PetUpdate {
 	return pu
 }
 
+// WhereIf appends a list predicates to the PetUpdate builder if b is true.
+func (pu *PetUpdate) WhereIf(b bool, ps ...predicate.Pet) *PetUpdate {
+	if b {
+		pu.mutation.Where(ps...)
+	}
+	return pu
+}
+
 // SetAge sets the "age" field.
 func (pu *PetUpdate) SetAge(f float64) *PetUpdate {
 	pu.mutation.ResetAge()

--- a/entc/integration/ent/spec_delete.go
+++ b/entc/integration/ent/spec_delete.go
@@ -30,6 +30,14 @@ func (sd *SpecDelete) Where(ps ...predicate.Spec) *SpecDelete {
 	return sd
 }
 
+// WhereIf appends a list predicates to the SpecDelete builder if b is true.
+func (sd *SpecDelete) WhereIf(b bool, ps ...predicate.Spec) *SpecDelete {
+	if b {
+		sd.mutation.Where(ps...)
+	}
+	return sd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (sd *SpecDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/ent/spec_query.go
+++ b/entc/integration/ent/spec_query.go
@@ -45,6 +45,14 @@ func (sq *SpecQuery) Where(ps ...predicate.Spec) *SpecQuery {
 	return sq
 }
 
+// WhereIf adds a new predicates to the SpecQuery builder if b is true.
+func (sq *SpecQuery) WhereIf(b bool, ps ...predicate.Spec) *SpecQuery {
+	if b {
+		sq.predicates = append(sq.predicates, ps...)
+	}
+	return sq
+}
+
 // Limit adds a limit step to the query.
 func (sq *SpecQuery) Limit(limit int) *SpecQuery {
 	sq.limit = &limit

--- a/entc/integration/ent/spec_update.go
+++ b/entc/integration/ent/spec_update.go
@@ -32,6 +32,14 @@ func (su *SpecUpdate) Where(ps ...predicate.Spec) *SpecUpdate {
 	return su
 }
 
+// WhereIf appends a list predicates to the SpecUpdate builder if b is true.
+func (su *SpecUpdate) WhereIf(b bool, ps ...predicate.Spec) *SpecUpdate {
+	if b {
+		su.mutation.Where(ps...)
+	}
+	return su
+}
+
 // AddCardIDs adds the "card" edge to the Card entity by IDs.
 func (su *SpecUpdate) AddCardIDs(ids ...int) *SpecUpdate {
 	su.mutation.AddCardIDs(ids...)

--- a/entc/integration/ent/task_delete.go
+++ b/entc/integration/ent/task_delete.go
@@ -30,6 +30,14 @@ func (td *TaskDelete) Where(ps ...predicate.Task) *TaskDelete {
 	return td
 }
 
+// WhereIf appends a list predicates to the TaskDelete builder if b is true.
+func (td *TaskDelete) WhereIf(b bool, ps ...predicate.Task) *TaskDelete {
+	if b {
+		td.mutation.Where(ps...)
+	}
+	return td
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (td *TaskDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/ent/task_query.go
+++ b/entc/integration/ent/task_query.go
@@ -41,6 +41,14 @@ func (tq *TaskQuery) Where(ps ...predicate.Task) *TaskQuery {
 	return tq
 }
 
+// WhereIf adds a new predicates to the TaskQuery builder if b is true.
+func (tq *TaskQuery) WhereIf(b bool, ps ...predicate.Task) *TaskQuery {
+	if b {
+		tq.predicates = append(tq.predicates, ps...)
+	}
+	return tq
+}
+
 // Limit adds a limit step to the query.
 func (tq *TaskQuery) Limit(limit int) *TaskQuery {
 	tq.limit = &limit

--- a/entc/integration/ent/task_update.go
+++ b/entc/integration/ent/task_update.go
@@ -32,6 +32,14 @@ func (tu *TaskUpdate) Where(ps ...predicate.Task) *TaskUpdate {
 	return tu
 }
 
+// WhereIf appends a list predicates to the TaskUpdate builder if b is true.
+func (tu *TaskUpdate) WhereIf(b bool, ps ...predicate.Task) *TaskUpdate {
+	if b {
+		tu.mutation.Where(ps...)
+	}
+	return tu
+}
+
 // SetPriority sets the "priority" field.
 func (tu *TaskUpdate) SetPriority(s schema.Priority) *TaskUpdate {
 	tu.mutation.ResetPriority()

--- a/entc/integration/ent/user_delete.go
+++ b/entc/integration/ent/user_delete.go
@@ -30,6 +30,14 @@ func (ud *UserDelete) Where(ps ...predicate.User) *UserDelete {
 	return ud
 }
 
+// WhereIf appends a list predicates to the UserDelete builder if b is true.
+func (ud *UserDelete) WhereIf(b bool, ps ...predicate.User) *UserDelete {
+	if b {
+		ud.mutation.Where(ps...)
+	}
+	return ud
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (ud *UserDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/ent/user_query.go
+++ b/entc/integration/ent/user_query.go
@@ -59,6 +59,14 @@ func (uq *UserQuery) Where(ps ...predicate.User) *UserQuery {
 	return uq
 }
 
+// WhereIf adds a new predicates to the UserQuery builder if b is true.
+func (uq *UserQuery) WhereIf(b bool, ps ...predicate.User) *UserQuery {
+	if b {
+		uq.predicates = append(uq.predicates, ps...)
+	}
+	return uq
+}
+
 // Limit adds a limit step to the query.
 func (uq *UserQuery) Limit(limit int) *UserQuery {
 	uq.limit = &limit

--- a/entc/integration/ent/user_update.go
+++ b/entc/integration/ent/user_update.go
@@ -35,6 +35,14 @@ func (uu *UserUpdate) Where(ps ...predicate.User) *UserUpdate {
 	return uu
 }
 
+// WhereIf appends a list predicates to the UserUpdate builder if b is true.
+func (uu *UserUpdate) WhereIf(b bool, ps ...predicate.User) *UserUpdate {
+	if b {
+		uu.mutation.Where(ps...)
+	}
+	return uu
+}
+
 // SetOptionalInt sets the "optional_int" field.
 func (uu *UserUpdate) SetOptionalInt(i int) *UserUpdate {
 	uu.mutation.ResetOptionalInt()

--- a/entc/integration/gremlin/ent/card_delete.go
+++ b/entc/integration/gremlin/ent/card_delete.go
@@ -31,6 +31,14 @@ func (cd *CardDelete) Where(ps ...predicate.Card) *CardDelete {
 	return cd
 }
 
+// WhereIf appends a list predicates to the CardDelete builder if b is true.
+func (cd *CardDelete) WhereIf(b bool, ps ...predicate.Card) *CardDelete {
+	if b {
+		cd.mutation.Where(ps...)
+	}
+	return cd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (cd *CardDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/gremlin/ent/card_query.go
+++ b/entc/integration/gremlin/ent/card_query.go
@@ -45,6 +45,14 @@ func (cq *CardQuery) Where(ps ...predicate.Card) *CardQuery {
 	return cq
 }
 
+// WhereIf adds a new predicates to the CardQuery builder if b is true.
+func (cq *CardQuery) WhereIf(b bool, ps ...predicate.Card) *CardQuery {
+	if b {
+		cq.predicates = append(cq.predicates, ps...)
+	}
+	return cq
+}
+
 // Limit adds a limit step to the query.
 func (cq *CardQuery) Limit(limit int) *CardQuery {
 	cq.limit = &limit

--- a/entc/integration/gremlin/ent/card_update.go
+++ b/entc/integration/gremlin/ent/card_update.go
@@ -36,6 +36,14 @@ func (cu *CardUpdate) Where(ps ...predicate.Card) *CardUpdate {
 	return cu
 }
 
+// WhereIf appends a list predicates to the CardUpdate builder if b is true.
+func (cu *CardUpdate) WhereIf(b bool, ps ...predicate.Card) *CardUpdate {
+	if b {
+		cu.mutation.Where(ps...)
+	}
+	return cu
+}
+
 // SetUpdateTime sets the "update_time" field.
 func (cu *CardUpdate) SetUpdateTime(t time.Time) *CardUpdate {
 	cu.mutation.SetUpdateTime(t)

--- a/entc/integration/gremlin/ent/comment_delete.go
+++ b/entc/integration/gremlin/ent/comment_delete.go
@@ -31,6 +31,14 @@ func (cd *CommentDelete) Where(ps ...predicate.Comment) *CommentDelete {
 	return cd
 }
 
+// WhereIf appends a list predicates to the CommentDelete builder if b is true.
+func (cd *CommentDelete) WhereIf(b bool, ps ...predicate.Comment) *CommentDelete {
+	if b {
+		cd.mutation.Where(ps...)
+	}
+	return cd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (cd *CommentDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/gremlin/ent/comment_query.go
+++ b/entc/integration/gremlin/ent/comment_query.go
@@ -40,6 +40,14 @@ func (cq *CommentQuery) Where(ps ...predicate.Comment) *CommentQuery {
 	return cq
 }
 
+// WhereIf adds a new predicates to the CommentQuery builder if b is true.
+func (cq *CommentQuery) WhereIf(b bool, ps ...predicate.Comment) *CommentQuery {
+	if b {
+		cq.predicates = append(cq.predicates, ps...)
+	}
+	return cq
+}
+
 // Limit adds a limit step to the query.
 func (cq *CommentQuery) Limit(limit int) *CommentQuery {
 	cq.limit = &limit

--- a/entc/integration/gremlin/ent/comment_update.go
+++ b/entc/integration/gremlin/ent/comment_update.go
@@ -33,6 +33,14 @@ func (cu *CommentUpdate) Where(ps ...predicate.Comment) *CommentUpdate {
 	return cu
 }
 
+// WhereIf appends a list predicates to the CommentUpdate builder if b is true.
+func (cu *CommentUpdate) WhereIf(b bool, ps ...predicate.Comment) *CommentUpdate {
+	if b {
+		cu.mutation.Where(ps...)
+	}
+	return cu
+}
+
 // SetUniqueInt sets the "unique_int" field.
 func (cu *CommentUpdate) SetUniqueInt(i int) *CommentUpdate {
 	cu.mutation.ResetUniqueInt()

--- a/entc/integration/gremlin/ent/fieldtype_delete.go
+++ b/entc/integration/gremlin/ent/fieldtype_delete.go
@@ -31,6 +31,14 @@ func (ftd *FieldTypeDelete) Where(ps ...predicate.FieldType) *FieldTypeDelete {
 	return ftd
 }
 
+// WhereIf appends a list predicates to the FieldTypeDelete builder if b is true.
+func (ftd *FieldTypeDelete) WhereIf(b bool, ps ...predicate.FieldType) *FieldTypeDelete {
+	if b {
+		ftd.mutation.Where(ps...)
+	}
+	return ftd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (ftd *FieldTypeDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/gremlin/ent/fieldtype_query.go
+++ b/entc/integration/gremlin/ent/fieldtype_query.go
@@ -40,6 +40,14 @@ func (ftq *FieldTypeQuery) Where(ps ...predicate.FieldType) *FieldTypeQuery {
 	return ftq
 }
 
+// WhereIf adds a new predicates to the FieldTypeQuery builder if b is true.
+func (ftq *FieldTypeQuery) WhereIf(b bool, ps ...predicate.FieldType) *FieldTypeQuery {
+	if b {
+		ftq.predicates = append(ftq.predicates, ps...)
+	}
+	return ftq
+}
+
 // Limit adds a limit step to the query.
 func (ftq *FieldTypeQuery) Limit(limit int) *FieldTypeQuery {
 	ftq.limit = &limit

--- a/entc/integration/gremlin/ent/fieldtype_update.go
+++ b/entc/integration/gremlin/ent/fieldtype_update.go
@@ -39,6 +39,14 @@ func (ftu *FieldTypeUpdate) Where(ps ...predicate.FieldType) *FieldTypeUpdate {
 	return ftu
 }
 
+// WhereIf appends a list predicates to the FieldTypeUpdate builder if b is true.
+func (ftu *FieldTypeUpdate) WhereIf(b bool, ps ...predicate.FieldType) *FieldTypeUpdate {
+	if b {
+		ftu.mutation.Where(ps...)
+	}
+	return ftu
+}
+
 // SetInt sets the "int" field.
 func (ftu *FieldTypeUpdate) SetInt(i int) *FieldTypeUpdate {
 	ftu.mutation.ResetInt()

--- a/entc/integration/gremlin/ent/file_delete.go
+++ b/entc/integration/gremlin/ent/file_delete.go
@@ -31,6 +31,14 @@ func (fd *FileDelete) Where(ps ...predicate.File) *FileDelete {
 	return fd
 }
 
+// WhereIf appends a list predicates to the FileDelete builder if b is true.
+func (fd *FileDelete) WhereIf(b bool, ps ...predicate.File) *FileDelete {
+	if b {
+		fd.mutation.Where(ps...)
+	}
+	return fd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (fd *FileDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/gremlin/ent/file_query.go
+++ b/entc/integration/gremlin/ent/file_query.go
@@ -46,6 +46,14 @@ func (fq *FileQuery) Where(ps ...predicate.File) *FileQuery {
 	return fq
 }
 
+// WhereIf adds a new predicates to the FileQuery builder if b is true.
+func (fq *FileQuery) WhereIf(b bool, ps ...predicate.File) *FileQuery {
+	if b {
+		fq.predicates = append(fq.predicates, ps...)
+	}
+	return fq
+}
+
 // Limit adds a limit step to the query.
 func (fq *FileQuery) Limit(limit int) *FileQuery {
 	fq.limit = &limit

--- a/entc/integration/gremlin/ent/file_update.go
+++ b/entc/integration/gremlin/ent/file_update.go
@@ -35,6 +35,14 @@ func (fu *FileUpdate) Where(ps ...predicate.File) *FileUpdate {
 	return fu
 }
 
+// WhereIf appends a list predicates to the FileUpdate builder if b is true.
+func (fu *FileUpdate) WhereIf(b bool, ps ...predicate.File) *FileUpdate {
+	if b {
+		fu.mutation.Where(ps...)
+	}
+	return fu
+}
+
 // SetSize sets the "size" field.
 func (fu *FileUpdate) SetSize(i int) *FileUpdate {
 	fu.mutation.ResetSize()

--- a/entc/integration/gremlin/ent/filetype_delete.go
+++ b/entc/integration/gremlin/ent/filetype_delete.go
@@ -31,6 +31,14 @@ func (ftd *FileTypeDelete) Where(ps ...predicate.FileType) *FileTypeDelete {
 	return ftd
 }
 
+// WhereIf appends a list predicates to the FileTypeDelete builder if b is true.
+func (ftd *FileTypeDelete) WhereIf(b bool, ps ...predicate.FileType) *FileTypeDelete {
+	if b {
+		ftd.mutation.Where(ps...)
+	}
+	return ftd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (ftd *FileTypeDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/gremlin/ent/filetype_query.go
+++ b/entc/integration/gremlin/ent/filetype_query.go
@@ -42,6 +42,14 @@ func (ftq *FileTypeQuery) Where(ps ...predicate.FileType) *FileTypeQuery {
 	return ftq
 }
 
+// WhereIf adds a new predicates to the FileTypeQuery builder if b is true.
+func (ftq *FileTypeQuery) WhereIf(b bool, ps ...predicate.FileType) *FileTypeQuery {
+	if b {
+		ftq.predicates = append(ftq.predicates, ps...)
+	}
+	return ftq
+}
+
 // Limit adds a limit step to the query.
 func (ftq *FileTypeQuery) Limit(limit int) *FileTypeQuery {
 	ftq.limit = &limit

--- a/entc/integration/gremlin/ent/filetype_update.go
+++ b/entc/integration/gremlin/ent/filetype_update.go
@@ -33,6 +33,14 @@ func (ftu *FileTypeUpdate) Where(ps ...predicate.FileType) *FileTypeUpdate {
 	return ftu
 }
 
+// WhereIf appends a list predicates to the FileTypeUpdate builder if b is true.
+func (ftu *FileTypeUpdate) WhereIf(b bool, ps ...predicate.FileType) *FileTypeUpdate {
+	if b {
+		ftu.mutation.Where(ps...)
+	}
+	return ftu
+}
+
 // SetName sets the "name" field.
 func (ftu *FileTypeUpdate) SetName(s string) *FileTypeUpdate {
 	ftu.mutation.SetName(s)

--- a/entc/integration/gremlin/ent/goods_delete.go
+++ b/entc/integration/gremlin/ent/goods_delete.go
@@ -31,6 +31,14 @@ func (gd *GoodsDelete) Where(ps ...predicate.Goods) *GoodsDelete {
 	return gd
 }
 
+// WhereIf appends a list predicates to the GoodsDelete builder if b is true.
+func (gd *GoodsDelete) WhereIf(b bool, ps ...predicate.Goods) *GoodsDelete {
+	if b {
+		gd.mutation.Where(ps...)
+	}
+	return gd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (gd *GoodsDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/gremlin/ent/goods_query.go
+++ b/entc/integration/gremlin/ent/goods_query.go
@@ -40,6 +40,14 @@ func (gq *GoodsQuery) Where(ps ...predicate.Goods) *GoodsQuery {
 	return gq
 }
 
+// WhereIf adds a new predicates to the GoodsQuery builder if b is true.
+func (gq *GoodsQuery) WhereIf(b bool, ps ...predicate.Goods) *GoodsQuery {
+	if b {
+		gq.predicates = append(gq.predicates, ps...)
+	}
+	return gq
+}
+
 // Limit adds a limit step to the query.
 func (gq *GoodsQuery) Limit(limit int) *GoodsQuery {
 	gq.limit = &limit

--- a/entc/integration/gremlin/ent/goods_update.go
+++ b/entc/integration/gremlin/ent/goods_update.go
@@ -31,6 +31,14 @@ func (gu *GoodsUpdate) Where(ps ...predicate.Goods) *GoodsUpdate {
 	return gu
 }
 
+// WhereIf appends a list predicates to the GoodsUpdate builder if b is true.
+func (gu *GoodsUpdate) WhereIf(b bool, ps ...predicate.Goods) *GoodsUpdate {
+	if b {
+		gu.mutation.Where(ps...)
+	}
+	return gu
+}
+
 // Mutation returns the GoodsMutation object of the builder.
 func (gu *GoodsUpdate) Mutation() *GoodsMutation {
 	return gu.mutation

--- a/entc/integration/gremlin/ent/group_delete.go
+++ b/entc/integration/gremlin/ent/group_delete.go
@@ -31,6 +31,14 @@ func (gd *GroupDelete) Where(ps ...predicate.Group) *GroupDelete {
 	return gd
 }
 
+// WhereIf appends a list predicates to the GroupDelete builder if b is true.
+func (gd *GroupDelete) WhereIf(b bool, ps ...predicate.Group) *GroupDelete {
+	if b {
+		gd.mutation.Where(ps...)
+	}
+	return gd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (gd *GroupDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/gremlin/ent/group_query.go
+++ b/entc/integration/gremlin/ent/group_query.go
@@ -46,6 +46,14 @@ func (gq *GroupQuery) Where(ps ...predicate.Group) *GroupQuery {
 	return gq
 }
 
+// WhereIf adds a new predicates to the GroupQuery builder if b is true.
+func (gq *GroupQuery) WhereIf(b bool, ps ...predicate.Group) *GroupQuery {
+	if b {
+		gq.predicates = append(gq.predicates, ps...)
+	}
+	return gq
+}
+
 // Limit adds a limit step to the query.
 func (gq *GroupQuery) Limit(limit int) *GroupQuery {
 	gq.limit = &limit

--- a/entc/integration/gremlin/ent/group_update.go
+++ b/entc/integration/gremlin/ent/group_update.go
@@ -35,6 +35,14 @@ func (gu *GroupUpdate) Where(ps ...predicate.Group) *GroupUpdate {
 	return gu
 }
 
+// WhereIf appends a list predicates to the GroupUpdate builder if b is true.
+func (gu *GroupUpdate) WhereIf(b bool, ps ...predicate.Group) *GroupUpdate {
+	if b {
+		gu.mutation.Where(ps...)
+	}
+	return gu
+}
+
 // SetActive sets the "active" field.
 func (gu *GroupUpdate) SetActive(b bool) *GroupUpdate {
 	gu.mutation.SetActive(b)

--- a/entc/integration/gremlin/ent/groupinfo_delete.go
+++ b/entc/integration/gremlin/ent/groupinfo_delete.go
@@ -31,6 +31,14 @@ func (gid *GroupInfoDelete) Where(ps ...predicate.GroupInfo) *GroupInfoDelete {
 	return gid
 }
 
+// WhereIf appends a list predicates to the GroupInfoDelete builder if b is true.
+func (gid *GroupInfoDelete) WhereIf(b bool, ps ...predicate.GroupInfo) *GroupInfoDelete {
+	if b {
+		gid.mutation.Where(ps...)
+	}
+	return gid
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (gid *GroupInfoDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/gremlin/ent/groupinfo_query.go
+++ b/entc/integration/gremlin/ent/groupinfo_query.go
@@ -43,6 +43,14 @@ func (giq *GroupInfoQuery) Where(ps ...predicate.GroupInfo) *GroupInfoQuery {
 	return giq
 }
 
+// WhereIf adds a new predicates to the GroupInfoQuery builder if b is true.
+func (giq *GroupInfoQuery) WhereIf(b bool, ps ...predicate.GroupInfo) *GroupInfoQuery {
+	if b {
+		giq.predicates = append(giq.predicates, ps...)
+	}
+	return giq
+}
+
 // Limit adds a limit step to the query.
 func (giq *GroupInfoQuery) Limit(limit int) *GroupInfoQuery {
 	giq.limit = &limit

--- a/entc/integration/gremlin/ent/groupinfo_update.go
+++ b/entc/integration/gremlin/ent/groupinfo_update.go
@@ -34,6 +34,14 @@ func (giu *GroupInfoUpdate) Where(ps ...predicate.GroupInfo) *GroupInfoUpdate {
 	return giu
 }
 
+// WhereIf appends a list predicates to the GroupInfoUpdate builder if b is true.
+func (giu *GroupInfoUpdate) WhereIf(b bool, ps ...predicate.GroupInfo) *GroupInfoUpdate {
+	if b {
+		giu.mutation.Where(ps...)
+	}
+	return giu
+}
+
 // SetDesc sets the "desc" field.
 func (giu *GroupInfoUpdate) SetDesc(s string) *GroupInfoUpdate {
 	giu.mutation.SetDesc(s)

--- a/entc/integration/gremlin/ent/item_delete.go
+++ b/entc/integration/gremlin/ent/item_delete.go
@@ -31,6 +31,14 @@ func (id *ItemDelete) Where(ps ...predicate.Item) *ItemDelete {
 	return id
 }
 
+// WhereIf appends a list predicates to the ItemDelete builder if b is true.
+func (id *ItemDelete) WhereIf(b bool, ps ...predicate.Item) *ItemDelete {
+	if b {
+		id.mutation.Where(ps...)
+	}
+	return id
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (id *ItemDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/gremlin/ent/item_query.go
+++ b/entc/integration/gremlin/ent/item_query.go
@@ -40,6 +40,14 @@ func (iq *ItemQuery) Where(ps ...predicate.Item) *ItemQuery {
 	return iq
 }
 
+// WhereIf adds a new predicates to the ItemQuery builder if b is true.
+func (iq *ItemQuery) WhereIf(b bool, ps ...predicate.Item) *ItemQuery {
+	if b {
+		iq.predicates = append(iq.predicates, ps...)
+	}
+	return iq
+}
+
 // Limit adds a limit step to the query.
 func (iq *ItemQuery) Limit(limit int) *ItemQuery {
 	iq.limit = &limit

--- a/entc/integration/gremlin/ent/item_update.go
+++ b/entc/integration/gremlin/ent/item_update.go
@@ -33,6 +33,14 @@ func (iu *ItemUpdate) Where(ps ...predicate.Item) *ItemUpdate {
 	return iu
 }
 
+// WhereIf appends a list predicates to the ItemUpdate builder if b is true.
+func (iu *ItemUpdate) WhereIf(b bool, ps ...predicate.Item) *ItemUpdate {
+	if b {
+		iu.mutation.Where(ps...)
+	}
+	return iu
+}
+
 // SetText sets the "text" field.
 func (iu *ItemUpdate) SetText(s string) *ItemUpdate {
 	iu.mutation.SetText(s)

--- a/entc/integration/gremlin/ent/node_delete.go
+++ b/entc/integration/gremlin/ent/node_delete.go
@@ -31,6 +31,14 @@ func (nd *NodeDelete) Where(ps ...predicate.Node) *NodeDelete {
 	return nd
 }
 
+// WhereIf appends a list predicates to the NodeDelete builder if b is true.
+func (nd *NodeDelete) WhereIf(b bool, ps ...predicate.Node) *NodeDelete {
+	if b {
+		nd.mutation.Where(ps...)
+	}
+	return nd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (nd *NodeDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/gremlin/ent/node_query.go
+++ b/entc/integration/gremlin/ent/node_query.go
@@ -43,6 +43,14 @@ func (nq *NodeQuery) Where(ps ...predicate.Node) *NodeQuery {
 	return nq
 }
 
+// WhereIf adds a new predicates to the NodeQuery builder if b is true.
+func (nq *NodeQuery) WhereIf(b bool, ps ...predicate.Node) *NodeQuery {
+	if b {
+		nq.predicates = append(nq.predicates, ps...)
+	}
+	return nq
+}
+
 // Limit adds a limit step to the query.
 func (nq *NodeQuery) Limit(limit int) *NodeQuery {
 	nq.limit = &limit

--- a/entc/integration/gremlin/ent/node_update.go
+++ b/entc/integration/gremlin/ent/node_update.go
@@ -33,6 +33,14 @@ func (nu *NodeUpdate) Where(ps ...predicate.Node) *NodeUpdate {
 	return nu
 }
 
+// WhereIf appends a list predicates to the NodeUpdate builder if b is true.
+func (nu *NodeUpdate) WhereIf(b bool, ps ...predicate.Node) *NodeUpdate {
+	if b {
+		nu.mutation.Where(ps...)
+	}
+	return nu
+}
+
 // SetValue sets the "value" field.
 func (nu *NodeUpdate) SetValue(i int) *NodeUpdate {
 	nu.mutation.ResetValue()

--- a/entc/integration/gremlin/ent/pet_delete.go
+++ b/entc/integration/gremlin/ent/pet_delete.go
@@ -31,6 +31,14 @@ func (pd *PetDelete) Where(ps ...predicate.Pet) *PetDelete {
 	return pd
 }
 
+// WhereIf appends a list predicates to the PetDelete builder if b is true.
+func (pd *PetDelete) WhereIf(b bool, ps ...predicate.Pet) *PetDelete {
+	if b {
+		pd.mutation.Where(ps...)
+	}
+	return pd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (pd *PetDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/gremlin/ent/pet_query.go
+++ b/entc/integration/gremlin/ent/pet_query.go
@@ -44,6 +44,14 @@ func (pq *PetQuery) Where(ps ...predicate.Pet) *PetQuery {
 	return pq
 }
 
+// WhereIf adds a new predicates to the PetQuery builder if b is true.
+func (pq *PetQuery) WhereIf(b bool, ps ...predicate.Pet) *PetQuery {
+	if b {
+		pq.predicates = append(pq.predicates, ps...)
+	}
+	return pq
+}
+
 // Limit adds a limit step to the query.
 func (pq *PetQuery) Limit(limit int) *PetQuery {
 	pq.limit = &limit

--- a/entc/integration/gremlin/ent/pet_update.go
+++ b/entc/integration/gremlin/ent/pet_update.go
@@ -35,6 +35,14 @@ func (pu *PetUpdate) Where(ps ...predicate.Pet) *PetUpdate {
 	return pu
 }
 
+// WhereIf appends a list predicates to the PetUpdate builder if b is true.
+func (pu *PetUpdate) WhereIf(b bool, ps ...predicate.Pet) *PetUpdate {
+	if b {
+		pu.mutation.Where(ps...)
+	}
+	return pu
+}
+
 // SetAge sets the "age" field.
 func (pu *PetUpdate) SetAge(f float64) *PetUpdate {
 	pu.mutation.ResetAge()

--- a/entc/integration/gremlin/ent/spec_delete.go
+++ b/entc/integration/gremlin/ent/spec_delete.go
@@ -31,6 +31,14 @@ func (sd *SpecDelete) Where(ps ...predicate.Spec) *SpecDelete {
 	return sd
 }
 
+// WhereIf appends a list predicates to the SpecDelete builder if b is true.
+func (sd *SpecDelete) WhereIf(b bool, ps ...predicate.Spec) *SpecDelete {
+	if b {
+		sd.mutation.Where(ps...)
+	}
+	return sd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (sd *SpecDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/gremlin/ent/spec_query.go
+++ b/entc/integration/gremlin/ent/spec_query.go
@@ -42,6 +42,14 @@ func (sq *SpecQuery) Where(ps ...predicate.Spec) *SpecQuery {
 	return sq
 }
 
+// WhereIf adds a new predicates to the SpecQuery builder if b is true.
+func (sq *SpecQuery) WhereIf(b bool, ps ...predicate.Spec) *SpecQuery {
+	if b {
+		sq.predicates = append(sq.predicates, ps...)
+	}
+	return sq
+}
+
 // Limit adds a limit step to the query.
 func (sq *SpecQuery) Limit(limit int) *SpecQuery {
 	sq.limit = &limit

--- a/entc/integration/gremlin/ent/spec_update.go
+++ b/entc/integration/gremlin/ent/spec_update.go
@@ -32,6 +32,14 @@ func (su *SpecUpdate) Where(ps ...predicate.Spec) *SpecUpdate {
 	return su
 }
 
+// WhereIf appends a list predicates to the SpecUpdate builder if b is true.
+func (su *SpecUpdate) WhereIf(b bool, ps ...predicate.Spec) *SpecUpdate {
+	if b {
+		su.mutation.Where(ps...)
+	}
+	return su
+}
+
 // AddCardIDs adds the "card" edge to the Card entity by IDs.
 func (su *SpecUpdate) AddCardIDs(ids ...string) *SpecUpdate {
 	su.mutation.AddCardIDs(ids...)

--- a/entc/integration/gremlin/ent/task_delete.go
+++ b/entc/integration/gremlin/ent/task_delete.go
@@ -31,6 +31,14 @@ func (td *TaskDelete) Where(ps ...predicate.Task) *TaskDelete {
 	return td
 }
 
+// WhereIf appends a list predicates to the TaskDelete builder if b is true.
+func (td *TaskDelete) WhereIf(b bool, ps ...predicate.Task) *TaskDelete {
+	if b {
+		td.mutation.Where(ps...)
+	}
+	return td
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (td *TaskDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/gremlin/ent/task_query.go
+++ b/entc/integration/gremlin/ent/task_query.go
@@ -40,6 +40,14 @@ func (tq *TaskQuery) Where(ps ...predicate.Task) *TaskQuery {
 	return tq
 }
 
+// WhereIf adds a new predicates to the TaskQuery builder if b is true.
+func (tq *TaskQuery) WhereIf(b bool, ps ...predicate.Task) *TaskQuery {
+	if b {
+		tq.predicates = append(tq.predicates, ps...)
+	}
+	return tq
+}
+
 // Limit adds a limit step to the query.
 func (tq *TaskQuery) Limit(limit int) *TaskQuery {
 	tq.limit = &limit

--- a/entc/integration/gremlin/ent/task_update.go
+++ b/entc/integration/gremlin/ent/task_update.go
@@ -33,6 +33,14 @@ func (tu *TaskUpdate) Where(ps ...predicate.Task) *TaskUpdate {
 	return tu
 }
 
+// WhereIf appends a list predicates to the TaskUpdate builder if b is true.
+func (tu *TaskUpdate) WhereIf(b bool, ps ...predicate.Task) *TaskUpdate {
+	if b {
+		tu.mutation.Where(ps...)
+	}
+	return tu
+}
+
 // SetPriority sets the "priority" field.
 func (tu *TaskUpdate) SetPriority(s schema.Priority) *TaskUpdate {
 	tu.mutation.ResetPriority()

--- a/entc/integration/gremlin/ent/user_delete.go
+++ b/entc/integration/gremlin/ent/user_delete.go
@@ -31,6 +31,14 @@ func (ud *UserDelete) Where(ps ...predicate.User) *UserDelete {
 	return ud
 }
 
+// WhereIf appends a list predicates to the UserDelete builder if b is true.
+func (ud *UserDelete) WhereIf(b bool, ps ...predicate.User) *UserDelete {
+	if b {
+		ud.mutation.Where(ps...)
+	}
+	return ud
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (ud *UserDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/gremlin/ent/user_query.go
+++ b/entc/integration/gremlin/ent/user_query.go
@@ -52,6 +52,14 @@ func (uq *UserQuery) Where(ps ...predicate.User) *UserQuery {
 	return uq
 }
 
+// WhereIf adds a new predicates to the UserQuery builder if b is true.
+func (uq *UserQuery) WhereIf(b bool, ps ...predicate.User) *UserQuery {
+	if b {
+		uq.predicates = append(uq.predicates, ps...)
+	}
+	return uq
+}
+
 // Limit adds a limit step to the query.
 func (uq *UserQuery) Limit(limit int) *UserQuery {
 	uq.limit = &limit

--- a/entc/integration/gremlin/ent/user_update.go
+++ b/entc/integration/gremlin/ent/user_update.go
@@ -33,6 +33,14 @@ func (uu *UserUpdate) Where(ps ...predicate.User) *UserUpdate {
 	return uu
 }
 
+// WhereIf appends a list predicates to the UserUpdate builder if b is true.
+func (uu *UserUpdate) WhereIf(b bool, ps ...predicate.User) *UserUpdate {
+	if b {
+		uu.mutation.Where(ps...)
+	}
+	return uu
+}
+
 // SetOptionalInt sets the "optional_int" field.
 func (uu *UserUpdate) SetOptionalInt(i int) *UserUpdate {
 	uu.mutation.ResetOptionalInt()

--- a/entc/integration/hooks/ent/card_delete.go
+++ b/entc/integration/hooks/ent/card_delete.go
@@ -30,6 +30,14 @@ func (cd *CardDelete) Where(ps ...predicate.Card) *CardDelete {
 	return cd
 }
 
+// WhereIf appends a list predicates to the CardDelete builder if b is true.
+func (cd *CardDelete) WhereIf(b bool, ps ...predicate.Card) *CardDelete {
+	if b {
+		cd.mutation.Where(ps...)
+	}
+	return cd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (cd *CardDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/hooks/ent/card_query.go
+++ b/entc/integration/hooks/ent/card_query.go
@@ -43,6 +43,14 @@ func (cq *CardQuery) Where(ps ...predicate.Card) *CardQuery {
 	return cq
 }
 
+// WhereIf adds a new predicates to the CardQuery builder if b is true.
+func (cq *CardQuery) WhereIf(b bool, ps ...predicate.Card) *CardQuery {
+	if b {
+		cq.predicates = append(cq.predicates, ps...)
+	}
+	return cq
+}
+
 // Limit adds a limit step to the query.
 func (cq *CardQuery) Limit(limit int) *CardQuery {
 	cq.limit = &limit

--- a/entc/integration/hooks/ent/card_update.go
+++ b/entc/integration/hooks/ent/card_update.go
@@ -33,6 +33,14 @@ func (cu *CardUpdate) Where(ps ...predicate.Card) *CardUpdate {
 	return cu
 }
 
+// WhereIf appends a list predicates to the CardUpdate builder if b is true.
+func (cu *CardUpdate) WhereIf(b bool, ps ...predicate.Card) *CardUpdate {
+	if b {
+		cu.mutation.Where(ps...)
+	}
+	return cu
+}
+
 // SetName sets the "name" field.
 func (cu *CardUpdate) SetName(s string) *CardUpdate {
 	cu.mutation.SetName(s)

--- a/entc/integration/hooks/ent/user_delete.go
+++ b/entc/integration/hooks/ent/user_delete.go
@@ -30,6 +30,14 @@ func (ud *UserDelete) Where(ps ...predicate.User) *UserDelete {
 	return ud
 }
 
+// WhereIf appends a list predicates to the UserDelete builder if b is true.
+func (ud *UserDelete) WhereIf(b bool, ps ...predicate.User) *UserDelete {
+	if b {
+		ud.mutation.Where(ps...)
+	}
+	return ud
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (ud *UserDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/hooks/ent/user_query.go
+++ b/entc/integration/hooks/ent/user_query.go
@@ -46,6 +46,14 @@ func (uq *UserQuery) Where(ps ...predicate.User) *UserQuery {
 	return uq
 }
 
+// WhereIf adds a new predicates to the UserQuery builder if b is true.
+func (uq *UserQuery) WhereIf(b bool, ps ...predicate.User) *UserQuery {
+	if b {
+		uq.predicates = append(uq.predicates, ps...)
+	}
+	return uq
+}
+
 // Limit adds a limit step to the query.
 func (uq *UserQuery) Limit(limit int) *UserQuery {
 	uq.limit = &limit

--- a/entc/integration/hooks/ent/user_update.go
+++ b/entc/integration/hooks/ent/user_update.go
@@ -32,6 +32,14 @@ func (uu *UserUpdate) Where(ps ...predicate.User) *UserUpdate {
 	return uu
 }
 
+// WhereIf appends a list predicates to the UserUpdate builder if b is true.
+func (uu *UserUpdate) WhereIf(b bool, ps ...predicate.User) *UserUpdate {
+	if b {
+		uu.mutation.Where(ps...)
+	}
+	return uu
+}
+
 // SetVersion sets the "version" field.
 func (uu *UserUpdate) SetVersion(i int) *UserUpdate {
 	uu.mutation.ResetVersion()

--- a/entc/integration/idtype/ent/user_delete.go
+++ b/entc/integration/idtype/ent/user_delete.go
@@ -30,6 +30,14 @@ func (ud *UserDelete) Where(ps ...predicate.User) *UserDelete {
 	return ud
 }
 
+// WhereIf appends a list predicates to the UserDelete builder if b is true.
+func (ud *UserDelete) WhereIf(b bool, ps ...predicate.User) *UserDelete {
+	if b {
+		ud.mutation.Where(ps...)
+	}
+	return ud
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (ud *UserDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/idtype/ent/user_query.go
+++ b/entc/integration/idtype/ent/user_query.go
@@ -45,6 +45,14 @@ func (uq *UserQuery) Where(ps ...predicate.User) *UserQuery {
 	return uq
 }
 
+// WhereIf adds a new predicates to the UserQuery builder if b is true.
+func (uq *UserQuery) WhereIf(b bool, ps ...predicate.User) *UserQuery {
+	if b {
+		uq.predicates = append(uq.predicates, ps...)
+	}
+	return uq
+}
+
 // Limit adds a limit step to the query.
 func (uq *UserQuery) Limit(limit int) *UserQuery {
 	uq.limit = &limit

--- a/entc/integration/idtype/ent/user_update.go
+++ b/entc/integration/idtype/ent/user_update.go
@@ -31,6 +31,14 @@ func (uu *UserUpdate) Where(ps ...predicate.User) *UserUpdate {
 	return uu
 }
 
+// WhereIf appends a list predicates to the UserUpdate builder if b is true.
+func (uu *UserUpdate) WhereIf(b bool, ps ...predicate.User) *UserUpdate {
+	if b {
+		uu.mutation.Where(ps...)
+	}
+	return uu
+}
+
 // SetName sets the "name" field.
 func (uu *UserUpdate) SetName(s string) *UserUpdate {
 	uu.mutation.SetName(s)

--- a/entc/integration/json/ent/user_delete.go
+++ b/entc/integration/json/ent/user_delete.go
@@ -30,6 +30,14 @@ func (ud *UserDelete) Where(ps ...predicate.User) *UserDelete {
 	return ud
 }
 
+// WhereIf appends a list predicates to the UserDelete builder if b is true.
+func (ud *UserDelete) WhereIf(b bool, ps ...predicate.User) *UserDelete {
+	if b {
+		ud.mutation.Where(ps...)
+	}
+	return ud
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (ud *UserDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/json/ent/user_query.go
+++ b/entc/integration/json/ent/user_query.go
@@ -39,6 +39,14 @@ func (uq *UserQuery) Where(ps ...predicate.User) *UserQuery {
 	return uq
 }
 
+// WhereIf adds a new predicates to the UserQuery builder if b is true.
+func (uq *UserQuery) WhereIf(b bool, ps ...predicate.User) *UserQuery {
+	if b {
+		uq.predicates = append(uq.predicates, ps...)
+	}
+	return uq
+}
+
 // Limit adds a limit step to the query.
 func (uq *UserQuery) Limit(limit int) *UserQuery {
 	uq.limit = &limit

--- a/entc/integration/json/ent/user_update.go
+++ b/entc/integration/json/ent/user_update.go
@@ -35,6 +35,14 @@ func (uu *UserUpdate) Where(ps ...predicate.User) *UserUpdate {
 	return uu
 }
 
+// WhereIf appends a list predicates to the UserUpdate builder if b is true.
+func (uu *UserUpdate) WhereIf(b bool, ps ...predicate.User) *UserUpdate {
+	if b {
+		uu.mutation.Where(ps...)
+	}
+	return uu
+}
+
 // SetT sets the "t" field.
 func (uu *UserUpdate) SetT(s *schema.T) *UserUpdate {
 	uu.mutation.SetT(s)

--- a/entc/integration/migrate/entv1/car_delete.go
+++ b/entc/integration/migrate/entv1/car_delete.go
@@ -30,6 +30,14 @@ func (cd *CarDelete) Where(ps ...predicate.Car) *CarDelete {
 	return cd
 }
 
+// WhereIf appends a list predicates to the CarDelete builder if b is true.
+func (cd *CarDelete) WhereIf(b bool, ps ...predicate.Car) *CarDelete {
+	if b {
+		cd.mutation.Where(ps...)
+	}
+	return cd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (cd *CarDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/migrate/entv1/car_query.go
+++ b/entc/integration/migrate/entv1/car_query.go
@@ -43,6 +43,14 @@ func (cq *CarQuery) Where(ps ...predicate.Car) *CarQuery {
 	return cq
 }
 
+// WhereIf adds a new predicates to the CarQuery builder if b is true.
+func (cq *CarQuery) WhereIf(b bool, ps ...predicate.Car) *CarQuery {
+	if b {
+		cq.predicates = append(cq.predicates, ps...)
+	}
+	return cq
+}
+
 // Limit adds a limit step to the query.
 func (cq *CarQuery) Limit(limit int) *CarQuery {
 	cq.limit = &limit

--- a/entc/integration/migrate/entv1/car_update.go
+++ b/entc/integration/migrate/entv1/car_update.go
@@ -32,6 +32,14 @@ func (cu *CarUpdate) Where(ps ...predicate.Car) *CarUpdate {
 	return cu
 }
 
+// WhereIf appends a list predicates to the CarUpdate builder if b is true.
+func (cu *CarUpdate) WhereIf(b bool, ps ...predicate.Car) *CarUpdate {
+	if b {
+		cu.mutation.Where(ps...)
+	}
+	return cu
+}
+
 // SetOwnerID sets the "owner" edge to the User entity by ID.
 func (cu *CarUpdate) SetOwnerID(id int) *CarUpdate {
 	cu.mutation.SetOwnerID(id)

--- a/entc/integration/migrate/entv1/conversion_delete.go
+++ b/entc/integration/migrate/entv1/conversion_delete.go
@@ -30,6 +30,14 @@ func (cd *ConversionDelete) Where(ps ...predicate.Conversion) *ConversionDelete 
 	return cd
 }
 
+// WhereIf appends a list predicates to the ConversionDelete builder if b is true.
+func (cd *ConversionDelete) WhereIf(b bool, ps ...predicate.Conversion) *ConversionDelete {
+	if b {
+		cd.mutation.Where(ps...)
+	}
+	return cd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (cd *ConversionDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/migrate/entv1/conversion_query.go
+++ b/entc/integration/migrate/entv1/conversion_query.go
@@ -39,6 +39,14 @@ func (cq *ConversionQuery) Where(ps ...predicate.Conversion) *ConversionQuery {
 	return cq
 }
 
+// WhereIf adds a new predicates to the ConversionQuery builder if b is true.
+func (cq *ConversionQuery) WhereIf(b bool, ps ...predicate.Conversion) *ConversionQuery {
+	if b {
+		cq.predicates = append(cq.predicates, ps...)
+	}
+	return cq
+}
+
 // Limit adds a limit step to the query.
 func (cq *ConversionQuery) Limit(limit int) *ConversionQuery {
 	cq.limit = &limit

--- a/entc/integration/migrate/entv1/conversion_update.go
+++ b/entc/integration/migrate/entv1/conversion_update.go
@@ -31,6 +31,14 @@ func (cu *ConversionUpdate) Where(ps ...predicate.Conversion) *ConversionUpdate 
 	return cu
 }
 
+// WhereIf appends a list predicates to the ConversionUpdate builder if b is true.
+func (cu *ConversionUpdate) WhereIf(b bool, ps ...predicate.Conversion) *ConversionUpdate {
+	if b {
+		cu.mutation.Where(ps...)
+	}
+	return cu
+}
+
 // SetName sets the "name" field.
 func (cu *ConversionUpdate) SetName(s string) *ConversionUpdate {
 	cu.mutation.SetName(s)

--- a/entc/integration/migrate/entv1/customtype_delete.go
+++ b/entc/integration/migrate/entv1/customtype_delete.go
@@ -30,6 +30,14 @@ func (ctd *CustomTypeDelete) Where(ps ...predicate.CustomType) *CustomTypeDelete
 	return ctd
 }
 
+// WhereIf appends a list predicates to the CustomTypeDelete builder if b is true.
+func (ctd *CustomTypeDelete) WhereIf(b bool, ps ...predicate.CustomType) *CustomTypeDelete {
+	if b {
+		ctd.mutation.Where(ps...)
+	}
+	return ctd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (ctd *CustomTypeDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/migrate/entv1/customtype_query.go
+++ b/entc/integration/migrate/entv1/customtype_query.go
@@ -39,6 +39,14 @@ func (ctq *CustomTypeQuery) Where(ps ...predicate.CustomType) *CustomTypeQuery {
 	return ctq
 }
 
+// WhereIf adds a new predicates to the CustomTypeQuery builder if b is true.
+func (ctq *CustomTypeQuery) WhereIf(b bool, ps ...predicate.CustomType) *CustomTypeQuery {
+	if b {
+		ctq.predicates = append(ctq.predicates, ps...)
+	}
+	return ctq
+}
+
 // Limit adds a limit step to the query.
 func (ctq *CustomTypeQuery) Limit(limit int) *CustomTypeQuery {
 	ctq.limit = &limit

--- a/entc/integration/migrate/entv1/customtype_update.go
+++ b/entc/integration/migrate/entv1/customtype_update.go
@@ -31,6 +31,14 @@ func (ctu *CustomTypeUpdate) Where(ps ...predicate.CustomType) *CustomTypeUpdate
 	return ctu
 }
 
+// WhereIf appends a list predicates to the CustomTypeUpdate builder if b is true.
+func (ctu *CustomTypeUpdate) WhereIf(b bool, ps ...predicate.CustomType) *CustomTypeUpdate {
+	if b {
+		ctu.mutation.Where(ps...)
+	}
+	return ctu
+}
+
 // SetCustom sets the "custom" field.
 func (ctu *CustomTypeUpdate) SetCustom(s string) *CustomTypeUpdate {
 	ctu.mutation.SetCustom(s)

--- a/entc/integration/migrate/entv1/user_delete.go
+++ b/entc/integration/migrate/entv1/user_delete.go
@@ -30,6 +30,14 @@ func (ud *UserDelete) Where(ps ...predicate.User) *UserDelete {
 	return ud
 }
 
+// WhereIf appends a list predicates to the UserDelete builder if b is true.
+func (ud *UserDelete) WhereIf(b bool, ps ...predicate.User) *UserDelete {
+	if b {
+		ud.mutation.Where(ps...)
+	}
+	return ud
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (ud *UserDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/migrate/entv1/user_query.go
+++ b/entc/integration/migrate/entv1/user_query.go
@@ -47,6 +47,14 @@ func (uq *UserQuery) Where(ps ...predicate.User) *UserQuery {
 	return uq
 }
 
+// WhereIf adds a new predicates to the UserQuery builder if b is true.
+func (uq *UserQuery) WhereIf(b bool, ps ...predicate.User) *UserQuery {
+	if b {
+		uq.predicates = append(uq.predicates, ps...)
+	}
+	return uq
+}
+
 // Limit adds a limit step to the query.
 func (uq *UserQuery) Limit(limit int) *UserQuery {
 	uq.limit = &limit

--- a/entc/integration/migrate/entv1/user_update.go
+++ b/entc/integration/migrate/entv1/user_update.go
@@ -32,6 +32,14 @@ func (uu *UserUpdate) Where(ps ...predicate.User) *UserUpdate {
 	return uu
 }
 
+// WhereIf appends a list predicates to the UserUpdate builder if b is true.
+func (uu *UserUpdate) WhereIf(b bool, ps ...predicate.User) *UserUpdate {
+	if b {
+		uu.mutation.Where(ps...)
+	}
+	return uu
+}
+
 // SetAge sets the "age" field.
 func (uu *UserUpdate) SetAge(i int32) *UserUpdate {
 	uu.mutation.ResetAge()

--- a/entc/integration/migrate/entv2/car_delete.go
+++ b/entc/integration/migrate/entv2/car_delete.go
@@ -30,6 +30,14 @@ func (cd *CarDelete) Where(ps ...predicate.Car) *CarDelete {
 	return cd
 }
 
+// WhereIf appends a list predicates to the CarDelete builder if b is true.
+func (cd *CarDelete) WhereIf(b bool, ps ...predicate.Car) *CarDelete {
+	if b {
+		cd.mutation.Where(ps...)
+	}
+	return cd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (cd *CarDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/migrate/entv2/car_query.go
+++ b/entc/integration/migrate/entv2/car_query.go
@@ -43,6 +43,14 @@ func (cq *CarQuery) Where(ps ...predicate.Car) *CarQuery {
 	return cq
 }
 
+// WhereIf adds a new predicates to the CarQuery builder if b is true.
+func (cq *CarQuery) WhereIf(b bool, ps ...predicate.Car) *CarQuery {
+	if b {
+		cq.predicates = append(cq.predicates, ps...)
+	}
+	return cq
+}
+
 // Limit adds a limit step to the query.
 func (cq *CarQuery) Limit(limit int) *CarQuery {
 	cq.limit = &limit

--- a/entc/integration/migrate/entv2/car_update.go
+++ b/entc/integration/migrate/entv2/car_update.go
@@ -32,6 +32,14 @@ func (cu *CarUpdate) Where(ps ...predicate.Car) *CarUpdate {
 	return cu
 }
 
+// WhereIf appends a list predicates to the CarUpdate builder if b is true.
+func (cu *CarUpdate) WhereIf(b bool, ps ...predicate.Car) *CarUpdate {
+	if b {
+		cu.mutation.Where(ps...)
+	}
+	return cu
+}
+
 // SetOwnerID sets the "owner" edge to the User entity by ID.
 func (cu *CarUpdate) SetOwnerID(id int) *CarUpdate {
 	cu.mutation.SetOwnerID(id)

--- a/entc/integration/migrate/entv2/conversion_delete.go
+++ b/entc/integration/migrate/entv2/conversion_delete.go
@@ -30,6 +30,14 @@ func (cd *ConversionDelete) Where(ps ...predicate.Conversion) *ConversionDelete 
 	return cd
 }
 
+// WhereIf appends a list predicates to the ConversionDelete builder if b is true.
+func (cd *ConversionDelete) WhereIf(b bool, ps ...predicate.Conversion) *ConversionDelete {
+	if b {
+		cd.mutation.Where(ps...)
+	}
+	return cd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (cd *ConversionDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/migrate/entv2/conversion_query.go
+++ b/entc/integration/migrate/entv2/conversion_query.go
@@ -39,6 +39,14 @@ func (cq *ConversionQuery) Where(ps ...predicate.Conversion) *ConversionQuery {
 	return cq
 }
 
+// WhereIf adds a new predicates to the ConversionQuery builder if b is true.
+func (cq *ConversionQuery) WhereIf(b bool, ps ...predicate.Conversion) *ConversionQuery {
+	if b {
+		cq.predicates = append(cq.predicates, ps...)
+	}
+	return cq
+}
+
 // Limit adds a limit step to the query.
 func (cq *ConversionQuery) Limit(limit int) *ConversionQuery {
 	cq.limit = &limit

--- a/entc/integration/migrate/entv2/conversion_update.go
+++ b/entc/integration/migrate/entv2/conversion_update.go
@@ -31,6 +31,14 @@ func (cu *ConversionUpdate) Where(ps ...predicate.Conversion) *ConversionUpdate 
 	return cu
 }
 
+// WhereIf appends a list predicates to the ConversionUpdate builder if b is true.
+func (cu *ConversionUpdate) WhereIf(b bool, ps ...predicate.Conversion) *ConversionUpdate {
+	if b {
+		cu.mutation.Where(ps...)
+	}
+	return cu
+}
+
 // SetName sets the "name" field.
 func (cu *ConversionUpdate) SetName(s string) *ConversionUpdate {
 	cu.mutation.SetName(s)

--- a/entc/integration/migrate/entv2/customtype_delete.go
+++ b/entc/integration/migrate/entv2/customtype_delete.go
@@ -30,6 +30,14 @@ func (ctd *CustomTypeDelete) Where(ps ...predicate.CustomType) *CustomTypeDelete
 	return ctd
 }
 
+// WhereIf appends a list predicates to the CustomTypeDelete builder if b is true.
+func (ctd *CustomTypeDelete) WhereIf(b bool, ps ...predicate.CustomType) *CustomTypeDelete {
+	if b {
+		ctd.mutation.Where(ps...)
+	}
+	return ctd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (ctd *CustomTypeDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/migrate/entv2/customtype_query.go
+++ b/entc/integration/migrate/entv2/customtype_query.go
@@ -39,6 +39,14 @@ func (ctq *CustomTypeQuery) Where(ps ...predicate.CustomType) *CustomTypeQuery {
 	return ctq
 }
 
+// WhereIf adds a new predicates to the CustomTypeQuery builder if b is true.
+func (ctq *CustomTypeQuery) WhereIf(b bool, ps ...predicate.CustomType) *CustomTypeQuery {
+	if b {
+		ctq.predicates = append(ctq.predicates, ps...)
+	}
+	return ctq
+}
+
 // Limit adds a limit step to the query.
 func (ctq *CustomTypeQuery) Limit(limit int) *CustomTypeQuery {
 	ctq.limit = &limit

--- a/entc/integration/migrate/entv2/customtype_update.go
+++ b/entc/integration/migrate/entv2/customtype_update.go
@@ -31,6 +31,14 @@ func (ctu *CustomTypeUpdate) Where(ps ...predicate.CustomType) *CustomTypeUpdate
 	return ctu
 }
 
+// WhereIf appends a list predicates to the CustomTypeUpdate builder if b is true.
+func (ctu *CustomTypeUpdate) WhereIf(b bool, ps ...predicate.CustomType) *CustomTypeUpdate {
+	if b {
+		ctu.mutation.Where(ps...)
+	}
+	return ctu
+}
+
 // SetCustom sets the "custom" field.
 func (ctu *CustomTypeUpdate) SetCustom(s string) *CustomTypeUpdate {
 	ctu.mutation.SetCustom(s)

--- a/entc/integration/migrate/entv2/group_delete.go
+++ b/entc/integration/migrate/entv2/group_delete.go
@@ -30,6 +30,14 @@ func (gd *GroupDelete) Where(ps ...predicate.Group) *GroupDelete {
 	return gd
 }
 
+// WhereIf appends a list predicates to the GroupDelete builder if b is true.
+func (gd *GroupDelete) WhereIf(b bool, ps ...predicate.Group) *GroupDelete {
+	if b {
+		gd.mutation.Where(ps...)
+	}
+	return gd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (gd *GroupDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/migrate/entv2/group_query.go
+++ b/entc/integration/migrate/entv2/group_query.go
@@ -39,6 +39,14 @@ func (gq *GroupQuery) Where(ps ...predicate.Group) *GroupQuery {
 	return gq
 }
 
+// WhereIf adds a new predicates to the GroupQuery builder if b is true.
+func (gq *GroupQuery) WhereIf(b bool, ps ...predicate.Group) *GroupQuery {
+	if b {
+		gq.predicates = append(gq.predicates, ps...)
+	}
+	return gq
+}
+
 // Limit adds a limit step to the query.
 func (gq *GroupQuery) Limit(limit int) *GroupQuery {
 	gq.limit = &limit

--- a/entc/integration/migrate/entv2/group_update.go
+++ b/entc/integration/migrate/entv2/group_update.go
@@ -31,6 +31,14 @@ func (gu *GroupUpdate) Where(ps ...predicate.Group) *GroupUpdate {
 	return gu
 }
 
+// WhereIf appends a list predicates to the GroupUpdate builder if b is true.
+func (gu *GroupUpdate) WhereIf(b bool, ps ...predicate.Group) *GroupUpdate {
+	if b {
+		gu.mutation.Where(ps...)
+	}
+	return gu
+}
+
 // Mutation returns the GroupMutation object of the builder.
 func (gu *GroupUpdate) Mutation() *GroupMutation {
 	return gu.mutation

--- a/entc/integration/migrate/entv2/media_delete.go
+++ b/entc/integration/migrate/entv2/media_delete.go
@@ -30,6 +30,14 @@ func (md *MediaDelete) Where(ps ...predicate.Media) *MediaDelete {
 	return md
 }
 
+// WhereIf appends a list predicates to the MediaDelete builder if b is true.
+func (md *MediaDelete) WhereIf(b bool, ps ...predicate.Media) *MediaDelete {
+	if b {
+		md.mutation.Where(ps...)
+	}
+	return md
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (md *MediaDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/migrate/entv2/media_query.go
+++ b/entc/integration/migrate/entv2/media_query.go
@@ -39,6 +39,14 @@ func (mq *MediaQuery) Where(ps ...predicate.Media) *MediaQuery {
 	return mq
 }
 
+// WhereIf adds a new predicates to the MediaQuery builder if b is true.
+func (mq *MediaQuery) WhereIf(b bool, ps ...predicate.Media) *MediaQuery {
+	if b {
+		mq.predicates = append(mq.predicates, ps...)
+	}
+	return mq
+}
+
 // Limit adds a limit step to the query.
 func (mq *MediaQuery) Limit(limit int) *MediaQuery {
 	mq.limit = &limit

--- a/entc/integration/migrate/entv2/media_update.go
+++ b/entc/integration/migrate/entv2/media_update.go
@@ -31,6 +31,14 @@ func (mu *MediaUpdate) Where(ps ...predicate.Media) *MediaUpdate {
 	return mu
 }
 
+// WhereIf appends a list predicates to the MediaUpdate builder if b is true.
+func (mu *MediaUpdate) WhereIf(b bool, ps ...predicate.Media) *MediaUpdate {
+	if b {
+		mu.mutation.Where(ps...)
+	}
+	return mu
+}
+
 // SetSource sets the "source" field.
 func (mu *MediaUpdate) SetSource(s string) *MediaUpdate {
 	mu.mutation.SetSource(s)

--- a/entc/integration/migrate/entv2/pet_delete.go
+++ b/entc/integration/migrate/entv2/pet_delete.go
@@ -30,6 +30,14 @@ func (pd *PetDelete) Where(ps ...predicate.Pet) *PetDelete {
 	return pd
 }
 
+// WhereIf appends a list predicates to the PetDelete builder if b is true.
+func (pd *PetDelete) WhereIf(b bool, ps ...predicate.Pet) *PetDelete {
+	if b {
+		pd.mutation.Where(ps...)
+	}
+	return pd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (pd *PetDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/migrate/entv2/pet_query.go
+++ b/entc/integration/migrate/entv2/pet_query.go
@@ -43,6 +43,14 @@ func (pq *PetQuery) Where(ps ...predicate.Pet) *PetQuery {
 	return pq
 }
 
+// WhereIf adds a new predicates to the PetQuery builder if b is true.
+func (pq *PetQuery) WhereIf(b bool, ps ...predicate.Pet) *PetQuery {
+	if b {
+		pq.predicates = append(pq.predicates, ps...)
+	}
+	return pq
+}
+
 // Limit adds a limit step to the query.
 func (pq *PetQuery) Limit(limit int) *PetQuery {
 	pq.limit = &limit

--- a/entc/integration/migrate/entv2/pet_update.go
+++ b/entc/integration/migrate/entv2/pet_update.go
@@ -32,6 +32,14 @@ func (pu *PetUpdate) Where(ps ...predicate.Pet) *PetUpdate {
 	return pu
 }
 
+// WhereIf appends a list predicates to the PetUpdate builder if b is true.
+func (pu *PetUpdate) WhereIf(b bool, ps ...predicate.Pet) *PetUpdate {
+	if b {
+		pu.mutation.Where(ps...)
+	}
+	return pu
+}
+
 // SetOwnerID sets the "owner" edge to the User entity by ID.
 func (pu *PetUpdate) SetOwnerID(id int) *PetUpdate {
 	pu.mutation.SetOwnerID(id)

--- a/entc/integration/migrate/entv2/user_delete.go
+++ b/entc/integration/migrate/entv2/user_delete.go
@@ -30,6 +30,14 @@ func (ud *UserDelete) Where(ps ...predicate.User) *UserDelete {
 	return ud
 }
 
+// WhereIf appends a list predicates to the UserDelete builder if b is true.
+func (ud *UserDelete) WhereIf(b bool, ps ...predicate.User) *UserDelete {
+	if b {
+		ud.mutation.Where(ps...)
+	}
+	return ud
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (ud *UserDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/migrate/entv2/user_query.go
+++ b/entc/integration/migrate/entv2/user_query.go
@@ -46,6 +46,14 @@ func (uq *UserQuery) Where(ps ...predicate.User) *UserQuery {
 	return uq
 }
 
+// WhereIf adds a new predicates to the UserQuery builder if b is true.
+func (uq *UserQuery) WhereIf(b bool, ps ...predicate.User) *UserQuery {
+	if b {
+		uq.predicates = append(uq.predicates, ps...)
+	}
+	return uq
+}
+
 // Limit adds a limit step to the query.
 func (uq *UserQuery) Limit(limit int) *UserQuery {
 	uq.limit = &limit

--- a/entc/integration/migrate/entv2/user_update.go
+++ b/entc/integration/migrate/entv2/user_update.go
@@ -34,6 +34,14 @@ func (uu *UserUpdate) Where(ps ...predicate.User) *UserUpdate {
 	return uu
 }
 
+// WhereIf appends a list predicates to the UserUpdate builder if b is true.
+func (uu *UserUpdate) WhereIf(b bool, ps ...predicate.User) *UserUpdate {
+	if b {
+		uu.mutation.Where(ps...)
+	}
+	return uu
+}
+
 // SetMixedString sets the "mixed_string" field.
 func (uu *UserUpdate) SetMixedString(s string) *UserUpdate {
 	uu.mutation.SetMixedString(s)

--- a/entc/integration/multischema/ent/group_delete.go
+++ b/entc/integration/multischema/ent/group_delete.go
@@ -31,6 +31,14 @@ func (gd *GroupDelete) Where(ps ...predicate.Group) *GroupDelete {
 	return gd
 }
 
+// WhereIf appends a list predicates to the GroupDelete builder if b is true.
+func (gd *GroupDelete) WhereIf(b bool, ps ...predicate.Group) *GroupDelete {
+	if b {
+		gd.mutation.Where(ps...)
+	}
+	return gd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (gd *GroupDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/multischema/ent/group_query.go
+++ b/entc/integration/multischema/ent/group_query.go
@@ -45,6 +45,14 @@ func (gq *GroupQuery) Where(ps ...predicate.Group) *GroupQuery {
 	return gq
 }
 
+// WhereIf adds a new predicates to the GroupQuery builder if b is true.
+func (gq *GroupQuery) WhereIf(b bool, ps ...predicate.Group) *GroupQuery {
+	if b {
+		gq.predicates = append(gq.predicates, ps...)
+	}
+	return gq
+}
+
 // Limit adds a limit step to the query.
 func (gq *GroupQuery) Limit(limit int) *GroupQuery {
 	gq.limit = &limit

--- a/entc/integration/multischema/ent/group_update.go
+++ b/entc/integration/multischema/ent/group_update.go
@@ -33,6 +33,14 @@ func (gu *GroupUpdate) Where(ps ...predicate.Group) *GroupUpdate {
 	return gu
 }
 
+// WhereIf appends a list predicates to the GroupUpdate builder if b is true.
+func (gu *GroupUpdate) WhereIf(b bool, ps ...predicate.Group) *GroupUpdate {
+	if b {
+		gu.mutation.Where(ps...)
+	}
+	return gu
+}
+
 // SetName sets the "name" field.
 func (gu *GroupUpdate) SetName(s string) *GroupUpdate {
 	gu.mutation.SetName(s)

--- a/entc/integration/multischema/ent/pet_delete.go
+++ b/entc/integration/multischema/ent/pet_delete.go
@@ -31,6 +31,14 @@ func (pd *PetDelete) Where(ps ...predicate.Pet) *PetDelete {
 	return pd
 }
 
+// WhereIf appends a list predicates to the PetDelete builder if b is true.
+func (pd *PetDelete) WhereIf(b bool, ps ...predicate.Pet) *PetDelete {
+	if b {
+		pd.mutation.Where(ps...)
+	}
+	return pd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (pd *PetDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/multischema/ent/pet_query.go
+++ b/entc/integration/multischema/ent/pet_query.go
@@ -44,6 +44,14 @@ func (pq *PetQuery) Where(ps ...predicate.Pet) *PetQuery {
 	return pq
 }
 
+// WhereIf adds a new predicates to the PetQuery builder if b is true.
+func (pq *PetQuery) WhereIf(b bool, ps ...predicate.Pet) *PetQuery {
+	if b {
+		pq.predicates = append(pq.predicates, ps...)
+	}
+	return pq
+}
+
 // Limit adds a limit step to the query.
 func (pq *PetQuery) Limit(limit int) *PetQuery {
 	pq.limit = &limit

--- a/entc/integration/multischema/ent/pet_update.go
+++ b/entc/integration/multischema/ent/pet_update.go
@@ -33,6 +33,14 @@ func (pu *PetUpdate) Where(ps ...predicate.Pet) *PetUpdate {
 	return pu
 }
 
+// WhereIf appends a list predicates to the PetUpdate builder if b is true.
+func (pu *PetUpdate) WhereIf(b bool, ps ...predicate.Pet) *PetUpdate {
+	if b {
+		pu.mutation.Where(ps...)
+	}
+	return pu
+}
+
 // SetName sets the "name" field.
 func (pu *PetUpdate) SetName(s string) *PetUpdate {
 	pu.mutation.SetName(s)

--- a/entc/integration/multischema/ent/user_delete.go
+++ b/entc/integration/multischema/ent/user_delete.go
@@ -31,6 +31,14 @@ func (ud *UserDelete) Where(ps ...predicate.User) *UserDelete {
 	return ud
 }
 
+// WhereIf appends a list predicates to the UserDelete builder if b is true.
+func (ud *UserDelete) WhereIf(b bool, ps ...predicate.User) *UserDelete {
+	if b {
+		ud.mutation.Where(ps...)
+	}
+	return ud
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (ud *UserDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/multischema/ent/user_query.go
+++ b/entc/integration/multischema/ent/user_query.go
@@ -47,6 +47,14 @@ func (uq *UserQuery) Where(ps ...predicate.User) *UserQuery {
 	return uq
 }
 
+// WhereIf adds a new predicates to the UserQuery builder if b is true.
+func (uq *UserQuery) WhereIf(b bool, ps ...predicate.User) *UserQuery {
+	if b {
+		uq.predicates = append(uq.predicates, ps...)
+	}
+	return uq
+}
+
 // Limit adds a limit step to the query.
 func (uq *UserQuery) Limit(limit int) *UserQuery {
 	uq.limit = &limit

--- a/entc/integration/multischema/ent/user_update.go
+++ b/entc/integration/multischema/ent/user_update.go
@@ -34,6 +34,14 @@ func (uu *UserUpdate) Where(ps ...predicate.User) *UserUpdate {
 	return uu
 }
 
+// WhereIf appends a list predicates to the UserUpdate builder if b is true.
+func (uu *UserUpdate) WhereIf(b bool, ps ...predicate.User) *UserUpdate {
+	if b {
+		uu.mutation.Where(ps...)
+	}
+	return uu
+}
+
 // SetName sets the "name" field.
 func (uu *UserUpdate) SetName(s string) *UserUpdate {
 	uu.mutation.SetName(s)

--- a/entc/integration/privacy/ent/task_delete.go
+++ b/entc/integration/privacy/ent/task_delete.go
@@ -30,6 +30,14 @@ func (td *TaskDelete) Where(ps ...predicate.Task) *TaskDelete {
 	return td
 }
 
+// WhereIf appends a list predicates to the TaskDelete builder if b is true.
+func (td *TaskDelete) WhereIf(b bool, ps ...predicate.Task) *TaskDelete {
+	if b {
+		td.mutation.Where(ps...)
+	}
+	return td
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (td *TaskDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/privacy/ent/task_query.go
+++ b/entc/integration/privacy/ent/task_query.go
@@ -46,6 +46,14 @@ func (tq *TaskQuery) Where(ps ...predicate.Task) *TaskQuery {
 	return tq
 }
 
+// WhereIf adds a new predicates to the TaskQuery builder if b is true.
+func (tq *TaskQuery) WhereIf(b bool, ps ...predicate.Task) *TaskQuery {
+	if b {
+		tq.predicates = append(tq.predicates, ps...)
+	}
+	return tq
+}
+
 // Limit adds a limit step to the query.
 func (tq *TaskQuery) Limit(limit int) *TaskQuery {
 	tq.limit = &limit

--- a/entc/integration/privacy/ent/task_update.go
+++ b/entc/integration/privacy/ent/task_update.go
@@ -34,6 +34,14 @@ func (tu *TaskUpdate) Where(ps ...predicate.Task) *TaskUpdate {
 	return tu
 }
 
+// WhereIf appends a list predicates to the TaskUpdate builder if b is true.
+func (tu *TaskUpdate) WhereIf(b bool, ps ...predicate.Task) *TaskUpdate {
+	if b {
+		tu.mutation.Where(ps...)
+	}
+	return tu
+}
+
 // SetTitle sets the "title" field.
 func (tu *TaskUpdate) SetTitle(s string) *TaskUpdate {
 	tu.mutation.SetTitle(s)

--- a/entc/integration/privacy/ent/team_delete.go
+++ b/entc/integration/privacy/ent/team_delete.go
@@ -30,6 +30,14 @@ func (td *TeamDelete) Where(ps ...predicate.Team) *TeamDelete {
 	return td
 }
 
+// WhereIf appends a list predicates to the TeamDelete builder if b is true.
+func (td *TeamDelete) WhereIf(b bool, ps ...predicate.Team) *TeamDelete {
+	if b {
+		td.mutation.Where(ps...)
+	}
+	return td
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (td *TeamDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/privacy/ent/team_query.go
+++ b/entc/integration/privacy/ent/team_query.go
@@ -45,6 +45,14 @@ func (tq *TeamQuery) Where(ps ...predicate.Team) *TeamQuery {
 	return tq
 }
 
+// WhereIf adds a new predicates to the TeamQuery builder if b is true.
+func (tq *TeamQuery) WhereIf(b bool, ps ...predicate.Team) *TeamQuery {
+	if b {
+		tq.predicates = append(tq.predicates, ps...)
+	}
+	return tq
+}
+
 // Limit adds a limit step to the query.
 func (tq *TeamQuery) Limit(limit int) *TeamQuery {
 	tq.limit = &limit

--- a/entc/integration/privacy/ent/team_update.go
+++ b/entc/integration/privacy/ent/team_update.go
@@ -33,6 +33,14 @@ func (tu *TeamUpdate) Where(ps ...predicate.Team) *TeamUpdate {
 	return tu
 }
 
+// WhereIf appends a list predicates to the TeamUpdate builder if b is true.
+func (tu *TeamUpdate) WhereIf(b bool, ps ...predicate.Team) *TeamUpdate {
+	if b {
+		tu.mutation.Where(ps...)
+	}
+	return tu
+}
+
 // SetName sets the "name" field.
 func (tu *TeamUpdate) SetName(s string) *TeamUpdate {
 	tu.mutation.SetName(s)

--- a/entc/integration/privacy/ent/user_delete.go
+++ b/entc/integration/privacy/ent/user_delete.go
@@ -30,6 +30,14 @@ func (ud *UserDelete) Where(ps ...predicate.User) *UserDelete {
 	return ud
 }
 
+// WhereIf appends a list predicates to the UserDelete builder if b is true.
+func (ud *UserDelete) WhereIf(b bool, ps ...predicate.User) *UserDelete {
+	if b {
+		ud.mutation.Where(ps...)
+	}
+	return ud
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (ud *UserDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/privacy/ent/user_query.go
+++ b/entc/integration/privacy/ent/user_query.go
@@ -45,6 +45,14 @@ func (uq *UserQuery) Where(ps ...predicate.User) *UserQuery {
 	return uq
 }
 
+// WhereIf adds a new predicates to the UserQuery builder if b is true.
+func (uq *UserQuery) WhereIf(b bool, ps ...predicate.User) *UserQuery {
+	if b {
+		uq.predicates = append(uq.predicates, ps...)
+	}
+	return uq
+}
+
 // Limit adds a limit step to the query.
 func (uq *UserQuery) Limit(limit int) *UserQuery {
 	uq.limit = &limit

--- a/entc/integration/privacy/ent/user_update.go
+++ b/entc/integration/privacy/ent/user_update.go
@@ -33,6 +33,14 @@ func (uu *UserUpdate) Where(ps ...predicate.User) *UserUpdate {
 	return uu
 }
 
+// WhereIf appends a list predicates to the UserUpdate builder if b is true.
+func (uu *UserUpdate) WhereIf(b bool, ps ...predicate.User) *UserUpdate {
+	if b {
+		uu.mutation.Where(ps...)
+	}
+	return uu
+}
+
 // SetAge sets the "age" field.
 func (uu *UserUpdate) SetAge(u uint) *UserUpdate {
 	uu.mutation.ResetAge()

--- a/entc/integration/template/ent/group_delete.go
+++ b/entc/integration/template/ent/group_delete.go
@@ -30,6 +30,14 @@ func (gd *GroupDelete) Where(ps ...predicate.Group) *GroupDelete {
 	return gd
 }
 
+// WhereIf appends a list predicates to the GroupDelete builder if b is true.
+func (gd *GroupDelete) WhereIf(b bool, ps ...predicate.Group) *GroupDelete {
+	if b {
+		gd.mutation.Where(ps...)
+	}
+	return gd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (gd *GroupDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/template/ent/group_query.go
+++ b/entc/integration/template/ent/group_query.go
@@ -42,6 +42,14 @@ func (gq *GroupQuery) Where(ps ...predicate.Group) *GroupQuery {
 	return gq
 }
 
+// WhereIf adds a new predicates to the GroupQuery builder if b is true.
+func (gq *GroupQuery) WhereIf(b bool, ps ...predicate.Group) *GroupQuery {
+	if b {
+		gq.predicates = append(gq.predicates, ps...)
+	}
+	return gq
+}
+
 // Limit adds a limit step to the query.
 func (gq *GroupQuery) Limit(limit int) *GroupQuery {
 	gq.limit = &limit

--- a/entc/integration/template/ent/group_update.go
+++ b/entc/integration/template/ent/group_update.go
@@ -31,6 +31,14 @@ func (gu *GroupUpdate) Where(ps ...predicate.Group) *GroupUpdate {
 	return gu
 }
 
+// WhereIf appends a list predicates to the GroupUpdate builder if b is true.
+func (gu *GroupUpdate) WhereIf(b bool, ps ...predicate.Group) *GroupUpdate {
+	if b {
+		gu.mutation.Where(ps...)
+	}
+	return gu
+}
+
 // SetMaxUsers sets the "max_users" field.
 func (gu *GroupUpdate) SetMaxUsers(i int) *GroupUpdate {
 	gu.mutation.ResetMaxUsers()

--- a/entc/integration/template/ent/pet_delete.go
+++ b/entc/integration/template/ent/pet_delete.go
@@ -30,6 +30,14 @@ func (pd *PetDelete) Where(ps ...predicate.Pet) *PetDelete {
 	return pd
 }
 
+// WhereIf appends a list predicates to the PetDelete builder if b is true.
+func (pd *PetDelete) WhereIf(b bool, ps ...predicate.Pet) *PetDelete {
+	if b {
+		pd.mutation.Where(ps...)
+	}
+	return pd
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (pd *PetDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/template/ent/pet_query.go
+++ b/entc/integration/template/ent/pet_query.go
@@ -46,6 +46,14 @@ func (pq *PetQuery) Where(ps ...predicate.Pet) *PetQuery {
 	return pq
 }
 
+// WhereIf adds a new predicates to the PetQuery builder if b is true.
+func (pq *PetQuery) WhereIf(b bool, ps ...predicate.Pet) *PetQuery {
+	if b {
+		pq.predicates = append(pq.predicates, ps...)
+	}
+	return pq
+}
+
 // Limit adds a limit step to the query.
 func (pq *PetQuery) Limit(limit int) *PetQuery {
 	pq.limit = &limit

--- a/entc/integration/template/ent/pet_update.go
+++ b/entc/integration/template/ent/pet_update.go
@@ -33,6 +33,14 @@ func (pu *PetUpdate) Where(ps ...predicate.Pet) *PetUpdate {
 	return pu
 }
 
+// WhereIf appends a list predicates to the PetUpdate builder if b is true.
+func (pu *PetUpdate) WhereIf(b bool, ps ...predicate.Pet) *PetUpdate {
+	if b {
+		pu.mutation.Where(ps...)
+	}
+	return pu
+}
+
 // SetAge sets the "age" field.
 func (pu *PetUpdate) SetAge(i int) *PetUpdate {
 	pu.mutation.ResetAge()

--- a/entc/integration/template/ent/user_delete.go
+++ b/entc/integration/template/ent/user_delete.go
@@ -30,6 +30,14 @@ func (ud *UserDelete) Where(ps ...predicate.User) *UserDelete {
 	return ud
 }
 
+// WhereIf appends a list predicates to the UserDelete builder if b is true.
+func (ud *UserDelete) WhereIf(b bool, ps ...predicate.User) *UserDelete {
+	if b {
+		ud.mutation.Where(ps...)
+	}
+	return ud
+}
+
 // Exec executes the deletion query and returns how many vertices were deleted.
 func (ud *UserDelete) Exec(ctx context.Context) (int, error) {
 	var (

--- a/entc/integration/template/ent/user_query.go
+++ b/entc/integration/template/ent/user_query.go
@@ -47,6 +47,14 @@ func (uq *UserQuery) Where(ps ...predicate.User) *UserQuery {
 	return uq
 }
 
+// WhereIf adds a new predicates to the UserQuery builder if b is true.
+func (uq *UserQuery) WhereIf(b bool, ps ...predicate.User) *UserQuery {
+	if b {
+		uq.predicates = append(uq.predicates, ps...)
+	}
+	return uq
+}
+
 // Limit adds a limit step to the query.
 func (uq *UserQuery) Limit(limit int) *UserQuery {
 	uq.limit = &limit

--- a/entc/integration/template/ent/user_update.go
+++ b/entc/integration/template/ent/user_update.go
@@ -32,6 +32,14 @@ func (uu *UserUpdate) Where(ps ...predicate.User) *UserUpdate {
 	return uu
 }
 
+// WhereIf appends a list predicates to the UserUpdate builder if b is true.
+func (uu *UserUpdate) WhereIf(b bool, ps ...predicate.User) *UserUpdate {
+	if b {
+		uu.mutation.Where(ps...)
+	}
+	return uu
+}
+
 // SetName sets the "name" field.
 func (uu *UserUpdate) SetName(s string) *UserUpdate {
 	uu.mutation.SetName(s)


### PR DESCRIPTION
Usually, we are writing some services may facing the conditional query, such as:
```go
query := s.client.UserAccount.Query().Where(useraccount.TenantId(1))
if withPositiveOnly {
	query.Where(useraccount.MoneyGT(0))
}
users, err := query.All(s.ctx)
```
It's very inconvenient, in many cases with more then three conditions.
It may be graceful, if it can be wrote like this:
```go
users, err := s.client.UserAccount.Query().Where(useraccount.TenantId(1)).WhereIf(withPositiveOnly, useraccount.MoneyGT(0)).All(s.ctx)
```
It's very clear and concise.
Think you.