### PR TITLE
dialect/sql/schema: add method to create a named versioned migration …

### DIFF
--- a/dialect/sql/schema/atlas.go
+++ b/dialect/sql/schema/atlas.go
@@ -308,7 +308,7 @@ func (m *Migrate) atCreate(ctx context.Context, tables ...*Table) error {
 				return err
 			}
 		}
-		plan, err := m.atDiff(ctx, tx, tables...)
+		plan, err := m.atDiff(ctx, tx, "", tables...)
 		if err != nil {
 			return err
 		}
@@ -334,7 +334,7 @@ func (m *Migrate) atCreate(ctx context.Context, tables ...*Table) error {
 	return tx.Commit()
 }
 
-func (m *Migrate) atDiff(ctx context.Context, conn dialect.ExecQuerier, tables ...*Table) (*migrate.Plan, error) {
+func (m *Migrate) atDiff(ctx context.Context, conn dialect.ExecQuerier, name string, tables ...*Table) (*migrate.Plan, error) {
 	drv, err := m.atOpen(conn)
 	if err != nil {
 		return nil, err
@@ -364,7 +364,7 @@ func (m *Migrate) atDiff(ctx context.Context, conn dialect.ExecQuerier, tables .
 		return nil, err
 	}
 	// Plan changes.
-	return drv.PlanChanges(ctx, "changes", changes)
+	return drv.PlanChanges(ctx, name, changes)
 }
 
 type db struct{ dialect.ExecQuerier }

--- a/dialect/sql/schema/migrate.go
+++ b/dialect/sql/schema/migrate.go
@@ -164,10 +164,16 @@ func (m *Migrate) Create(ctx context.Context, tables ...*Table) error {
 // Diff compares the state read from the StateReader with the state defined by Ent.
 // Changes will be written to migration files by the configures Planner.
 func (m *Migrate) Diff(ctx context.Context, tables ...*Table) error {
+	return m.NamedDiff(ctx, "changes", tables...)
+}
+
+// NamedDiff compares the state read from the StateReader with the state defined by Ent.
+// Changes will be written to migration files by the configures Planner.
+func (m *Migrate) NamedDiff(ctx context.Context, name string, tables ...*Table) error {
 	if m.atlas.dir == nil {
 		return errors.New("no migration directory given")
 	}
-	plan, err := m.atDiff(ctx, m, tables...)
+	plan, err := m.atDiff(ctx, m, name, tables...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
…file

As suggested in #2382 this adds a new method `NamedDiff()` to create migration files with a name.