### PR TITLE
Add required json1 build tag to contributing instructions.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Then, in `entc/integration` run `docker-compose` in order to spin-up all databas
 docker-compose -f docker-compose.yaml up -d
 ```
 
-Then, run `go test ./...` to run all integration tests.
+Then, run `go test -tags json1 ./...` to run all integration tests.
 
 
 ## Pull Requests


### PR DESCRIPTION
Ent tests require the `json1` build flag to enable JSON support in SQLite, otherwise the tests fail with an error:

~~~
--- FAIL: TestSQLite (0.00s)
    json_test.go:232:
        	Error Trace:	json_test.go:232
        	            				json_test.go:130
        	Error:      	Received unexpected error:
        	            	no such function: JSON_EXTRACT
        	Test:       	TestSQLite
FAIL
~~~

Let's make it easy on first-time contributors by prompting them to use this flag in the contributing documentation.