### PR TITLE
Adding ELI5 video to the home page

### DIFF
--- a/doc/website/src/css/custom.css
+++ b/doc/website/src/css/custom.css
@@ -458,6 +458,10 @@ html {
   padding: 0 15%;
 }
 
+.video h2 {
+  color: white;
+}
+
 .navigationSlider .slidingNav {
   position: relative;
 }

--- a/doc/website/src/pages/index.js
+++ b/doc/website/src/pages/index.js
@@ -61,6 +61,29 @@ const Features = () => (
   </div>
 );
 
+const VideoContainer = () => {
+  return (
+    <div className="container video text--center margin-bottom--lg margin-top--lg">
+      <div className="row">
+        <div className="col" style={{textAlign: 'center'}}>
+          <h2>Check it out in the intro video</h2>
+          <div>
+            <iframe
+              width="560"
+              height="315"
+              src="https://www.youtube.com/embed/RCzeYg-_dbU"
+              title="Explain Like I'm 5: Ent"
+              frameBorder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 class HomeSplash extends React.Component {
   render() {
     const {siteConfig, language = ''} = this.props;
@@ -129,6 +152,7 @@ class HomeSplash extends React.Component {
           <div className="gopherGraph">
             <img src="https://entgo.io/images/assets/gopher_graph.png" />
           </div>
+          <VideoContainer />
           <Features />
         </div>
       </SplashContainer>


### PR DESCRIPTION
## Summary
Here at Meta Open Source, we've been creating short-form videos to explain Meta OSS projects in the simplest terms possible. We started embedding these videos into project pages as you can see in [Docusaurus home page](https://docusaurus.io/), [Jest](https://jestjs.io/), [Litho](https://fblitho.com/), [Hydra](https://hydra.cc/), etc.

Although Ent has moved to Linux foundation, I wanted to propose adding this video to Ent as well, as it's been getting decent views and might benefit the community.


## Test plan
<img width="1305" alt="image" src="https://user-images.githubusercontent.com/12485205/154986510-1c6dd975-96ef-4af1-9536-8b6bc1e28815.png">
