### PR TITLE
Update getting-started.md

### DIFF
--- a/doc/md/getting-started.md
+++ b/doc/md/getting-started.md
@@ -29,7 +29,7 @@ go mod init <project>
 ## Installation
 
 ```console
-go get -d entgo.io/ent/cmd/ent
+go install entgo.io/ent/cmd/ent@latest
 ```
 
 After installing `ent` codegen tool, you should have it in your `PATH`.


### PR DESCRIPTION
Since Go 1.18 is now released, `go get` is no longer the way to download a command for any supported version: updated to use go install instead.