### PR TITLE
Add check that model file doesn't already exist on ent init

### DIFF
--- a/cmd/ent/ent_test.go
+++ b/cmd/ent/ent_test.go
@@ -19,6 +19,8 @@ func TestCmd(t *testing.T) {
 	stderr := bytes.NewBuffer(nil)
 	cmd.Stderr = stderr
 	require.NoError(t, cmd.Run(), stderr.String())
+	cmd = exec.Command("go", "run", "entgo.io/ent/cmd/ent", "init", "User")
+	require.Error(t, cmd.Run())
 
 	_, err := os.Stat("ent/generate.go")
 	require.NoError(t, err)

--- a/cmd/internal/base/base.go
+++ b/cmd/internal/base/base.go
@@ -184,6 +184,9 @@ func initEnv(target string, names []string) error {
 		if err := gen.ValidSchemaName(name); err != nil {
 			return fmt.Errorf("init schema %s: %w", name, err)
 		}
+		if fileExists(target, name) {
+			return fmt.Errorf("init schema %s: already exists", name)
+		}
 		b := bytes.NewBuffer(nil)
 		if err := tmpl.Execute(b, name); err != nil {
 			return fmt.Errorf("executing template %s: %w", name, err)
@@ -211,6 +214,12 @@ func createDir(target string) error {
 		return fmt.Errorf("creating generate.go file: %w", err)
 	}
 	return nil
+}
+
+func fileExists(target, name string) bool {
+	var _, err = os.Stat(filepath.Join(target, strings.ToLower(name+".go")))
+
+	return err == nil
 }
 
 // schema template for the "init" command.


### PR DESCRIPTION
Previously if you ran `ent init` it would overwrite an existing file  f that already existed. Now  checks if that file already exists, and returns an error if so.