### PR TITLE
Update schema-def to use proper method

### DIFF
--- a/doc/md/schema-def.md
+++ b/doc/md/schema-def.md
@@ -43,7 +43,7 @@ func (User) Edges() []ent.Edge {
 	}
 }
 
-func (User) Index() []ent.Index {
+func (User) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("age", "name").
 			Unique(),


### PR DESCRIPTION
The exemple incorrectly adds an ignored `User.Index` method, although ent actually needs a `User.Indexes` method as part of `ent.Interface`