### PR TITLE
init db version before executing diff

### DIFF
--- a/dialect/sql/schema/migrate.go
+++ b/dialect/sql/schema/migrate.go
@@ -173,6 +173,9 @@ func (m *Migrate) NamedDiff(ctx context.Context, name string, tables ...*Table) 
 	if m.atlas.dir == nil {
 		return errors.New("no migration directory given")
 	}
+	if err := m.init(ctx, m); err != nil {
+		return err
+	}
 	plan, err := m.atDiff(ctx, m, name, tables...)
 	if err != nil {
 		return err


### PR DESCRIPTION
What's the problem: Under versioned migration on MySQL 8.0, unique string field would be generated as type varchar(191) instead of varchar(255). This is because in generating migration files by NamedDiff(), sqlDialect's init() method is not called. 

Further concern: For init() function, MySQL and Postgres's implementation checks the database version which is what I want. But SQLite's implementation checks the foreign_keys support. So I think there might be a better may to check the database version before doing Diff().