### PR TITLE
fix: update only/onlyID comments

### DIFF
--- a/entc/gen/template/builder/query.tmpl
+++ b/entc/gen/template/builder/query.tmpl
@@ -144,7 +144,7 @@ func ({{ $receiver }} *{{ $builder }}) FirstIDX(ctx context.Context) {{ $.ID.Typ
 }
 
 // Only returns a single {{ $.Name }} entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when more than exactly one {{ $.Name }} entity is found.
+// Returns a *NotSingularError when more than one {{ $.Name }} entity is found.
 // Returns a *NotFoundError when no {{ $.Name }} entities are found.
 func ({{ $receiver }} *{{ $builder }}) Only(ctx context.Context) (*{{ $.Name }}, error) {
 	nodes, err := {{ $receiver }}.Limit(2).All(ctx)

--- a/entc/gen/template/builder/query.tmpl
+++ b/entc/gen/template/builder/query.tmpl
@@ -171,7 +171,7 @@ func ({{ $receiver }} *{{ $builder }}) OnlyX(ctx context.Context) *{{ $.Name }} 
 }
 
 // OnlyID is like Only, but returns the only {{ $.Name }} ID in the query.
-// Returns a *NotSingularError when more than exactly one {{ $.Name }} ID is found.
+// Returns a *NotSingularError when more than one {{ $.Name }} ID is found.
 // Returns a *NotFoundError when no entities are found.
 func ({{ $receiver }} *{{ $builder }}) OnlyID(ctx context.Context) (id {{ $.ID.Type }}, err error) {
 	var ids []{{ $.ID.Type }}

--- a/entc/gen/template/builder/query.tmpl
+++ b/entc/gen/template/builder/query.tmpl
@@ -144,7 +144,7 @@ func ({{ $receiver }} *{{ $builder }}) FirstIDX(ctx context.Context) {{ $.ID.Typ
 }
 
 // Only returns a single {{ $.Name }} entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one {{ $.Name }} entity is not found.
+// Returns a *NotSingularError when more than exactly one {{ $.Name }} entity is found.
 // Returns a *NotFoundError when no {{ $.Name }} entities are found.
 func ({{ $receiver }} *{{ $builder }}) Only(ctx context.Context) (*{{ $.Name }}, error) {
 	nodes, err := {{ $receiver }}.Limit(2).All(ctx)
@@ -171,7 +171,7 @@ func ({{ $receiver }} *{{ $builder }}) OnlyX(ctx context.Context) *{{ $.Name }} 
 }
 
 // OnlyID is like Only, but returns the only {{ $.Name }} ID in the query.
-// Returns a *NotSingularError when exactly one {{ $.Name }} ID is not found.
+// Returns a *NotSingularError when more than exactly one {{ $.Name }} ID is found.
 // Returns a *NotFoundError when no entities are found.
 func ({{ $receiver }} *{{ $builder }}) OnlyID(ctx context.Context) (id {{ $.ID.Type }}, err error) {
 	var ids []{{ $.ID.Type }}

--- a/entc/integration/cascadelete/ent/comment_query.go
+++ b/entc/integration/cascadelete/ent/comment_query.go
@@ -135,7 +135,7 @@ func (cq *CommentQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Comment entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Comment entity is not found.
+// Returns a *NotSingularError when more than one Comment entity is found.
 // Returns a *NotFoundError when no Comment entities are found.
 func (cq *CommentQuery) Only(ctx context.Context) (*Comment, error) {
 	nodes, err := cq.Limit(2).All(ctx)
@@ -162,7 +162,7 @@ func (cq *CommentQuery) OnlyX(ctx context.Context) *Comment {
 }
 
 // OnlyID is like Only, but returns the only Comment ID in the query.
-// Returns a *NotSingularError when exactly one Comment ID is not found.
+// Returns a *NotSingularError when more than one Comment ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (cq *CommentQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/cascadelete/ent/post_query.go
+++ b/entc/integration/cascadelete/ent/post_query.go
@@ -160,7 +160,7 @@ func (pq *PostQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Post entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Post entity is not found.
+// Returns a *NotSingularError when more than one Post entity is found.
 // Returns a *NotFoundError when no Post entities are found.
 func (pq *PostQuery) Only(ctx context.Context) (*Post, error) {
 	nodes, err := pq.Limit(2).All(ctx)
@@ -187,7 +187,7 @@ func (pq *PostQuery) OnlyX(ctx context.Context) *Post {
 }
 
 // OnlyID is like Only, but returns the only Post ID in the query.
-// Returns a *NotSingularError when exactly one Post ID is not found.
+// Returns a *NotSingularError when more than one Post ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (pq *PostQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/cascadelete/ent/user_query.go
+++ b/entc/integration/cascadelete/ent/user_query.go
@@ -136,7 +136,7 @@ func (uq *UserQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single User entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one User entity is not found.
+// Returns a *NotSingularError when more than one User entity is found.
 // Returns a *NotFoundError when no User entities are found.
 func (uq *UserQuery) Only(ctx context.Context) (*User, error) {
 	nodes, err := uq.Limit(2).All(ctx)
@@ -163,7 +163,7 @@ func (uq *UserQuery) OnlyX(ctx context.Context) *User {
 }
 
 // OnlyID is like Only, but returns the only User ID in the query.
-// Returns a *NotSingularError when exactly one User ID is not found.
+// Returns a *NotSingularError when more than one User ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (uq *UserQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/config/ent/user_query.go
+++ b/entc/integration/config/ent/user_query.go
@@ -110,7 +110,7 @@ func (uq *UserQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single User entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one User entity is not found.
+// Returns a *NotSingularError when more than one User entity is found.
 // Returns a *NotFoundError when no User entities are found.
 func (uq *UserQuery) Only(ctx context.Context) (*User, error) {
 	nodes, err := uq.Limit(2).All(ctx)
@@ -137,7 +137,7 @@ func (uq *UserQuery) OnlyX(ctx context.Context) *User {
 }
 
 // OnlyID is like Only, but returns the only User ID in the query.
-// Returns a *NotSingularError when exactly one User ID is not found.
+// Returns a *NotSingularError when more than one User ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (uq *UserQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/customid/ent/blob_query.go
+++ b/entc/integration/customid/ent/blob_query.go
@@ -160,7 +160,7 @@ func (bq *BlobQuery) FirstIDX(ctx context.Context) uuid.UUID {
 }
 
 // Only returns a single Blob entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Blob entity is not found.
+// Returns a *NotSingularError when more than one Blob entity is found.
 // Returns a *NotFoundError when no Blob entities are found.
 func (bq *BlobQuery) Only(ctx context.Context) (*Blob, error) {
 	nodes, err := bq.Limit(2).All(ctx)
@@ -187,7 +187,7 @@ func (bq *BlobQuery) OnlyX(ctx context.Context) *Blob {
 }
 
 // OnlyID is like Only, but returns the only Blob ID in the query.
-// Returns a *NotSingularError when exactly one Blob ID is not found.
+// Returns a *NotSingularError when more than one Blob ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (bq *BlobQuery) OnlyID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID

--- a/entc/integration/customid/ent/car_query.go
+++ b/entc/integration/customid/ent/car_query.go
@@ -136,7 +136,7 @@ func (cq *CarQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Car entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Car entity is not found.
+// Returns a *NotSingularError when more than one Car entity is found.
 // Returns a *NotFoundError when no Car entities are found.
 func (cq *CarQuery) Only(ctx context.Context) (*Car, error) {
 	nodes, err := cq.Limit(2).All(ctx)
@@ -163,7 +163,7 @@ func (cq *CarQuery) OnlyX(ctx context.Context) *Car {
 }
 
 // OnlyID is like Only, but returns the only Car ID in the query.
-// Returns a *NotSingularError when exactly one Car ID is not found.
+// Returns a *NotSingularError when more than one Car ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (cq *CarQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/customid/ent/device_query.go
+++ b/entc/integration/customid/ent/device_query.go
@@ -161,7 +161,7 @@ func (dq *DeviceQuery) FirstIDX(ctx context.Context) schema.ID {
 }
 
 // Only returns a single Device entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Device entity is not found.
+// Returns a *NotSingularError when more than one Device entity is found.
 // Returns a *NotFoundError when no Device entities are found.
 func (dq *DeviceQuery) Only(ctx context.Context) (*Device, error) {
 	nodes, err := dq.Limit(2).All(ctx)
@@ -188,7 +188,7 @@ func (dq *DeviceQuery) OnlyX(ctx context.Context) *Device {
 }
 
 // OnlyID is like Only, but returns the only Device ID in the query.
-// Returns a *NotSingularError when exactly one Device ID is not found.
+// Returns a *NotSingularError when more than one Device ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (dq *DeviceQuery) OnlyID(ctx context.Context) (id schema.ID, err error) {
 	var ids []schema.ID

--- a/entc/integration/customid/ent/doc_query.go
+++ b/entc/integration/customid/ent/doc_query.go
@@ -160,7 +160,7 @@ func (dq *DocQuery) FirstIDX(ctx context.Context) schema.DocID {
 }
 
 // Only returns a single Doc entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Doc entity is not found.
+// Returns a *NotSingularError when more than one Doc entity is found.
 // Returns a *NotFoundError when no Doc entities are found.
 func (dq *DocQuery) Only(ctx context.Context) (*Doc, error) {
 	nodes, err := dq.Limit(2).All(ctx)
@@ -187,7 +187,7 @@ func (dq *DocQuery) OnlyX(ctx context.Context) *Doc {
 }
 
 // OnlyID is like Only, but returns the only Doc ID in the query.
-// Returns a *NotSingularError when exactly one Doc ID is not found.
+// Returns a *NotSingularError when more than one Doc ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (dq *DocQuery) OnlyID(ctx context.Context) (id schema.DocID, err error) {
 	var ids []schema.DocID

--- a/entc/integration/customid/ent/group_query.go
+++ b/entc/integration/customid/ent/group_query.go
@@ -136,7 +136,7 @@ func (gq *GroupQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Group entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Group entity is not found.
+// Returns a *NotSingularError when more than one Group entity is found.
 // Returns a *NotFoundError when no Group entities are found.
 func (gq *GroupQuery) Only(ctx context.Context) (*Group, error) {
 	nodes, err := gq.Limit(2).All(ctx)
@@ -163,7 +163,7 @@ func (gq *GroupQuery) OnlyX(ctx context.Context) *Group {
 }
 
 // OnlyID is like Only, but returns the only Group ID in the query.
-// Returns a *NotSingularError when exactly one Group ID is not found.
+// Returns a *NotSingularError when more than one Group ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (gq *GroupQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/customid/ent/mixinid_query.go
+++ b/entc/integration/customid/ent/mixinid_query.go
@@ -111,7 +111,7 @@ func (miq *MixinIDQuery) FirstIDX(ctx context.Context) uuid.UUID {
 }
 
 // Only returns a single MixinID entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one MixinID entity is not found.
+// Returns a *NotSingularError when more than one MixinID entity is found.
 // Returns a *NotFoundError when no MixinID entities are found.
 func (miq *MixinIDQuery) Only(ctx context.Context) (*MixinID, error) {
 	nodes, err := miq.Limit(2).All(ctx)
@@ -138,7 +138,7 @@ func (miq *MixinIDQuery) OnlyX(ctx context.Context) *MixinID {
 }
 
 // OnlyID is like Only, but returns the only MixinID ID in the query.
-// Returns a *NotSingularError when exactly one MixinID ID is not found.
+// Returns a *NotSingularError when more than one MixinID ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (miq *MixinIDQuery) OnlyID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID

--- a/entc/integration/customid/ent/note_query.go
+++ b/entc/integration/customid/ent/note_query.go
@@ -160,7 +160,7 @@ func (nq *NoteQuery) FirstIDX(ctx context.Context) schema.NoteID {
 }
 
 // Only returns a single Note entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Note entity is not found.
+// Returns a *NotSingularError when more than one Note entity is found.
 // Returns a *NotFoundError when no Note entities are found.
 func (nq *NoteQuery) Only(ctx context.Context) (*Note, error) {
 	nodes, err := nq.Limit(2).All(ctx)
@@ -187,7 +187,7 @@ func (nq *NoteQuery) OnlyX(ctx context.Context) *Note {
 }
 
 // OnlyID is like Only, but returns the only Note ID in the query.
-// Returns a *NotSingularError when exactly one Note ID is not found.
+// Returns a *NotSingularError when more than one Note ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (nq *NoteQuery) OnlyID(ctx context.Context) (id schema.NoteID, err error) {
 	var ids []schema.NoteID

--- a/entc/integration/customid/ent/pet_query.go
+++ b/entc/integration/customid/ent/pet_query.go
@@ -207,7 +207,7 @@ func (pq *PetQuery) FirstIDX(ctx context.Context) string {
 }
 
 // Only returns a single Pet entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Pet entity is not found.
+// Returns a *NotSingularError when more than one Pet entity is found.
 // Returns a *NotFoundError when no Pet entities are found.
 func (pq *PetQuery) Only(ctx context.Context) (*Pet, error) {
 	nodes, err := pq.Limit(2).All(ctx)
@@ -234,7 +234,7 @@ func (pq *PetQuery) OnlyX(ctx context.Context) *Pet {
 }
 
 // OnlyID is like Only, but returns the only Pet ID in the query.
-// Returns a *NotSingularError when exactly one Pet ID is not found.
+// Returns a *NotSingularError when more than one Pet ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (pq *PetQuery) OnlyID(ctx context.Context) (id string, err error) {
 	var ids []string

--- a/entc/integration/customid/ent/session_query.go
+++ b/entc/integration/customid/ent/session_query.go
@@ -137,7 +137,7 @@ func (sq *SessionQuery) FirstIDX(ctx context.Context) schema.ID {
 }
 
 // Only returns a single Session entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Session entity is not found.
+// Returns a *NotSingularError when more than one Session entity is found.
 // Returns a *NotFoundError when no Session entities are found.
 func (sq *SessionQuery) Only(ctx context.Context) (*Session, error) {
 	nodes, err := sq.Limit(2).All(ctx)
@@ -164,7 +164,7 @@ func (sq *SessionQuery) OnlyX(ctx context.Context) *Session {
 }
 
 // OnlyID is like Only, but returns the only Session ID in the query.
-// Returns a *NotSingularError when exactly one Session ID is not found.
+// Returns a *NotSingularError when more than one Session ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (sq *SessionQuery) OnlyID(ctx context.Context) (id schema.ID, err error) {
 	var ids []schema.ID

--- a/entc/integration/customid/ent/user_query.go
+++ b/entc/integration/customid/ent/user_query.go
@@ -207,7 +207,7 @@ func (uq *UserQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single User entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one User entity is not found.
+// Returns a *NotSingularError when more than one User entity is found.
 // Returns a *NotFoundError when no User entities are found.
 func (uq *UserQuery) Only(ctx context.Context) (*User, error) {
 	nodes, err := uq.Limit(2).All(ctx)
@@ -234,7 +234,7 @@ func (uq *UserQuery) OnlyX(ctx context.Context) *User {
 }
 
 // OnlyID is like Only, but returns the only User ID in the query.
-// Returns a *NotSingularError when exactly one User ID is not found.
+// Returns a *NotSingularError when more than one User ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (uq *UserQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/edgefield/ent/car_query.go
+++ b/entc/integration/edgefield/ent/car_query.go
@@ -137,7 +137,7 @@ func (cq *CarQuery) FirstIDX(ctx context.Context) uuid.UUID {
 }
 
 // Only returns a single Car entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Car entity is not found.
+// Returns a *NotSingularError when more than one Car entity is found.
 // Returns a *NotFoundError when no Car entities are found.
 func (cq *CarQuery) Only(ctx context.Context) (*Car, error) {
 	nodes, err := cq.Limit(2).All(ctx)
@@ -164,7 +164,7 @@ func (cq *CarQuery) OnlyX(ctx context.Context) *Car {
 }
 
 // OnlyID is like Only, but returns the only Car ID in the query.
-// Returns a *NotSingularError when exactly one Car ID is not found.
+// Returns a *NotSingularError when more than one Car ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (cq *CarQuery) OnlyID(ctx context.Context) (id uuid.UUID, err error) {
 	var ids []uuid.UUID

--- a/entc/integration/edgefield/ent/card_query.go
+++ b/entc/integration/edgefield/ent/card_query.go
@@ -135,7 +135,7 @@ func (cq *CardQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Card entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Card entity is not found.
+// Returns a *NotSingularError when more than one Card entity is found.
 // Returns a *NotFoundError when no Card entities are found.
 func (cq *CardQuery) Only(ctx context.Context) (*Card, error) {
 	nodes, err := cq.Limit(2).All(ctx)
@@ -162,7 +162,7 @@ func (cq *CardQuery) OnlyX(ctx context.Context) *Card {
 }
 
 // OnlyID is like Only, but returns the only Card ID in the query.
-// Returns a *NotSingularError when exactly one Card ID is not found.
+// Returns a *NotSingularError when more than one Card ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (cq *CardQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/edgefield/ent/info_query.go
+++ b/entc/integration/edgefield/ent/info_query.go
@@ -135,7 +135,7 @@ func (iq *InfoQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Info entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Info entity is not found.
+// Returns a *NotSingularError when more than one Info entity is found.
 // Returns a *NotFoundError when no Info entities are found.
 func (iq *InfoQuery) Only(ctx context.Context) (*Info, error) {
 	nodes, err := iq.Limit(2).All(ctx)
@@ -162,7 +162,7 @@ func (iq *InfoQuery) OnlyX(ctx context.Context) *Info {
 }
 
 // OnlyID is like Only, but returns the only Info ID in the query.
-// Returns a *NotSingularError when exactly one Info ID is not found.
+// Returns a *NotSingularError when more than one Info ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (iq *InfoQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/edgefield/ent/metadata_query.go
+++ b/entc/integration/edgefield/ent/metadata_query.go
@@ -182,7 +182,7 @@ func (mq *MetadataQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Metadata entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Metadata entity is not found.
+// Returns a *NotSingularError when more than one Metadata entity is found.
 // Returns a *NotFoundError when no Metadata entities are found.
 func (mq *MetadataQuery) Only(ctx context.Context) (*Metadata, error) {
 	nodes, err := mq.Limit(2).All(ctx)
@@ -209,7 +209,7 @@ func (mq *MetadataQuery) OnlyX(ctx context.Context) *Metadata {
 }
 
 // OnlyID is like Only, but returns the only Metadata ID in the query.
-// Returns a *NotSingularError when exactly one Metadata ID is not found.
+// Returns a *NotSingularError when more than one Metadata ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (mq *MetadataQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/edgefield/ent/node_query.go
+++ b/entc/integration/edgefield/ent/node_query.go
@@ -158,7 +158,7 @@ func (nq *NodeQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Node entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Node entity is not found.
+// Returns a *NotSingularError when more than one Node entity is found.
 // Returns a *NotFoundError when no Node entities are found.
 func (nq *NodeQuery) Only(ctx context.Context) (*Node, error) {
 	nodes, err := nq.Limit(2).All(ctx)
@@ -185,7 +185,7 @@ func (nq *NodeQuery) OnlyX(ctx context.Context) *Node {
 }
 
 // OnlyID is like Only, but returns the only Node ID in the query.
-// Returns a *NotSingularError when exactly one Node ID is not found.
+// Returns a *NotSingularError when more than one Node ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (nq *NodeQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/edgefield/ent/pet_query.go
+++ b/entc/integration/edgefield/ent/pet_query.go
@@ -135,7 +135,7 @@ func (pq *PetQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Pet entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Pet entity is not found.
+// Returns a *NotSingularError when more than one Pet entity is found.
 // Returns a *NotFoundError when no Pet entities are found.
 func (pq *PetQuery) Only(ctx context.Context) (*Pet, error) {
 	nodes, err := pq.Limit(2).All(ctx)
@@ -162,7 +162,7 @@ func (pq *PetQuery) OnlyX(ctx context.Context) *Pet {
 }
 
 // OnlyID is like Only, but returns the only Pet ID in the query.
-// Returns a *NotSingularError when exactly one Pet ID is not found.
+// Returns a *NotSingularError when more than one Pet ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (pq *PetQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/edgefield/ent/post_query.go
+++ b/entc/integration/edgefield/ent/post_query.go
@@ -135,7 +135,7 @@ func (pq *PostQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Post entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Post entity is not found.
+// Returns a *NotSingularError when more than one Post entity is found.
 // Returns a *NotFoundError when no Post entities are found.
 func (pq *PostQuery) Only(ctx context.Context) (*Post, error) {
 	nodes, err := pq.Limit(2).All(ctx)
@@ -162,7 +162,7 @@ func (pq *PostQuery) OnlyX(ctx context.Context) *Post {
 }
 
 // OnlyID is like Only, but returns the only Post ID in the query.
-// Returns a *NotSingularError when exactly one Post ID is not found.
+// Returns a *NotSingularError when more than one Post ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (pq *PostQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/edgefield/ent/rental_query.go
+++ b/entc/integration/edgefield/ent/rental_query.go
@@ -160,7 +160,7 @@ func (rq *RentalQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Rental entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Rental entity is not found.
+// Returns a *NotSingularError when more than one Rental entity is found.
 // Returns a *NotFoundError when no Rental entities are found.
 func (rq *RentalQuery) Only(ctx context.Context) (*Rental, error) {
 	nodes, err := rq.Limit(2).All(ctx)
@@ -187,7 +187,7 @@ func (rq *RentalQuery) OnlyX(ctx context.Context) *Rental {
 }
 
 // OnlyID is like Only, but returns the only Rental ID in the query.
-// Returns a *NotSingularError when exactly one Rental ID is not found.
+// Returns a *NotSingularError when more than one Rental ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (rq *RentalQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/edgefield/ent/user_query.go
+++ b/entc/integration/edgefield/ent/user_query.go
@@ -301,7 +301,7 @@ func (uq *UserQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single User entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one User entity is not found.
+// Returns a *NotSingularError when more than one User entity is found.
 // Returns a *NotFoundError when no User entities are found.
 func (uq *UserQuery) Only(ctx context.Context) (*User, error) {
 	nodes, err := uq.Limit(2).All(ctx)
@@ -328,7 +328,7 @@ func (uq *UserQuery) OnlyX(ctx context.Context) *User {
 }
 
 // OnlyID is like Only, but returns the only User ID in the query.
-// Returns a *NotSingularError when exactly one User ID is not found.
+// Returns a *NotSingularError when more than one User ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (uq *UserQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/ent/card_query.go
+++ b/entc/integration/ent/card_query.go
@@ -163,7 +163,7 @@ func (cq *CardQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Card entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Card entity is not found.
+// Returns a *NotSingularError when more than one Card entity is found.
 // Returns a *NotFoundError when no Card entities are found.
 func (cq *CardQuery) Only(ctx context.Context) (*Card, error) {
 	nodes, err := cq.Limit(2).All(ctx)
@@ -190,7 +190,7 @@ func (cq *CardQuery) OnlyX(ctx context.Context) *Card {
 }
 
 // OnlyID is like Only, but returns the only Card ID in the query.
-// Returns a *NotSingularError when exactly one Card ID is not found.
+// Returns a *NotSingularError when more than one Card ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (cq *CardQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/ent/comment_query.go
+++ b/entc/integration/ent/comment_query.go
@@ -112,7 +112,7 @@ func (cq *CommentQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Comment entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Comment entity is not found.
+// Returns a *NotSingularError when more than one Comment entity is found.
 // Returns a *NotFoundError when no Comment entities are found.
 func (cq *CommentQuery) Only(ctx context.Context) (*Comment, error) {
 	nodes, err := cq.Limit(2).All(ctx)
@@ -139,7 +139,7 @@ func (cq *CommentQuery) OnlyX(ctx context.Context) *Comment {
 }
 
 // OnlyID is like Only, but returns the only Comment ID in the query.
-// Returns a *NotSingularError when exactly one Comment ID is not found.
+// Returns a *NotSingularError when more than one Comment ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (cq *CommentQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/ent/fieldtype_query.go
+++ b/entc/integration/ent/fieldtype_query.go
@@ -113,7 +113,7 @@ func (ftq *FieldTypeQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single FieldType entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one FieldType entity is not found.
+// Returns a *NotSingularError when more than one FieldType entity is found.
 // Returns a *NotFoundError when no FieldType entities are found.
 func (ftq *FieldTypeQuery) Only(ctx context.Context) (*FieldType, error) {
 	nodes, err := ftq.Limit(2).All(ctx)
@@ -140,7 +140,7 @@ func (ftq *FieldTypeQuery) OnlyX(ctx context.Context) *FieldType {
 }
 
 // OnlyID is like Only, but returns the only FieldType ID in the query.
-// Returns a *NotSingularError when exactly one FieldType ID is not found.
+// Returns a *NotSingularError when more than one FieldType ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (ftq *FieldTypeQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/ent/file_query.go
+++ b/entc/integration/ent/file_query.go
@@ -187,7 +187,7 @@ func (fq *FileQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single File entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one File entity is not found.
+// Returns a *NotSingularError when more than one File entity is found.
 // Returns a *NotFoundError when no File entities are found.
 func (fq *FileQuery) Only(ctx context.Context) (*File, error) {
 	nodes, err := fq.Limit(2).All(ctx)
@@ -214,7 +214,7 @@ func (fq *FileQuery) OnlyX(ctx context.Context) *File {
 }
 
 // OnlyID is like Only, but returns the only File ID in the query.
-// Returns a *NotSingularError when exactly one File ID is not found.
+// Returns a *NotSingularError when more than one File ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (fq *FileQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/ent/filetype_query.go
+++ b/entc/integration/ent/filetype_query.go
@@ -138,7 +138,7 @@ func (ftq *FileTypeQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single FileType entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one FileType entity is not found.
+// Returns a *NotSingularError when more than one FileType entity is found.
 // Returns a *NotFoundError when no FileType entities are found.
 func (ftq *FileTypeQuery) Only(ctx context.Context) (*FileType, error) {
 	nodes, err := ftq.Limit(2).All(ctx)
@@ -165,7 +165,7 @@ func (ftq *FileTypeQuery) OnlyX(ctx context.Context) *FileType {
 }
 
 // OnlyID is like Only, but returns the only FileType ID in the query.
-// Returns a *NotSingularError when exactly one FileType ID is not found.
+// Returns a *NotSingularError when more than one FileType ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (ftq *FileTypeQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/ent/goods_query.go
+++ b/entc/integration/ent/goods_query.go
@@ -112,7 +112,7 @@ func (gq *GoodsQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Goods entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Goods entity is not found.
+// Returns a *NotSingularError when more than one Goods entity is found.
 // Returns a *NotFoundError when no Goods entities are found.
 func (gq *GoodsQuery) Only(ctx context.Context) (*Goods, error) {
 	nodes, err := gq.Limit(2).All(ctx)
@@ -139,7 +139,7 @@ func (gq *GoodsQuery) OnlyX(ctx context.Context) *Goods {
 }
 
 // OnlyID is like Only, but returns the only Goods ID in the query.
-// Returns a *NotSingularError when exactly one Goods ID is not found.
+// Returns a *NotSingularError when more than one Goods ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (gq *GoodsQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/ent/group_query.go
+++ b/entc/integration/ent/group_query.go
@@ -210,7 +210,7 @@ func (gq *GroupQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Group entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Group entity is not found.
+// Returns a *NotSingularError when more than one Group entity is found.
 // Returns a *NotFoundError when no Group entities are found.
 func (gq *GroupQuery) Only(ctx context.Context) (*Group, error) {
 	nodes, err := gq.Limit(2).All(ctx)
@@ -237,7 +237,7 @@ func (gq *GroupQuery) OnlyX(ctx context.Context) *Group {
 }
 
 // OnlyID is like Only, but returns the only Group ID in the query.
-// Returns a *NotSingularError when exactly one Group ID is not found.
+// Returns a *NotSingularError when more than one Group ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (gq *GroupQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/ent/groupinfo_query.go
+++ b/entc/integration/ent/groupinfo_query.go
@@ -138,7 +138,7 @@ func (giq *GroupInfoQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single GroupInfo entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one GroupInfo entity is not found.
+// Returns a *NotSingularError when more than one GroupInfo entity is found.
 // Returns a *NotFoundError when no GroupInfo entities are found.
 func (giq *GroupInfoQuery) Only(ctx context.Context) (*GroupInfo, error) {
 	nodes, err := giq.Limit(2).All(ctx)
@@ -165,7 +165,7 @@ func (giq *GroupInfoQuery) OnlyX(ctx context.Context) *GroupInfo {
 }
 
 // OnlyID is like Only, but returns the only GroupInfo ID in the query.
-// Returns a *NotSingularError when exactly one GroupInfo ID is not found.
+// Returns a *NotSingularError when more than one GroupInfo ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (giq *GroupInfoQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/ent/item_query.go
+++ b/entc/integration/ent/item_query.go
@@ -112,7 +112,7 @@ func (iq *ItemQuery) FirstIDX(ctx context.Context) string {
 }
 
 // Only returns a single Item entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Item entity is not found.
+// Returns a *NotSingularError when more than one Item entity is found.
 // Returns a *NotFoundError when no Item entities are found.
 func (iq *ItemQuery) Only(ctx context.Context) (*Item, error) {
 	nodes, err := iq.Limit(2).All(ctx)
@@ -139,7 +139,7 @@ func (iq *ItemQuery) OnlyX(ctx context.Context) *Item {
 }
 
 // OnlyID is like Only, but returns the only Item ID in the query.
-// Returns a *NotSingularError when exactly one Item ID is not found.
+// Returns a *NotSingularError when more than one Item ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (iq *ItemQuery) OnlyID(ctx context.Context) (id string, err error) {
 	var ids []string

--- a/entc/integration/ent/node_query.go
+++ b/entc/integration/ent/node_query.go
@@ -161,7 +161,7 @@ func (nq *NodeQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Node entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Node entity is not found.
+// Returns a *NotSingularError when more than one Node entity is found.
 // Returns a *NotFoundError when no Node entities are found.
 func (nq *NodeQuery) Only(ctx context.Context) (*Node, error) {
 	nodes, err := nq.Limit(2).All(ctx)
@@ -188,7 +188,7 @@ func (nq *NodeQuery) OnlyX(ctx context.Context) *Node {
 }
 
 // OnlyID is like Only, but returns the only Node ID in the query.
-// Returns a *NotSingularError when exactly one Node ID is not found.
+// Returns a *NotSingularError when more than one Node ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (nq *NodeQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/ent/pet_query.go
+++ b/entc/integration/ent/pet_query.go
@@ -161,7 +161,7 @@ func (pq *PetQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Pet entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Pet entity is not found.
+// Returns a *NotSingularError when more than one Pet entity is found.
 // Returns a *NotFoundError when no Pet entities are found.
 func (pq *PetQuery) Only(ctx context.Context) (*Pet, error) {
 	nodes, err := pq.Limit(2).All(ctx)
@@ -188,7 +188,7 @@ func (pq *PetQuery) OnlyX(ctx context.Context) *Pet {
 }
 
 // OnlyID is like Only, but returns the only Pet ID in the query.
-// Returns a *NotSingularError when exactly one Pet ID is not found.
+// Returns a *NotSingularError when more than one Pet ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (pq *PetQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/ent/spec_query.go
+++ b/entc/integration/ent/spec_query.go
@@ -138,7 +138,7 @@ func (sq *SpecQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Spec entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Spec entity is not found.
+// Returns a *NotSingularError when more than one Spec entity is found.
 // Returns a *NotFoundError when no Spec entities are found.
 func (sq *SpecQuery) Only(ctx context.Context) (*Spec, error) {
 	nodes, err := sq.Limit(2).All(ctx)
@@ -165,7 +165,7 @@ func (sq *SpecQuery) OnlyX(ctx context.Context) *Spec {
 }
 
 // OnlyID is like Only, but returns the only Spec ID in the query.
-// Returns a *NotSingularError when exactly one Spec ID is not found.
+// Returns a *NotSingularError when more than one Spec ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (sq *SpecQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/ent/task_query.go
+++ b/entc/integration/ent/task_query.go
@@ -112,7 +112,7 @@ func (tq *TaskQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Task entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Task entity is not found.
+// Returns a *NotSingularError when more than one Task entity is found.
 // Returns a *NotFoundError when no Task entities are found.
 func (tq *TaskQuery) Only(ctx context.Context) (*Task, error) {
 	nodes, err := tq.Limit(2).All(ctx)
@@ -139,7 +139,7 @@ func (tq *TaskQuery) OnlyX(ctx context.Context) *Task {
 }
 
 // OnlyID is like Only, but returns the only Task ID in the query.
-// Returns a *NotSingularError when exactly one Task ID is not found.
+// Returns a *NotSingularError when more than one Task ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (tq *TaskQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/ent/user_query.go
+++ b/entc/integration/ent/user_query.go
@@ -372,7 +372,7 @@ func (uq *UserQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single User entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one User entity is not found.
+// Returns a *NotSingularError when more than one User entity is found.
 // Returns a *NotFoundError when no User entities are found.
 func (uq *UserQuery) Only(ctx context.Context) (*User, error) {
 	nodes, err := uq.Limit(2).All(ctx)
@@ -399,7 +399,7 @@ func (uq *UserQuery) OnlyX(ctx context.Context) *User {
 }
 
 // OnlyID is like Only, but returns the only User ID in the query.
-// Returns a *NotSingularError when exactly one User ID is not found.
+// Returns a *NotSingularError when more than one User ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (uq *UserQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/gremlin/ent/card_query.go
+++ b/entc/integration/gremlin/ent/card_query.go
@@ -144,7 +144,7 @@ func (cq *CardQuery) FirstIDX(ctx context.Context) string {
 }
 
 // Only returns a single Card entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Card entity is not found.
+// Returns a *NotSingularError when more than one Card entity is found.
 // Returns a *NotFoundError when no Card entities are found.
 func (cq *CardQuery) Only(ctx context.Context) (*Card, error) {
 	nodes, err := cq.Limit(2).All(ctx)
@@ -171,7 +171,7 @@ func (cq *CardQuery) OnlyX(ctx context.Context) *Card {
 }
 
 // OnlyID is like Only, but returns the only Card ID in the query.
-// Returns a *NotSingularError when exactly one Card ID is not found.
+// Returns a *NotSingularError when more than one Card ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (cq *CardQuery) OnlyID(ctx context.Context) (id string, err error) {
 	var ids []string

--- a/entc/integration/gremlin/ent/comment_query.go
+++ b/entc/integration/gremlin/ent/comment_query.go
@@ -111,7 +111,7 @@ func (cq *CommentQuery) FirstIDX(ctx context.Context) string {
 }
 
 // Only returns a single Comment entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Comment entity is not found.
+// Returns a *NotSingularError when more than one Comment entity is found.
 // Returns a *NotFoundError when no Comment entities are found.
 func (cq *CommentQuery) Only(ctx context.Context) (*Comment, error) {
 	nodes, err := cq.Limit(2).All(ctx)
@@ -138,7 +138,7 @@ func (cq *CommentQuery) OnlyX(ctx context.Context) *Comment {
 }
 
 // OnlyID is like Only, but returns the only Comment ID in the query.
-// Returns a *NotSingularError when exactly one Comment ID is not found.
+// Returns a *NotSingularError when more than one Comment ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (cq *CommentQuery) OnlyID(ctx context.Context) (id string, err error) {
 	var ids []string

--- a/entc/integration/gremlin/ent/fieldtype_query.go
+++ b/entc/integration/gremlin/ent/fieldtype_query.go
@@ -111,7 +111,7 @@ func (ftq *FieldTypeQuery) FirstIDX(ctx context.Context) string {
 }
 
 // Only returns a single FieldType entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one FieldType entity is not found.
+// Returns a *NotSingularError when more than one FieldType entity is found.
 // Returns a *NotFoundError when no FieldType entities are found.
 func (ftq *FieldTypeQuery) Only(ctx context.Context) (*FieldType, error) {
 	nodes, err := ftq.Limit(2).All(ctx)
@@ -138,7 +138,7 @@ func (ftq *FieldTypeQuery) OnlyX(ctx context.Context) *FieldType {
 }
 
 // OnlyID is like Only, but returns the only FieldType ID in the query.
-// Returns a *NotSingularError when exactly one FieldType ID is not found.
+// Returns a *NotSingularError when more than one FieldType ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (ftq *FieldTypeQuery) OnlyID(ctx context.Context) (id string, err error) {
 	var ids []string

--- a/entc/integration/gremlin/ent/file_query.go
+++ b/entc/integration/gremlin/ent/file_query.go
@@ -159,7 +159,7 @@ func (fq *FileQuery) FirstIDX(ctx context.Context) string {
 }
 
 // Only returns a single File entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one File entity is not found.
+// Returns a *NotSingularError when more than one File entity is found.
 // Returns a *NotFoundError when no File entities are found.
 func (fq *FileQuery) Only(ctx context.Context) (*File, error) {
 	nodes, err := fq.Limit(2).All(ctx)
@@ -186,7 +186,7 @@ func (fq *FileQuery) OnlyX(ctx context.Context) *File {
 }
 
 // OnlyID is like Only, but returns the only File ID in the query.
-// Returns a *NotSingularError when exactly one File ID is not found.
+// Returns a *NotSingularError when more than one File ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (fq *FileQuery) OnlyID(ctx context.Context) (id string, err error) {
 	var ids []string

--- a/entc/integration/gremlin/ent/filetype_query.go
+++ b/entc/integration/gremlin/ent/filetype_query.go
@@ -127,7 +127,7 @@ func (ftq *FileTypeQuery) FirstIDX(ctx context.Context) string {
 }
 
 // Only returns a single FileType entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one FileType entity is not found.
+// Returns a *NotSingularError when more than one FileType entity is found.
 // Returns a *NotFoundError when no FileType entities are found.
 func (ftq *FileTypeQuery) Only(ctx context.Context) (*FileType, error) {
 	nodes, err := ftq.Limit(2).All(ctx)
@@ -154,7 +154,7 @@ func (ftq *FileTypeQuery) OnlyX(ctx context.Context) *FileType {
 }
 
 // OnlyID is like Only, but returns the only FileType ID in the query.
-// Returns a *NotSingularError when exactly one FileType ID is not found.
+// Returns a *NotSingularError when more than one FileType ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (ftq *FileTypeQuery) OnlyID(ctx context.Context) (id string, err error) {
 	var ids []string

--- a/entc/integration/gremlin/ent/goods_query.go
+++ b/entc/integration/gremlin/ent/goods_query.go
@@ -111,7 +111,7 @@ func (gq *GoodsQuery) FirstIDX(ctx context.Context) string {
 }
 
 // Only returns a single Goods entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Goods entity is not found.
+// Returns a *NotSingularError when more than one Goods entity is found.
 // Returns a *NotFoundError when no Goods entities are found.
 func (gq *GoodsQuery) Only(ctx context.Context) (*Goods, error) {
 	nodes, err := gq.Limit(2).All(ctx)
@@ -138,7 +138,7 @@ func (gq *GoodsQuery) OnlyX(ctx context.Context) *Goods {
 }
 
 // OnlyID is like Only, but returns the only Goods ID in the query.
-// Returns a *NotSingularError when exactly one Goods ID is not found.
+// Returns a *NotSingularError when more than one Goods ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (gq *GoodsQuery) OnlyID(ctx context.Context) (id string, err error) {
 	var ids []string

--- a/entc/integration/gremlin/ent/group_query.go
+++ b/entc/integration/gremlin/ent/group_query.go
@@ -173,7 +173,7 @@ func (gq *GroupQuery) FirstIDX(ctx context.Context) string {
 }
 
 // Only returns a single Group entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Group entity is not found.
+// Returns a *NotSingularError when more than one Group entity is found.
 // Returns a *NotFoundError when no Group entities are found.
 func (gq *GroupQuery) Only(ctx context.Context) (*Group, error) {
 	nodes, err := gq.Limit(2).All(ctx)
@@ -200,7 +200,7 @@ func (gq *GroupQuery) OnlyX(ctx context.Context) *Group {
 }
 
 // OnlyID is like Only, but returns the only Group ID in the query.
-// Returns a *NotSingularError when exactly one Group ID is not found.
+// Returns a *NotSingularError when more than one Group ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (gq *GroupQuery) OnlyID(ctx context.Context) (id string, err error) {
 	var ids []string

--- a/entc/integration/gremlin/ent/groupinfo_query.go
+++ b/entc/integration/gremlin/ent/groupinfo_query.go
@@ -128,7 +128,7 @@ func (giq *GroupInfoQuery) FirstIDX(ctx context.Context) string {
 }
 
 // Only returns a single GroupInfo entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one GroupInfo entity is not found.
+// Returns a *NotSingularError when more than one GroupInfo entity is found.
 // Returns a *NotFoundError when no GroupInfo entities are found.
 func (giq *GroupInfoQuery) Only(ctx context.Context) (*GroupInfo, error) {
 	nodes, err := giq.Limit(2).All(ctx)
@@ -155,7 +155,7 @@ func (giq *GroupInfoQuery) OnlyX(ctx context.Context) *GroupInfo {
 }
 
 // OnlyID is like Only, but returns the only GroupInfo ID in the query.
-// Returns a *NotSingularError when exactly one GroupInfo ID is not found.
+// Returns a *NotSingularError when more than one GroupInfo ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (giq *GroupInfoQuery) OnlyID(ctx context.Context) (id string, err error) {
 	var ids []string

--- a/entc/integration/gremlin/ent/item_query.go
+++ b/entc/integration/gremlin/ent/item_query.go
@@ -111,7 +111,7 @@ func (iq *ItemQuery) FirstIDX(ctx context.Context) string {
 }
 
 // Only returns a single Item entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Item entity is not found.
+// Returns a *NotSingularError when more than one Item entity is found.
 // Returns a *NotFoundError when no Item entities are found.
 func (iq *ItemQuery) Only(ctx context.Context) (*Item, error) {
 	nodes, err := iq.Limit(2).All(ctx)
@@ -138,7 +138,7 @@ func (iq *ItemQuery) OnlyX(ctx context.Context) *Item {
 }
 
 // OnlyID is like Only, but returns the only Item ID in the query.
-// Returns a *NotSingularError when exactly one Item ID is not found.
+// Returns a *NotSingularError when more than one Item ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (iq *ItemQuery) OnlyID(ctx context.Context) (id string, err error) {
 	var ids []string

--- a/entc/integration/gremlin/ent/node_query.go
+++ b/entc/integration/gremlin/ent/node_query.go
@@ -142,7 +142,7 @@ func (nq *NodeQuery) FirstIDX(ctx context.Context) string {
 }
 
 // Only returns a single Node entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Node entity is not found.
+// Returns a *NotSingularError when more than one Node entity is found.
 // Returns a *NotFoundError when no Node entities are found.
 func (nq *NodeQuery) Only(ctx context.Context) (*Node, error) {
 	nodes, err := nq.Limit(2).All(ctx)
@@ -169,7 +169,7 @@ func (nq *NodeQuery) OnlyX(ctx context.Context) *Node {
 }
 
 // OnlyID is like Only, but returns the only Node ID in the query.
-// Returns a *NotSingularError when exactly one Node ID is not found.
+// Returns a *NotSingularError when more than one Node ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (nq *NodeQuery) OnlyID(ctx context.Context) (id string, err error) {
 	var ids []string

--- a/entc/integration/gremlin/ent/pet_query.go
+++ b/entc/integration/gremlin/ent/pet_query.go
@@ -143,7 +143,7 @@ func (pq *PetQuery) FirstIDX(ctx context.Context) string {
 }
 
 // Only returns a single Pet entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Pet entity is not found.
+// Returns a *NotSingularError when more than one Pet entity is found.
 // Returns a *NotFoundError when no Pet entities are found.
 func (pq *PetQuery) Only(ctx context.Context) (*Pet, error) {
 	nodes, err := pq.Limit(2).All(ctx)
@@ -170,7 +170,7 @@ func (pq *PetQuery) OnlyX(ctx context.Context) *Pet {
 }
 
 // OnlyID is like Only, but returns the only Pet ID in the query.
-// Returns a *NotSingularError when exactly one Pet ID is not found.
+// Returns a *NotSingularError when more than one Pet ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (pq *PetQuery) OnlyID(ctx context.Context) (id string, err error) {
 	var ids []string

--- a/entc/integration/gremlin/ent/spec_query.go
+++ b/entc/integration/gremlin/ent/spec_query.go
@@ -127,7 +127,7 @@ func (sq *SpecQuery) FirstIDX(ctx context.Context) string {
 }
 
 // Only returns a single Spec entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Spec entity is not found.
+// Returns a *NotSingularError when more than one Spec entity is found.
 // Returns a *NotFoundError when no Spec entities are found.
 func (sq *SpecQuery) Only(ctx context.Context) (*Spec, error) {
 	nodes, err := sq.Limit(2).All(ctx)
@@ -154,7 +154,7 @@ func (sq *SpecQuery) OnlyX(ctx context.Context) *Spec {
 }
 
 // OnlyID is like Only, but returns the only Spec ID in the query.
-// Returns a *NotSingularError when exactly one Spec ID is not found.
+// Returns a *NotSingularError when more than one Spec ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (sq *SpecQuery) OnlyID(ctx context.Context) (id string, err error) {
 	var ids []string

--- a/entc/integration/gremlin/ent/task_query.go
+++ b/entc/integration/gremlin/ent/task_query.go
@@ -111,7 +111,7 @@ func (tq *TaskQuery) FirstIDX(ctx context.Context) string {
 }
 
 // Only returns a single Task entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Task entity is not found.
+// Returns a *NotSingularError when more than one Task entity is found.
 // Returns a *NotFoundError when no Task entities are found.
 func (tq *TaskQuery) Only(ctx context.Context) (*Task, error) {
 	nodes, err := tq.Limit(2).All(ctx)
@@ -138,7 +138,7 @@ func (tq *TaskQuery) OnlyX(ctx context.Context) *Task {
 }
 
 // OnlyID is like Only, but returns the only Task ID in the query.
-// Returns a *NotSingularError when exactly one Task ID is not found.
+// Returns a *NotSingularError when more than one Task ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (tq *TaskQuery) OnlyID(ctx context.Context) (id string, err error) {
 	var ids []string

--- a/entc/integration/gremlin/ent/user_query.go
+++ b/entc/integration/gremlin/ent/user_query.go
@@ -277,7 +277,7 @@ func (uq *UserQuery) FirstIDX(ctx context.Context) string {
 }
 
 // Only returns a single User entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one User entity is not found.
+// Returns a *NotSingularError when more than one User entity is found.
 // Returns a *NotFoundError when no User entities are found.
 func (uq *UserQuery) Only(ctx context.Context) (*User, error) {
 	nodes, err := uq.Limit(2).All(ctx)
@@ -304,7 +304,7 @@ func (uq *UserQuery) OnlyX(ctx context.Context) *User {
 }
 
 // OnlyID is like Only, but returns the only User ID in the query.
-// Returns a *NotSingularError when exactly one User ID is not found.
+// Returns a *NotSingularError when more than one User ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (uq *UserQuery) OnlyID(ctx context.Context) (id string, err error) {
 	var ids []string

--- a/entc/integration/hooks/ent/card_query.go
+++ b/entc/integration/hooks/ent/card_query.go
@@ -136,7 +136,7 @@ func (cq *CardQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Card entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Card entity is not found.
+// Returns a *NotSingularError when more than one Card entity is found.
 // Returns a *NotFoundError when no Card entities are found.
 func (cq *CardQuery) Only(ctx context.Context) (*Card, error) {
 	nodes, err := cq.Limit(2).All(ctx)
@@ -163,7 +163,7 @@ func (cq *CardQuery) OnlyX(ctx context.Context) *Card {
 }
 
 // OnlyID is like Only, but returns the only Card ID in the query.
-// Returns a *NotSingularError when exactly one Card ID is not found.
+// Returns a *NotSingularError when more than one Card ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (cq *CardQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/hooks/ent/user_query.go
+++ b/entc/integration/hooks/ent/user_query.go
@@ -183,7 +183,7 @@ func (uq *UserQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single User entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one User entity is not found.
+// Returns a *NotSingularError when more than one User entity is found.
 // Returns a *NotFoundError when no User entities are found.
 func (uq *UserQuery) Only(ctx context.Context) (*User, error) {
 	nodes, err := uq.Limit(2).All(ctx)
@@ -210,7 +210,7 @@ func (uq *UserQuery) OnlyX(ctx context.Context) *User {
 }
 
 // OnlyID is like Only, but returns the only User ID in the query.
-// Returns a *NotSingularError when exactly one User ID is not found.
+// Returns a *NotSingularError when more than one User ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (uq *UserQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/idtype/ent/user_query.go
+++ b/entc/integration/idtype/ent/user_query.go
@@ -182,7 +182,7 @@ func (uq *UserQuery) FirstIDX(ctx context.Context) uint64 {
 }
 
 // Only returns a single User entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one User entity is not found.
+// Returns a *NotSingularError when more than one User entity is found.
 // Returns a *NotFoundError when no User entities are found.
 func (uq *UserQuery) Only(ctx context.Context) (*User, error) {
 	nodes, err := uq.Limit(2).All(ctx)
@@ -209,7 +209,7 @@ func (uq *UserQuery) OnlyX(ctx context.Context) *User {
 }
 
 // OnlyID is like Only, but returns the only User ID in the query.
-// Returns a *NotSingularError when exactly one User ID is not found.
+// Returns a *NotSingularError when more than one User ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (uq *UserQuery) OnlyID(ctx context.Context) (id uint64, err error) {
 	var ids []uint64

--- a/entc/integration/json/ent/user_query.go
+++ b/entc/integration/json/ent/user_query.go
@@ -110,7 +110,7 @@ func (uq *UserQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single User entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one User entity is not found.
+// Returns a *NotSingularError when more than one User entity is found.
 // Returns a *NotFoundError when no User entities are found.
 func (uq *UserQuery) Only(ctx context.Context) (*User, error) {
 	nodes, err := uq.Limit(2).All(ctx)
@@ -137,7 +137,7 @@ func (uq *UserQuery) OnlyX(ctx context.Context) *User {
 }
 
 // OnlyID is like Only, but returns the only User ID in the query.
-// Returns a *NotSingularError when exactly one User ID is not found.
+// Returns a *NotSingularError when more than one User ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (uq *UserQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/migrate/entv1/car_query.go
+++ b/entc/integration/migrate/entv1/car_query.go
@@ -136,7 +136,7 @@ func (cq *CarQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Car entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Car entity is not found.
+// Returns a *NotSingularError when more than one Car entity is found.
 // Returns a *NotFoundError when no Car entities are found.
 func (cq *CarQuery) Only(ctx context.Context) (*Car, error) {
 	nodes, err := cq.Limit(2).All(ctx)
@@ -163,7 +163,7 @@ func (cq *CarQuery) OnlyX(ctx context.Context) *Car {
 }
 
 // OnlyID is like Only, but returns the only Car ID in the query.
-// Returns a *NotSingularError when exactly one Car ID is not found.
+// Returns a *NotSingularError when more than one Car ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (cq *CarQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/migrate/entv1/conversion_query.go
+++ b/entc/integration/migrate/entv1/conversion_query.go
@@ -110,7 +110,7 @@ func (cq *ConversionQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Conversion entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Conversion entity is not found.
+// Returns a *NotSingularError when more than one Conversion entity is found.
 // Returns a *NotFoundError when no Conversion entities are found.
 func (cq *ConversionQuery) Only(ctx context.Context) (*Conversion, error) {
 	nodes, err := cq.Limit(2).All(ctx)
@@ -137,7 +137,7 @@ func (cq *ConversionQuery) OnlyX(ctx context.Context) *Conversion {
 }
 
 // OnlyID is like Only, but returns the only Conversion ID in the query.
-// Returns a *NotSingularError when exactly one Conversion ID is not found.
+// Returns a *NotSingularError when more than one Conversion ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (cq *ConversionQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/migrate/entv1/customtype_query.go
+++ b/entc/integration/migrate/entv1/customtype_query.go
@@ -110,7 +110,7 @@ func (ctq *CustomTypeQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single CustomType entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one CustomType entity is not found.
+// Returns a *NotSingularError when more than one CustomType entity is found.
 // Returns a *NotFoundError when no CustomType entities are found.
 func (ctq *CustomTypeQuery) Only(ctx context.Context) (*CustomType, error) {
 	nodes, err := ctq.Limit(2).All(ctx)
@@ -137,7 +137,7 @@ func (ctq *CustomTypeQuery) OnlyX(ctx context.Context) *CustomType {
 }
 
 // OnlyID is like Only, but returns the only CustomType ID in the query.
-// Returns a *NotSingularError when exactly one CustomType ID is not found.
+// Returns a *NotSingularError when more than one CustomType ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (ctq *CustomTypeQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/migrate/entv1/user_query.go
+++ b/entc/integration/migrate/entv1/user_query.go
@@ -206,7 +206,7 @@ func (uq *UserQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single User entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one User entity is not found.
+// Returns a *NotSingularError when more than one User entity is found.
 // Returns a *NotFoundError when no User entities are found.
 func (uq *UserQuery) Only(ctx context.Context) (*User, error) {
 	nodes, err := uq.Limit(2).All(ctx)
@@ -233,7 +233,7 @@ func (uq *UserQuery) OnlyX(ctx context.Context) *User {
 }
 
 // OnlyID is like Only, but returns the only User ID in the query.
-// Returns a *NotSingularError when exactly one User ID is not found.
+// Returns a *NotSingularError when more than one User ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (uq *UserQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/migrate/entv2/car_query.go
+++ b/entc/integration/migrate/entv2/car_query.go
@@ -136,7 +136,7 @@ func (cq *CarQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Car entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Car entity is not found.
+// Returns a *NotSingularError when more than one Car entity is found.
 // Returns a *NotFoundError when no Car entities are found.
 func (cq *CarQuery) Only(ctx context.Context) (*Car, error) {
 	nodes, err := cq.Limit(2).All(ctx)
@@ -163,7 +163,7 @@ func (cq *CarQuery) OnlyX(ctx context.Context) *Car {
 }
 
 // OnlyID is like Only, but returns the only Car ID in the query.
-// Returns a *NotSingularError when exactly one Car ID is not found.
+// Returns a *NotSingularError when more than one Car ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (cq *CarQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/migrate/entv2/conversion_query.go
+++ b/entc/integration/migrate/entv2/conversion_query.go
@@ -110,7 +110,7 @@ func (cq *ConversionQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Conversion entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Conversion entity is not found.
+// Returns a *NotSingularError when more than one Conversion entity is found.
 // Returns a *NotFoundError when no Conversion entities are found.
 func (cq *ConversionQuery) Only(ctx context.Context) (*Conversion, error) {
 	nodes, err := cq.Limit(2).All(ctx)
@@ -137,7 +137,7 @@ func (cq *ConversionQuery) OnlyX(ctx context.Context) *Conversion {
 }
 
 // OnlyID is like Only, but returns the only Conversion ID in the query.
-// Returns a *NotSingularError when exactly one Conversion ID is not found.
+// Returns a *NotSingularError when more than one Conversion ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (cq *ConversionQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/migrate/entv2/customtype_query.go
+++ b/entc/integration/migrate/entv2/customtype_query.go
@@ -110,7 +110,7 @@ func (ctq *CustomTypeQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single CustomType entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one CustomType entity is not found.
+// Returns a *NotSingularError when more than one CustomType entity is found.
 // Returns a *NotFoundError when no CustomType entities are found.
 func (ctq *CustomTypeQuery) Only(ctx context.Context) (*CustomType, error) {
 	nodes, err := ctq.Limit(2).All(ctx)
@@ -137,7 +137,7 @@ func (ctq *CustomTypeQuery) OnlyX(ctx context.Context) *CustomType {
 }
 
 // OnlyID is like Only, but returns the only CustomType ID in the query.
-// Returns a *NotSingularError when exactly one CustomType ID is not found.
+// Returns a *NotSingularError when more than one CustomType ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (ctq *CustomTypeQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/migrate/entv2/group_query.go
+++ b/entc/integration/migrate/entv2/group_query.go
@@ -110,7 +110,7 @@ func (gq *GroupQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Group entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Group entity is not found.
+// Returns a *NotSingularError when more than one Group entity is found.
 // Returns a *NotFoundError when no Group entities are found.
 func (gq *GroupQuery) Only(ctx context.Context) (*Group, error) {
 	nodes, err := gq.Limit(2).All(ctx)
@@ -137,7 +137,7 @@ func (gq *GroupQuery) OnlyX(ctx context.Context) *Group {
 }
 
 // OnlyID is like Only, but returns the only Group ID in the query.
-// Returns a *NotSingularError when exactly one Group ID is not found.
+// Returns a *NotSingularError when more than one Group ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (gq *GroupQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/migrate/entv2/media_query.go
+++ b/entc/integration/migrate/entv2/media_query.go
@@ -110,7 +110,7 @@ func (mq *MediaQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Media entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Media entity is not found.
+// Returns a *NotSingularError when more than one Media entity is found.
 // Returns a *NotFoundError when no Media entities are found.
 func (mq *MediaQuery) Only(ctx context.Context) (*Media, error) {
 	nodes, err := mq.Limit(2).All(ctx)
@@ -137,7 +137,7 @@ func (mq *MediaQuery) OnlyX(ctx context.Context) *Media {
 }
 
 // OnlyID is like Only, but returns the only Media ID in the query.
-// Returns a *NotSingularError when exactly one Media ID is not found.
+// Returns a *NotSingularError when more than one Media ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (mq *MediaQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/migrate/entv2/pet_query.go
+++ b/entc/integration/migrate/entv2/pet_query.go
@@ -136,7 +136,7 @@ func (pq *PetQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Pet entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Pet entity is not found.
+// Returns a *NotSingularError when more than one Pet entity is found.
 // Returns a *NotFoundError when no Pet entities are found.
 func (pq *PetQuery) Only(ctx context.Context) (*Pet, error) {
 	nodes, err := pq.Limit(2).All(ctx)
@@ -163,7 +163,7 @@ func (pq *PetQuery) OnlyX(ctx context.Context) *Pet {
 }
 
 // OnlyID is like Only, but returns the only Pet ID in the query.
-// Returns a *NotSingularError when exactly one Pet ID is not found.
+// Returns a *NotSingularError when more than one Pet ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (pq *PetQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/migrate/entv2/user_query.go
+++ b/entc/integration/migrate/entv2/user_query.go
@@ -183,7 +183,7 @@ func (uq *UserQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single User entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one User entity is not found.
+// Returns a *NotSingularError when more than one User entity is found.
 // Returns a *NotFoundError when no User entities are found.
 func (uq *UserQuery) Only(ctx context.Context) (*User, error) {
 	nodes, err := uq.Limit(2).All(ctx)
@@ -210,7 +210,7 @@ func (uq *UserQuery) OnlyX(ctx context.Context) *User {
 }
 
 // OnlyID is like Only, but returns the only User ID in the query.
-// Returns a *NotSingularError when exactly one User ID is not found.
+// Returns a *NotSingularError when more than one User ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (uq *UserQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/multischema/ent/group_query.go
+++ b/entc/integration/multischema/ent/group_query.go
@@ -141,7 +141,7 @@ func (gq *GroupQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Group entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Group entity is not found.
+// Returns a *NotSingularError when more than one Group entity is found.
 // Returns a *NotFoundError when no Group entities are found.
 func (gq *GroupQuery) Only(ctx context.Context) (*Group, error) {
 	nodes, err := gq.Limit(2).All(ctx)
@@ -168,7 +168,7 @@ func (gq *GroupQuery) OnlyX(ctx context.Context) *Group {
 }
 
 // OnlyID is like Only, but returns the only Group ID in the query.
-// Returns a *NotSingularError when exactly one Group ID is not found.
+// Returns a *NotSingularError when more than one Group ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (gq *GroupQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/multischema/ent/pet_query.go
+++ b/entc/integration/multischema/ent/pet_query.go
@@ -140,7 +140,7 @@ func (pq *PetQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Pet entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Pet entity is not found.
+// Returns a *NotSingularError when more than one Pet entity is found.
 // Returns a *NotFoundError when no Pet entities are found.
 func (pq *PetQuery) Only(ctx context.Context) (*Pet, error) {
 	nodes, err := pq.Limit(2).All(ctx)
@@ -167,7 +167,7 @@ func (pq *PetQuery) OnlyX(ctx context.Context) *Pet {
 }
 
 // OnlyID is like Only, but returns the only Pet ID in the query.
-// Returns a *NotSingularError when exactly one Pet ID is not found.
+// Returns a *NotSingularError when more than one Pet ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (pq *PetQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/multischema/ent/user_query.go
+++ b/entc/integration/multischema/ent/user_query.go
@@ -168,7 +168,7 @@ func (uq *UserQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single User entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one User entity is not found.
+// Returns a *NotSingularError when more than one User entity is found.
 // Returns a *NotFoundError when no User entities are found.
 func (uq *UserQuery) Only(ctx context.Context) (*User, error) {
 	nodes, err := uq.Limit(2).All(ctx)
@@ -195,7 +195,7 @@ func (uq *UserQuery) OnlyX(ctx context.Context) *User {
 }
 
 // OnlyID is like Only, but returns the only User ID in the query.
-// Returns a *NotSingularError when exactly one User ID is not found.
+// Returns a *NotSingularError when more than one User ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (uq *UserQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/privacy/ent/task_query.go
+++ b/entc/integration/privacy/ent/task_query.go
@@ -161,7 +161,7 @@ func (tq *TaskQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Task entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Task entity is not found.
+// Returns a *NotSingularError when more than one Task entity is found.
 // Returns a *NotFoundError when no Task entities are found.
 func (tq *TaskQuery) Only(ctx context.Context) (*Task, error) {
 	nodes, err := tq.Limit(2).All(ctx)
@@ -188,7 +188,7 @@ func (tq *TaskQuery) OnlyX(ctx context.Context) *Task {
 }
 
 // OnlyID is like Only, but returns the only Task ID in the query.
-// Returns a *NotSingularError when exactly one Task ID is not found.
+// Returns a *NotSingularError when more than one Task ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (tq *TaskQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/privacy/ent/team_query.go
+++ b/entc/integration/privacy/ent/team_query.go
@@ -160,7 +160,7 @@ func (tq *TeamQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Team entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Team entity is not found.
+// Returns a *NotSingularError when more than one Team entity is found.
 // Returns a *NotFoundError when no Team entities are found.
 func (tq *TeamQuery) Only(ctx context.Context) (*Team, error) {
 	nodes, err := tq.Limit(2).All(ctx)
@@ -187,7 +187,7 @@ func (tq *TeamQuery) OnlyX(ctx context.Context) *Team {
 }
 
 // OnlyID is like Only, but returns the only Team ID in the query.
-// Returns a *NotSingularError when exactly one Team ID is not found.
+// Returns a *NotSingularError when more than one Team ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (tq *TeamQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/privacy/ent/user_query.go
+++ b/entc/integration/privacy/ent/user_query.go
@@ -160,7 +160,7 @@ func (uq *UserQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single User entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one User entity is not found.
+// Returns a *NotSingularError when more than one User entity is found.
 // Returns a *NotFoundError when no User entities are found.
 func (uq *UserQuery) Only(ctx context.Context) (*User, error) {
 	nodes, err := uq.Limit(2).All(ctx)
@@ -187,7 +187,7 @@ func (uq *UserQuery) OnlyX(ctx context.Context) *User {
 }
 
 // OnlyID is like Only, but returns the only User ID in the query.
-// Returns a *NotSingularError when exactly one User ID is not found.
+// Returns a *NotSingularError when more than one User ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (uq *UserQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/template/ent/group_query.go
+++ b/entc/integration/template/ent/group_query.go
@@ -113,7 +113,7 @@ func (gq *GroupQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Group entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Group entity is not found.
+// Returns a *NotSingularError when more than one Group entity is found.
 // Returns a *NotFoundError when no Group entities are found.
 func (gq *GroupQuery) Only(ctx context.Context) (*Group, error) {
 	nodes, err := gq.Limit(2).All(ctx)
@@ -140,7 +140,7 @@ func (gq *GroupQuery) OnlyX(ctx context.Context) *Group {
 }
 
 // OnlyID is like Only, but returns the only Group ID in the query.
-// Returns a *NotSingularError when exactly one Group ID is not found.
+// Returns a *NotSingularError when more than one Group ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (gq *GroupQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/template/ent/pet_query.go
+++ b/entc/integration/template/ent/pet_query.go
@@ -139,7 +139,7 @@ func (pq *PetQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Pet entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Pet entity is not found.
+// Returns a *NotSingularError when more than one Pet entity is found.
 // Returns a *NotFoundError when no Pet entities are found.
 func (pq *PetQuery) Only(ctx context.Context) (*Pet, error) {
 	nodes, err := pq.Limit(2).All(ctx)
@@ -166,7 +166,7 @@ func (pq *PetQuery) OnlyX(ctx context.Context) *Pet {
 }
 
 // OnlyID is like Only, but returns the only Pet ID in the query.
-// Returns a *NotSingularError when exactly one Pet ID is not found.
+// Returns a *NotSingularError when more than one Pet ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (pq *PetQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/entc/integration/template/ent/user_query.go
+++ b/entc/integration/template/ent/user_query.go
@@ -162,7 +162,7 @@ func (uq *UserQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single User entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one User entity is not found.
+// Returns a *NotSingularError when more than one User entity is found.
 // Returns a *NotFoundError when no User entities are found.
 func (uq *UserQuery) Only(ctx context.Context) (*User, error) {
 	nodes, err := uq.Limit(2).All(ctx)
@@ -189,7 +189,7 @@ func (uq *UserQuery) OnlyX(ctx context.Context) *User {
 }
 
 // OnlyID is like Only, but returns the only User ID in the query.
-// Returns a *NotSingularError when exactly one User ID is not found.
+// Returns a *NotSingularError when more than one User ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (uq *UserQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/examples/edgeindex/ent/city_query.go
+++ b/examples/edgeindex/ent/city_query.go
@@ -136,7 +136,7 @@ func (cq *CityQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single City entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one City entity is not found.
+// Returns a *NotSingularError when more than one City entity is found.
 // Returns a *NotFoundError when no City entities are found.
 func (cq *CityQuery) Only(ctx context.Context) (*City, error) {
 	nodes, err := cq.Limit(2).All(ctx)
@@ -163,7 +163,7 @@ func (cq *CityQuery) OnlyX(ctx context.Context) *City {
 }
 
 // OnlyID is like Only, but returns the only City ID in the query.
-// Returns a *NotSingularError when exactly one City ID is not found.
+// Returns a *NotSingularError when more than one City ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (cq *CityQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/examples/edgeindex/ent/street_query.go
+++ b/examples/edgeindex/ent/street_query.go
@@ -136,7 +136,7 @@ func (sq *StreetQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Street entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Street entity is not found.
+// Returns a *NotSingularError when more than one Street entity is found.
 // Returns a *NotFoundError when no Street entities are found.
 func (sq *StreetQuery) Only(ctx context.Context) (*Street, error) {
 	nodes, err := sq.Limit(2).All(ctx)
@@ -163,7 +163,7 @@ func (sq *StreetQuery) OnlyX(ctx context.Context) *Street {
 }
 
 // OnlyID is like Only, but returns the only Street ID in the query.
-// Returns a *NotSingularError when exactly one Street ID is not found.
+// Returns a *NotSingularError when more than one Street ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (sq *StreetQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/examples/entcpkg/ent/user_query.go
+++ b/examples/entcpkg/ent/user_query.go
@@ -110,7 +110,7 @@ func (uq *UserQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single User entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one User entity is not found.
+// Returns a *NotSingularError when more than one User entity is found.
 // Returns a *NotFoundError when no User entities are found.
 func (uq *UserQuery) Only(ctx context.Context) (*User, error) {
 	nodes, err := uq.Limit(2).All(ctx)
@@ -137,7 +137,7 @@ func (uq *UserQuery) OnlyX(ctx context.Context) *User {
 }
 
 // OnlyID is like Only, but returns the only User ID in the query.
-// Returns a *NotSingularError when exactly one User ID is not found.
+// Returns a *NotSingularError when more than one User ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (uq *UserQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/examples/fs/ent/file_query.go
+++ b/examples/fs/ent/file_query.go
@@ -158,7 +158,7 @@ func (fq *FileQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single File entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one File entity is not found.
+// Returns a *NotSingularError when more than one File entity is found.
 // Returns a *NotFoundError when no File entities are found.
 func (fq *FileQuery) Only(ctx context.Context) (*File, error) {
 	nodes, err := fq.Limit(2).All(ctx)
@@ -185,7 +185,7 @@ func (fq *FileQuery) OnlyX(ctx context.Context) *File {
 }
 
 // OnlyID is like Only, but returns the only File ID in the query.
-// Returns a *NotSingularError when exactly one File ID is not found.
+// Returns a *NotSingularError when more than one File ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (fq *FileQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/examples/m2m2types/ent/group_query.go
+++ b/examples/m2m2types/ent/group_query.go
@@ -136,7 +136,7 @@ func (gq *GroupQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Group entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Group entity is not found.
+// Returns a *NotSingularError when more than one Group entity is found.
 // Returns a *NotFoundError when no Group entities are found.
 func (gq *GroupQuery) Only(ctx context.Context) (*Group, error) {
 	nodes, err := gq.Limit(2).All(ctx)
@@ -163,7 +163,7 @@ func (gq *GroupQuery) OnlyX(ctx context.Context) *Group {
 }
 
 // OnlyID is like Only, but returns the only Group ID in the query.
-// Returns a *NotSingularError when exactly one Group ID is not found.
+// Returns a *NotSingularError when more than one Group ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (gq *GroupQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/examples/m2m2types/ent/user_query.go
+++ b/examples/m2m2types/ent/user_query.go
@@ -136,7 +136,7 @@ func (uq *UserQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single User entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one User entity is not found.
+// Returns a *NotSingularError when more than one User entity is found.
 // Returns a *NotFoundError when no User entities are found.
 func (uq *UserQuery) Only(ctx context.Context) (*User, error) {
 	nodes, err := uq.Limit(2).All(ctx)
@@ -163,7 +163,7 @@ func (uq *UserQuery) OnlyX(ctx context.Context) *User {
 }
 
 // OnlyID is like Only, but returns the only User ID in the query.
-// Returns a *NotSingularError when exactly one User ID is not found.
+// Returns a *NotSingularError when more than one User ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (uq *UserQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/examples/m2mbidi/ent/user_query.go
+++ b/examples/m2mbidi/ent/user_query.go
@@ -135,7 +135,7 @@ func (uq *UserQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single User entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one User entity is not found.
+// Returns a *NotSingularError when more than one User entity is found.
 // Returns a *NotFoundError when no User entities are found.
 func (uq *UserQuery) Only(ctx context.Context) (*User, error) {
 	nodes, err := uq.Limit(2).All(ctx)
@@ -162,7 +162,7 @@ func (uq *UserQuery) OnlyX(ctx context.Context) *User {
 }
 
 // OnlyID is like Only, but returns the only User ID in the query.
-// Returns a *NotSingularError when exactly one User ID is not found.
+// Returns a *NotSingularError when more than one User ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (uq *UserQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/examples/m2mrecur/ent/user_query.go
+++ b/examples/m2mrecur/ent/user_query.go
@@ -158,7 +158,7 @@ func (uq *UserQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single User entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one User entity is not found.
+// Returns a *NotSingularError when more than one User entity is found.
 // Returns a *NotFoundError when no User entities are found.
 func (uq *UserQuery) Only(ctx context.Context) (*User, error) {
 	nodes, err := uq.Limit(2).All(ctx)
@@ -185,7 +185,7 @@ func (uq *UserQuery) OnlyX(ctx context.Context) *User {
 }
 
 // OnlyID is like Only, but returns the only User ID in the query.
-// Returns a *NotSingularError when exactly one User ID is not found.
+// Returns a *NotSingularError when more than one User ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (uq *UserQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/examples/o2m2types/ent/pet_query.go
+++ b/examples/o2m2types/ent/pet_query.go
@@ -136,7 +136,7 @@ func (pq *PetQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Pet entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Pet entity is not found.
+// Returns a *NotSingularError when more than one Pet entity is found.
 // Returns a *NotFoundError when no Pet entities are found.
 func (pq *PetQuery) Only(ctx context.Context) (*Pet, error) {
 	nodes, err := pq.Limit(2).All(ctx)
@@ -163,7 +163,7 @@ func (pq *PetQuery) OnlyX(ctx context.Context) *Pet {
 }
 
 // OnlyID is like Only, but returns the only Pet ID in the query.
-// Returns a *NotSingularError when exactly one Pet ID is not found.
+// Returns a *NotSingularError when more than one Pet ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (pq *PetQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/examples/o2m2types/ent/user_query.go
+++ b/examples/o2m2types/ent/user_query.go
@@ -136,7 +136,7 @@ func (uq *UserQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single User entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one User entity is not found.
+// Returns a *NotSingularError when more than one User entity is found.
 // Returns a *NotFoundError when no User entities are found.
 func (uq *UserQuery) Only(ctx context.Context) (*User, error) {
 	nodes, err := uq.Limit(2).All(ctx)
@@ -163,7 +163,7 @@ func (uq *UserQuery) OnlyX(ctx context.Context) *User {
 }
 
 // OnlyID is like Only, but returns the only User ID in the query.
-// Returns a *NotSingularError when exactly one User ID is not found.
+// Returns a *NotSingularError when more than one User ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (uq *UserQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/examples/o2mrecur/ent/node_query.go
+++ b/examples/o2mrecur/ent/node_query.go
@@ -159,7 +159,7 @@ func (nq *NodeQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Node entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Node entity is not found.
+// Returns a *NotSingularError when more than one Node entity is found.
 // Returns a *NotFoundError when no Node entities are found.
 func (nq *NodeQuery) Only(ctx context.Context) (*Node, error) {
 	nodes, err := nq.Limit(2).All(ctx)
@@ -186,7 +186,7 @@ func (nq *NodeQuery) OnlyX(ctx context.Context) *Node {
 }
 
 // OnlyID is like Only, but returns the only Node ID in the query.
-// Returns a *NotSingularError when exactly one Node ID is not found.
+// Returns a *NotSingularError when more than one Node ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (nq *NodeQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/examples/o2o2types/ent/card_query.go
+++ b/examples/o2o2types/ent/card_query.go
@@ -136,7 +136,7 @@ func (cq *CardQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Card entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Card entity is not found.
+// Returns a *NotSingularError when more than one Card entity is found.
 // Returns a *NotFoundError when no Card entities are found.
 func (cq *CardQuery) Only(ctx context.Context) (*Card, error) {
 	nodes, err := cq.Limit(2).All(ctx)
@@ -163,7 +163,7 @@ func (cq *CardQuery) OnlyX(ctx context.Context) *Card {
 }
 
 // OnlyID is like Only, but returns the only Card ID in the query.
-// Returns a *NotSingularError when exactly one Card ID is not found.
+// Returns a *NotSingularError when more than one Card ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (cq *CardQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/examples/o2o2types/ent/user_query.go
+++ b/examples/o2o2types/ent/user_query.go
@@ -136,7 +136,7 @@ func (uq *UserQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single User entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one User entity is not found.
+// Returns a *NotSingularError when more than one User entity is found.
 // Returns a *NotFoundError when no User entities are found.
 func (uq *UserQuery) Only(ctx context.Context) (*User, error) {
 	nodes, err := uq.Limit(2).All(ctx)
@@ -163,7 +163,7 @@ func (uq *UserQuery) OnlyX(ctx context.Context) *User {
 }
 
 // OnlyID is like Only, but returns the only User ID in the query.
-// Returns a *NotSingularError when exactly one User ID is not found.
+// Returns a *NotSingularError when more than one User ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (uq *UserQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/examples/o2obidi/ent/user_query.go
+++ b/examples/o2obidi/ent/user_query.go
@@ -135,7 +135,7 @@ func (uq *UserQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single User entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one User entity is not found.
+// Returns a *NotSingularError when more than one User entity is found.
 // Returns a *NotFoundError when no User entities are found.
 func (uq *UserQuery) Only(ctx context.Context) (*User, error) {
 	nodes, err := uq.Limit(2).All(ctx)
@@ -162,7 +162,7 @@ func (uq *UserQuery) OnlyX(ctx context.Context) *User {
 }
 
 // OnlyID is like Only, but returns the only User ID in the query.
-// Returns a *NotSingularError when exactly one User ID is not found.
+// Returns a *NotSingularError when more than one User ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (uq *UserQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/examples/o2orecur/ent/node_query.go
+++ b/examples/o2orecur/ent/node_query.go
@@ -159,7 +159,7 @@ func (nq *NodeQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Node entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Node entity is not found.
+// Returns a *NotSingularError when more than one Node entity is found.
 // Returns a *NotFoundError when no Node entities are found.
 func (nq *NodeQuery) Only(ctx context.Context) (*Node, error) {
 	nodes, err := nq.Limit(2).All(ctx)
@@ -186,7 +186,7 @@ func (nq *NodeQuery) OnlyX(ctx context.Context) *Node {
 }
 
 // OnlyID is like Only, but returns the only Node ID in the query.
-// Returns a *NotSingularError when exactly one Node ID is not found.
+// Returns a *NotSingularError when more than one Node ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (nq *NodeQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/examples/privacyadmin/ent/user_query.go
+++ b/examples/privacyadmin/ent/user_query.go
@@ -110,7 +110,7 @@ func (uq *UserQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single User entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one User entity is not found.
+// Returns a *NotSingularError when more than one User entity is found.
 // Returns a *NotFoundError when no User entities are found.
 func (uq *UserQuery) Only(ctx context.Context) (*User, error) {
 	nodes, err := uq.Limit(2).All(ctx)
@@ -137,7 +137,7 @@ func (uq *UserQuery) OnlyX(ctx context.Context) *User {
 }
 
 // OnlyID is like Only, but returns the only User ID in the query.
-// Returns a *NotSingularError when exactly one User ID is not found.
+// Returns a *NotSingularError when more than one User ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (uq *UserQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/examples/privacytenant/ent/group_query.go
+++ b/examples/privacytenant/ent/group_query.go
@@ -161,7 +161,7 @@ func (gq *GroupQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Group entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Group entity is not found.
+// Returns a *NotSingularError when more than one Group entity is found.
 // Returns a *NotFoundError when no Group entities are found.
 func (gq *GroupQuery) Only(ctx context.Context) (*Group, error) {
 	nodes, err := gq.Limit(2).All(ctx)
@@ -188,7 +188,7 @@ func (gq *GroupQuery) OnlyX(ctx context.Context) *Group {
 }
 
 // OnlyID is like Only, but returns the only Group ID in the query.
-// Returns a *NotSingularError when exactly one Group ID is not found.
+// Returns a *NotSingularError when more than one Group ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (gq *GroupQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/examples/privacytenant/ent/tenant_query.go
+++ b/examples/privacytenant/ent/tenant_query.go
@@ -110,7 +110,7 @@ func (tq *TenantQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Tenant entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Tenant entity is not found.
+// Returns a *NotSingularError when more than one Tenant entity is found.
 // Returns a *NotFoundError when no Tenant entities are found.
 func (tq *TenantQuery) Only(ctx context.Context) (*Tenant, error) {
 	nodes, err := tq.Limit(2).All(ctx)
@@ -137,7 +137,7 @@ func (tq *TenantQuery) OnlyX(ctx context.Context) *Tenant {
 }
 
 // OnlyID is like Only, but returns the only Tenant ID in the query.
-// Returns a *NotSingularError when exactly one Tenant ID is not found.
+// Returns a *NotSingularError when more than one Tenant ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (tq *TenantQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/examples/privacytenant/ent/user_query.go
+++ b/examples/privacytenant/ent/user_query.go
@@ -161,7 +161,7 @@ func (uq *UserQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single User entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one User entity is not found.
+// Returns a *NotSingularError when more than one User entity is found.
 // Returns a *NotFoundError when no User entities are found.
 func (uq *UserQuery) Only(ctx context.Context) (*User, error) {
 	nodes, err := uq.Limit(2).All(ctx)
@@ -188,7 +188,7 @@ func (uq *UserQuery) OnlyX(ctx context.Context) *User {
 }
 
 // OnlyID is like Only, but returns the only User ID in the query.
-// Returns a *NotSingularError when exactly one User ID is not found.
+// Returns a *NotSingularError when more than one User ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (uq *UserQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/examples/start/ent/car_query.go
+++ b/examples/start/ent/car_query.go
@@ -136,7 +136,7 @@ func (cq *CarQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Car entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Car entity is not found.
+// Returns a *NotSingularError when more than one Car entity is found.
 // Returns a *NotFoundError when no Car entities are found.
 func (cq *CarQuery) Only(ctx context.Context) (*Car, error) {
 	nodes, err := cq.Limit(2).All(ctx)
@@ -163,7 +163,7 @@ func (cq *CarQuery) OnlyX(ctx context.Context) *Car {
 }
 
 // OnlyID is like Only, but returns the only Car ID in the query.
-// Returns a *NotSingularError when exactly one Car ID is not found.
+// Returns a *NotSingularError when more than one Car ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (cq *CarQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/examples/start/ent/group_query.go
+++ b/examples/start/ent/group_query.go
@@ -136,7 +136,7 @@ func (gq *GroupQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Group entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Group entity is not found.
+// Returns a *NotSingularError when more than one Group entity is found.
 // Returns a *NotFoundError when no Group entities are found.
 func (gq *GroupQuery) Only(ctx context.Context) (*Group, error) {
 	nodes, err := gq.Limit(2).All(ctx)
@@ -163,7 +163,7 @@ func (gq *GroupQuery) OnlyX(ctx context.Context) *Group {
 }
 
 // OnlyID is like Only, but returns the only Group ID in the query.
-// Returns a *NotSingularError when exactly one Group ID is not found.
+// Returns a *NotSingularError when more than one Group ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (gq *GroupQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/examples/start/ent/user_query.go
+++ b/examples/start/ent/user_query.go
@@ -160,7 +160,7 @@ func (uq *UserQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single User entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one User entity is not found.
+// Returns a *NotSingularError when more than one User entity is found.
 // Returns a *NotFoundError when no User entities are found.
 func (uq *UserQuery) Only(ctx context.Context) (*User, error) {
 	nodes, err := uq.Limit(2).All(ctx)
@@ -187,7 +187,7 @@ func (uq *UserQuery) OnlyX(ctx context.Context) *User {
 }
 
 // OnlyID is like Only, but returns the only User ID in the query.
-// Returns a *NotSingularError when exactly one User ID is not found.
+// Returns a *NotSingularError when more than one User ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (uq *UserQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/examples/traversal/ent/group_query.go
+++ b/examples/traversal/ent/group_query.go
@@ -160,7 +160,7 @@ func (gq *GroupQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Group entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Group entity is not found.
+// Returns a *NotSingularError when more than one Group entity is found.
 // Returns a *NotFoundError when no Group entities are found.
 func (gq *GroupQuery) Only(ctx context.Context) (*Group, error) {
 	nodes, err := gq.Limit(2).All(ctx)
@@ -187,7 +187,7 @@ func (gq *GroupQuery) OnlyX(ctx context.Context) *Group {
 }
 
 // OnlyID is like Only, but returns the only Group ID in the query.
-// Returns a *NotSingularError when exactly one Group ID is not found.
+// Returns a *NotSingularError when more than one Group ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (gq *GroupQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/examples/traversal/ent/pet_query.go
+++ b/examples/traversal/ent/pet_query.go
@@ -160,7 +160,7 @@ func (pq *PetQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single Pet entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one Pet entity is not found.
+// Returns a *NotSingularError when more than one Pet entity is found.
 // Returns a *NotFoundError when no Pet entities are found.
 func (pq *PetQuery) Only(ctx context.Context) (*Pet, error) {
 	nodes, err := pq.Limit(2).All(ctx)
@@ -187,7 +187,7 @@ func (pq *PetQuery) OnlyX(ctx context.Context) *Pet {
 }
 
 // OnlyID is like Only, but returns the only Pet ID in the query.
-// Returns a *NotSingularError when exactly one Pet ID is not found.
+// Returns a *NotSingularError when more than one Pet ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (pq *PetQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/examples/traversal/ent/user_query.go
+++ b/examples/traversal/ent/user_query.go
@@ -206,7 +206,7 @@ func (uq *UserQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single User entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one User entity is not found.
+// Returns a *NotSingularError when more than one User entity is found.
 // Returns a *NotFoundError when no User entities are found.
 func (uq *UserQuery) Only(ctx context.Context) (*User, error) {
 	nodes, err := uq.Limit(2).All(ctx)
@@ -233,7 +233,7 @@ func (uq *UserQuery) OnlyX(ctx context.Context) *User {
 }
 
 // OnlyID is like Only, but returns the only User ID in the query.
-// Returns a *NotSingularError when exactly one User ID is not found.
+// Returns a *NotSingularError when more than one User ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (uq *UserQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int

--- a/examples/version/ent/user_query.go
+++ b/examples/version/ent/user_query.go
@@ -110,7 +110,7 @@ func (uq *UserQuery) FirstIDX(ctx context.Context) int {
 }
 
 // Only returns a single User entity found by the query, ensuring it only returns one.
-// Returns a *NotSingularError when exactly one User entity is not found.
+// Returns a *NotSingularError when more than one User entity is found.
 // Returns a *NotFoundError when no User entities are found.
 func (uq *UserQuery) Only(ctx context.Context) (*User, error) {
 	nodes, err := uq.Limit(2).All(ctx)
@@ -137,7 +137,7 @@ func (uq *UserQuery) OnlyX(ctx context.Context) *User {
 }
 
 // OnlyID is like Only, but returns the only User ID in the query.
-// Returns a *NotSingularError when exactly one User ID is not found.
+// Returns a *NotSingularError when more than one User ID is found.
 // Returns a *NotFoundError when no entities are found.
 func (uq *UserQuery) OnlyID(ctx context.Context) (id int, err error) {
 	var ids []int


### PR DESCRIPTION
this patch updates the Only/OnlyID methods in the builder template from:

> // Returns a *NotSingularError when exactly one {{ $.Name }} entity is not found.
to
> // Returns a *NotSingularError when more than exactly one {{ $.Name }} ID is found.

in an effort to be more explicit in the explanation of the behavior of the methods.

I caught myself reading the difference between the lines more than a few times just to make sure I truly understood the behavior. Maybe others agree?