### PR TITLE
Sub queries

### DIFF
--- a/dialect/sql/builder.go
+++ b/dialect/sql/builder.go
@@ -2657,12 +2657,13 @@ func (s *Selector) Query() (string, []interface{}) {
 	} else {
 		b.WriteString("*")
 	}
-	b.WriteString(" FROM ")
 	switch t := s.from.(type) {
 	case *SelectTable:
+		b.WriteString(" FROM ")
 		t.SetDialect(s.dialect)
 		b.WriteString(t.ref())
 	case *Selector:
+		b.WriteString(" FROM ")
 		t.SetDialect(s.dialect)
 		b.Nested(func(b *Builder) {
 			b.Join(t)
@@ -2670,6 +2671,7 @@ func (s *Selector) Query() (string, []interface{}) {
 		b.WriteString(" AS ")
 		b.Ident(t.as)
 	case *WithBuilder:
+		b.WriteString(" FROM ")
 		t.SetDialect(s.dialect)
 		b.Ident(t.Name())
 	}

--- a/dialect/sql/builder_test.go
+++ b/dialect/sql/builder_test.go
@@ -1289,6 +1289,10 @@ func TestBuilder(t *testing.T) {
 			wantArgs:  []interface{}{"bar"},
 		},
 		{
+			input:     SelectExpr(Raw("1")),
+			wantQuery: "SELECT 1",
+		},
+		{
 			input: func() Querier {
 				builder := Dialect(dialect.Postgres)
 				t1 := builder.Table("groups")

--- a/dialect/sql/builder_test.go
+++ b/dialect/sql/builder_test.go
@@ -1293,6 +1293,10 @@ func TestBuilder(t *testing.T) {
 			wantQuery: "SELECT 1",
 		},
 		{
+			input:     Select("*").From(SelectExpr(Raw("1")).As("s")),
+			wantQuery: "SELECT * FROM (SELECT 1) AS `s`",
+		},
+		{
 			input: func() Querier {
 				builder := Dialect(dialect.Postgres)
 				t1 := builder.Table("groups")

--- a/entc/integration/integration_test.go
+++ b/entc/integration/integration_test.go
@@ -689,6 +689,16 @@ func Select(t *testing.T, client *ent.Client) {
 	}).Int(ctx)
 	require.NoError(err)
 	require.Equal(1, i)
+	// example with join
+	u = client.User.Create().SetName("crossworth").SetAge(28).SaveX(ctx)
+	userTable := sql.Table(user.Table)
+	subQuery = sql.Select("id").From(userTable).Where(sql.EQ(userTable.C(user.FieldName), "crossworth"))
+	users = client.User.Query().Modify(func(s *sql.Selector) {
+		s.Select("*").From(userTable)
+		s.Join(subQuery).On(userTable.C("id"), subQuery.C("id"))
+	}).AllX(ctx)
+	require.Len(users, 1)
+	require.Equal(u.ID, users[0].ID)
 }
 
 func ExecQuery(t *testing.T, client *ent.Client) {

--- a/entc/integration/integration_test.go
+++ b/entc/integration/integration_test.go
@@ -692,15 +692,15 @@ func Select(t *testing.T, client *ent.Client) {
 		Int(ctx)
 	require.NoError(err)
 	require.Equal(1, i)
-	
+
 	// Select with join.
 	u = client.User.Create().SetName("crossworth").SetAge(28).SaveX(ctx)
 	id := client.User.
 		Query().
-		Modify(func(s *sql.Selector) {
+		Where(func(s *sql.Selector) {
 			subQuery := sql.Select(user.FieldID).
 				From(sql.Table(user.Table)).
-				Where(sql.EQ(userT.C(user.FieldName), "crossworth"))
+				Where(sql.EQ(s.C(user.FieldName), "crossworth"))
 			s.Join(subQuery).On(s.C(user.FieldID), subQuery.C(user.FieldID))
 		}).
 		OnlyIDX(ctx)

--- a/entc/integration/integration_test.go
+++ b/entc/integration/integration_test.go
@@ -680,6 +680,15 @@ func Select(t *testing.T, client *ent.Client) {
 	require.Len(gs, 2)
 	require.Equal(hub.QueryUsers().CountX(ctx), gs[0].UsersCount)
 	require.Equal(lab.QueryUsers().CountX(ctx), gs[1].UsersCount)
+
+	// Select Subquery.
+	t.Log("select subquery")
+	subQuery := sql.SelectExpr(sql.Raw("1"))
+	i, err := client.User.Query().Modify(func(s *sql.Selector) {
+		s.Select("*").From(subQuery.As("s"))
+	}).Int(ctx)
+	require.NoError(err)
+	require.Equal(1, i)
 }
 
 func ExecQuery(t *testing.T, client *ent.Client) {


### PR DESCRIPTION
This PR adds a few example of the sub-query usage, I could not think a better example for the join case.
Related: https://github.com/ent/ent/issues/2484#issuecomment-1108492471

I have changed the `builder.go` as well otherwise a empty `FROM` is always generated:
![image](https://user-images.githubusercontent.com/1251151/166089685-3e038129-8a8e-4b96-8129-a8dc82675aba.png)
