### PR TITLE
dialect/sql/schema: add name to versioned migration files

### DIFF
--- a/dialect/sql/schema/atlas.go
+++ b/dialect/sql/schema/atlas.go
@@ -364,7 +364,7 @@ func (m *Migrate) atDiff(ctx context.Context, conn dialect.ExecQuerier, tables .
 		return nil, err
 	}
 	// Plan changes.
-	return drv.PlanChanges(ctx, "", changes)
+	return drv.PlanChanges(ctx, "changes", changes)
 }
 
 type db struct{ dialect.ExecQuerier }

--- a/dialect/sql/schema/migrate.go
+++ b/dialect/sql/schema/migrate.go
@@ -171,6 +171,10 @@ func (m *Migrate) Diff(ctx context.Context, tables ...*Table) error {
 	if err != nil {
 		return err
 	}
+	// Skip if the plan has no changes
+	if len(plan.Changes) == 0 {
+		return nil
+	}
 	return migrate.New(nil, m.atlas.dir, m.atlas.fmt).WritePlan(plan)
 }
 


### PR DESCRIPTION
Currently, `golang-migrate` will not be able to scan versioned migration files generated because the filename does not match this pattern: [^([0-9]+)_(.*)\.(down|up)\.(. *)$](https://github.com/golang-migrate/migrate/blob/57aead3125fa6354d48199ac37f5bca5293ee600/source/parse.go#L21). So to satisfy the above pattern, we need to add names for the versioned migration files.

Another thing is that we should not execute `Planner.WritePlan` if there are no changes. Otherwise, it will generate empty migration files.