### PR TITLE
doc/md: document custom where filters

### DIFF
--- a/doc/md/tutorial-todo-gql-filter-input.md
+++ b/doc/md/tutorial-todo-gql-filter-input.md
@@ -288,13 +288,11 @@ func (r *todoWhereInputResolver) IsCompleted(ctx context.Context, obj *ent.TodoW
 	if obj == nil || data == nil {
 		return nil
 	}
-
 	if *data {
 		obj.AddPredicates(todo.StatusEQ(todo.StatusCompleted))
 	} else {
 		obj.AddPredicates(todo.StatusNEQ(todo.StatusCompleted))
 	}
-
 	return nil
 }
 ```


### PR DESCRIPTION
A few points:

- I could not think of a better example for the custom filter, I wanted to use a where filter for a field present in the page, so this limited me to `createdAt` and `status`.
- Dependencies of https://github.com/a8m/ent-graphql-example should be updated to make it work.
- I linked the `Templates` and `SchemaHooks` with docs for the `@master` version, but we should change it to a permanent version.
