### PR TITLE
dialect/entsql: add support for index-type annotation 

### DIFF
--- a/dialect/entsql/annotation.go
+++ b/dialect/entsql/annotation.go
@@ -224,6 +224,30 @@ type IndexAnnotation struct {
 	//	CREATE INDEX `table_c1_c2_c3` ON `table`(`c1` DESC, `c2` DESC, `c3`)
 	//
 	DescColumns map[string]bool
+
+	// Type defines the type of the index.
+	// In MySQL, the following annotation maps to:
+	//
+	//	index.Fields("c1").
+	//		Annotation(
+	//			entsql.IndexType("FULLTEXT"),
+	//		)
+	//
+	//	CREATE FULLTEXT INDEX `table_c1` ON `table`(`c1`)
+	//
+	Type string
+
+	// Types is like the Type option but allows mapping an index-type per dialect.
+	//
+	//	index.Fields("c1").
+	//		Annotation(
+	//			entsql.IndexTypes(map[string]string{
+	//				dialect.MySQL:		"FULLTEXT",
+	//				dialect.Postgres:	"GIN",
+	//			}),
+	//		)
+	//
+	Types map[string]string
 }
 
 // Prefix returns a new index annotation with a single string column index.
@@ -293,6 +317,34 @@ func DescColumns(names ...string) *IndexAnnotation {
 	return ant
 }
 
+// Type defines the type of the index.
+// In MySQL, the following annotation maps to:
+//
+//	index.Fields("c1").
+//		Annotation(
+//			entsql.IndexType("FULLTEXT"),
+//		)
+//
+//	CREATE FULLTEXT INDEX `table_c1` ON `table`(`c1`)
+//
+func IndexType(t string) *IndexAnnotation {
+	return &IndexAnnotation{Type: t}
+}
+
+// Types is like the Type option but allows mapping an index-type per dialect.
+//
+//	index.Fields("c1").
+//		Annotations(
+//			entsql.IndexTypes(map[string]string{
+//				dialect.MySQL:    "FULLTEXT",
+//				dialect.Postgres: "GIN",
+//			}),
+//		)
+//
+func IndexTypes(types map[string]string) *IndexAnnotation {
+	return &IndexAnnotation{Types: types}
+}
+
 // Name describes the annotation name.
 func (IndexAnnotation) Name() string {
 	return "EntSQLIndexes"
@@ -332,6 +384,12 @@ func (a IndexAnnotation) Merge(other schema.Annotation) schema.Annotation {
 		for column, desc := range ant.DescColumns {
 			a.DescColumns[column] = desc
 		}
+	}
+	if ant.Type != "" {
+		a.Type = ant.Type
+	}
+	if ant.Types != nil {
+		a.Types = ant.Types
 	}
 	return a
 }

--- a/dialect/sql/schema/mysql.go
+++ b/dialect/sql/schema/mysql.go
@@ -951,5 +951,22 @@ func (d *MySQL) atIndex(idx1 *Index, t2 *schema.Table, idx2 *schema.Index) error
 		}
 		idx2.AddParts(part)
 	}
+	if t, ok := indexType(idx1, dialect.MySQL); ok {
+		idx2.AddAttrs(&mysql.IndexType{T: t})
+	}
 	return nil
+}
+
+func indexType(idx *Index, d string) (string, bool) {
+	ant := idx.Annotation
+	if ant == nil {
+		return "", false
+	}
+	if ant.Type != "" {
+		return idx.Annotation.Type, true
+	}
+	if ant.Types != nil && ant.Types[d] != "" {
+		return ant.Types[d], true
+	}
+	return "", false
 }

--- a/dialect/sql/schema/mysql.go
+++ b/dialect/sql/schema/mysql.go
@@ -962,11 +962,11 @@ func indexType(idx *Index, d string) (string, bool) {
 	if ant == nil {
 		return "", false
 	}
-	if ant.Type != "" {
-		return idx.Annotation.Type, true
-	}
 	if ant.Types != nil && ant.Types[d] != "" {
 		return ant.Types[d], true
+	}
+	if ant.Type != "" {
+		return ant.Type, true
 	}
 	return "", false
 }

--- a/dialect/sql/schema/postgres.go
+++ b/dialect/sql/schema/postgres.go
@@ -779,5 +779,8 @@ func (d *Postgres) atIndex(idx1 *Index, t2 *schema.Table, idx2 *schema.Index) er
 		}
 		idx2.AddParts(&schema.IndexPart{C: c2})
 	}
+	if t, ok := indexType(idx1, dialect.Postgres); ok {
+		idx2.AddAttrs(&postgres.IndexType{T: t})
+	}
 	return nil
 }

--- a/entc/gen/template/migrate/schema.tmpl
+++ b/entc/gen/template/migrate/schema.tmpl
@@ -130,6 +130,16 @@ var (
 										{{- end }}
 										},
 									{{- end }}
+									{{- with $ant.Type }}
+										Type: "{{ . }}",
+									{{- end }}
+									{{- with $keys := keys $ant.Types }}
+										Types: map[string]string{
+											{{- range $k := $keys }}
+												"{{ $k }}": "{{ index $ant.Types $k }}",
+											{{- end }}
+										},
+									{{- end }}
 								},
 							{{- end }}
 						},

--- a/entc/integration/migrate/entv2/migrate/schema.go
+++ b/entc/integration/migrate/entv2/migrate/schema.go
@@ -170,6 +170,16 @@ var (
 					Desc: true,
 				},
 			},
+			{
+				Name:    "user_nickname",
+				Unique:  false,
+				Columns: []*schema.Column{UsersColumns[6]},
+				Annotation: &entsql.IndexAnnotation{
+					Types: map[string]string{
+						"mysql": "FULLTEXT",
+					},
+				},
+			},
 		},
 	}
 	// FriendsColumns holds the columns for the "friends" table.

--- a/entc/integration/migrate/entv2/schema/user.go
+++ b/entc/integration/migrate/entv2/schema/user.go
@@ -7,9 +7,8 @@ package schema
 import (
 	"time"
 
-	"entgo.io/ent/dialect"
-
 	"entgo.io/ent"
+	"entgo.io/ent/dialect"
 	"entgo.io/ent/dialect/entsql"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
@@ -128,11 +127,12 @@ func (User) Indexes() []ent.Index {
 			Unique(),
 		index.Fields("age").
 			Annotations(entsql.Desc()),
+		// Enable FULLTEXT search on "nickname"
+		// field only in MySQL.
 		index.Fields("nickname").
 			Annotations(
 				entsql.IndexTypes(map[string]string{
-					dialect.MySQL:    "FULLTEXT",
-					dialect.Postgres: "GIN",
+					dialect.MySQL: "FULLTEXT",
 				}),
 			),
 	}

--- a/entc/integration/migrate/entv2/schema/user.go
+++ b/entc/integration/migrate/entv2/schema/user.go
@@ -7,6 +7,8 @@ package schema
 import (
 	"time"
 
+	"entgo.io/ent/dialect"
+
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/entsql"
 	"entgo.io/ent/schema/edge"
@@ -126,6 +128,13 @@ func (User) Indexes() []ent.Index {
 			Unique(),
 		index.Fields("age").
 			Annotations(entsql.Desc()),
+		index.Fields("nickname").
+			Annotations(
+				entsql.IndexTypes(map[string]string{
+					dialect.MySQL:    "FULLTEXT",
+					dialect.Postgres: "GIN",
+				}),
+			),
 	}
 }
 


### PR DESCRIPTION
In future PRs, we can add support for `Search` predicates to simplify constructing the WHERE expression manually. Also, we should consider add the common index types to entsql:

```go
entsql.FullText()
entgql.GIN()
...
```