### PR TITLE
Fix propagating post-save mutations

### DIFF
--- a/entc/gen/template/builder/create.tmpl
+++ b/entc/gen/template/builder/create.tmpl
@@ -83,8 +83,10 @@ func ({{ $receiver }} *{{ $builder }}) Save(ctx context.Context) (*{{ $.Name }},
 			}
 			mut = {{ $receiver }}.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, {{ $mutation }}); err != nil {
+		if v, err := mut.Mutate(ctx, {{ $mutation }}); err != nil {
 			return nil, err
+		} else if v, ok := v.(*{{ $.Name }}); ok {
+			node = v
 		}
 	}
 	return node, err

--- a/entc/gen/template/builder/create.tmpl
+++ b/entc/gen/template/builder/create.tmpl
@@ -83,11 +83,15 @@ func ({{ $receiver }} *{{ $builder }}) Save(ctx context.Context) (*{{ $.Name }},
 			}
 			mut = {{ $receiver }}.hooks[i](mut)
 		}
-		if v, err := mut.Mutate(ctx, {{ $mutation }}); err != nil {
+		v, err := mut.Mutate(ctx, {{ $mutation }})
+		if err != nil {
 			return nil, err
-		} else if v, ok := v.(*{{ $.Name }}); ok {
-			node = v
 		}
+		 nv, ok := v.(*{{ $.Name }})
+		 if !ok {
+		 	 return nil, fmt.Errorf("unexpected node type %T returned from {{ $.MutationName }}", v)
+		 }
+		 node = nv
 	}
 	return node, err
 }

--- a/entc/gen/template/builder/create.tmpl
+++ b/entc/gen/template/builder/create.tmpl
@@ -87,11 +87,11 @@ func ({{ $receiver }} *{{ $builder }}) Save(ctx context.Context) (*{{ $.Name }},
 		if err != nil {
 			return nil, err
 		}
-		 nv, ok := v.(*{{ $.Name }})
-		 if !ok {
-		 	 return nil, fmt.Errorf("unexpected node type %T returned from {{ $.MutationName }}", v)
-		 }
-		 node = nv
+		nv, ok := v.(*{{ $.Name }})
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from {{ $.MutationName }}", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/gen/template/builder/update.tmpl
+++ b/entc/gen/template/builder/update.tmpl
@@ -197,9 +197,15 @@ func ({{ $receiver }} *{{ $onebuilder }} ) Save(ctx context.Context) (*{{ $.Name
 			}
 			mut = {{ $receiver }}.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, {{ $mutation }}); err != nil {
+		v, err := mut.Mutate(ctx, {{ $mutation }})
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*{{ $.Name }})
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from {{ $.MutationName }}", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/cascadelete/ent/comment_create.go
+++ b/entc/integration/cascadelete/ent/comment_create.go
@@ -80,9 +80,15 @@ func (cc *CommentCreate) Save(ctx context.Context) (*Comment, error) {
 			}
 			mut = cc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, cc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, cc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Comment)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from CommentMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/cascadelete/ent/comment_update.go
+++ b/entc/integration/cascadelete/ent/comment_update.go
@@ -273,9 +273,15 @@ func (cuo *CommentUpdateOne) Save(ctx context.Context) (*Comment, error) {
 			}
 			mut = cuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, cuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, cuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Comment)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from CommentMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/cascadelete/ent/post_create.go
+++ b/entc/integration/cascadelete/ent/post_create.go
@@ -113,9 +113,15 @@ func (pc *PostCreate) Save(ctx context.Context) (*Post, error) {
 			}
 			mut = pc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, pc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, pc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Post)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from PostMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/cascadelete/ent/post_update.go
+++ b/entc/integration/cascadelete/ent/post_update.go
@@ -424,9 +424,15 @@ func (puo *PostUpdateOne) Save(ctx context.Context) (*Post, error) {
 			}
 			mut = puo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, puo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, puo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Post)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from PostMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/cascadelete/ent/user_create.go
+++ b/entc/integration/cascadelete/ent/user_create.go
@@ -93,9 +93,15 @@ func (uc *UserCreate) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/cascadelete/ent/user_update.go
+++ b/entc/integration/cascadelete/ent/user_update.go
@@ -326,9 +326,15 @@ func (uuo *UserUpdateOne) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/config/ent/user_create.go
+++ b/entc/integration/config/ent/user_create.go
@@ -95,9 +95,15 @@ func (uc *UserCreate) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/config/ent/user_update.go
+++ b/entc/integration/config/ent/user_update.go
@@ -270,9 +270,15 @@ func (uuo *UserUpdateOne) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/customid/ent/account_create.go
+++ b/entc/integration/customid/ent/account_create.go
@@ -103,9 +103,15 @@ func (ac *AccountCreate) Save(ctx context.Context) (*Account, error) {
 			}
 			mut = ac.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, ac.mutation); err != nil {
+		v, err := mut.Mutate(ctx, ac.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Account)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from AccountMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/customid/ent/account_update.go
+++ b/entc/integration/customid/ent/account_update.go
@@ -333,9 +333,15 @@ func (auo *AccountUpdateOne) Save(ctx context.Context) (*Account, error) {
 			}
 			mut = auo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, auo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, auo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Account)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from AccountMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/customid/ent/blob_create.go
+++ b/entc/integration/customid/ent/blob_create.go
@@ -143,9 +143,15 @@ func (bc *BlobCreate) Save(ctx context.Context) (*Blob, error) {
 			}
 			mut = bc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, bc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, bc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Blob)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from BlobMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/customid/ent/blob_update.go
+++ b/entc/integration/customid/ent/blob_update.go
@@ -467,9 +467,15 @@ func (buo *BlobUpdateOne) Save(ctx context.Context) (*Blob, error) {
 			}
 			mut = buo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, buo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, buo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Blob)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from BlobMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/customid/ent/car_create.go
+++ b/entc/integration/customid/ent/car_create.go
@@ -124,9 +124,15 @@ func (cc *CarCreate) Save(ctx context.Context) (*Car, error) {
 			}
 			mut = cc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, cc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, cc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Car)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from CarMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/customid/ent/car_update.go
+++ b/entc/integration/customid/ent/car_update.go
@@ -444,9 +444,15 @@ func (cuo *CarUpdateOne) Save(ctx context.Context) (*Car, error) {
 			}
 			mut = cuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, cuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, cuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Car)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from CarMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/customid/ent/device_create.go
+++ b/entc/integration/customid/ent/device_create.go
@@ -116,9 +116,15 @@ func (dc *DeviceCreate) Save(ctx context.Context) (*Device, error) {
 			}
 			mut = dc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, dc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, dc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Device)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from DeviceMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/customid/ent/device_update.go
+++ b/entc/integration/customid/ent/device_update.go
@@ -377,9 +377,15 @@ func (duo *DeviceUpdateOne) Save(ctx context.Context) (*Device, error) {
 			}
 			mut = duo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, duo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, duo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Device)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from DeviceMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/customid/ent/doc_create.go
+++ b/entc/integration/customid/ent/doc_create.go
@@ -129,9 +129,15 @@ func (dc *DocCreate) Save(ctx context.Context) (*Doc, error) {
 			}
 			mut = dc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, dc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, dc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Doc)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from DocMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/customid/ent/doc_update.go
+++ b/entc/integration/customid/ent/doc_update.go
@@ -429,9 +429,15 @@ func (duo *DocUpdateOne) Save(ctx context.Context) (*Doc, error) {
 			}
 			mut = duo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, duo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, duo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Doc)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from DocMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/customid/ent/group_create.go
+++ b/entc/integration/customid/ent/group_create.go
@@ -86,9 +86,15 @@ func (gc *GroupCreate) Save(ctx context.Context) (*Group, error) {
 			}
 			mut = gc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, gc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, gc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Group)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from GroupMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/customid/ent/group_update.go
+++ b/entc/integration/customid/ent/group_update.go
@@ -291,9 +291,15 @@ func (guo *GroupUpdateOne) Save(ctx context.Context) (*Group, error) {
 			}
 			mut = guo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, guo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, guo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Group)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from GroupMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/customid/ent/mixinid_create.go
+++ b/entc/integration/customid/ent/mixinid_create.go
@@ -93,9 +93,15 @@ func (mic *MixinIDCreate) Save(ctx context.Context) (*MixinID, error) {
 			}
 			mut = mic.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, mic.mutation); err != nil {
+		v, err := mut.Mutate(ctx, mic.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*MixinID)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from MixinIDMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/customid/ent/mixinid_update.go
+++ b/entc/integration/customid/ent/mixinid_update.go
@@ -202,9 +202,15 @@ func (miuo *MixinIDUpdateOne) Save(ctx context.Context) (*MixinID, error) {
 			}
 			mut = miuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, miuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, miuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*MixinID)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from MixinIDMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/customid/ent/note_create.go
+++ b/entc/integration/customid/ent/note_create.go
@@ -129,9 +129,15 @@ func (nc *NoteCreate) Save(ctx context.Context) (*Note, error) {
 			}
 			mut = nc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, nc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, nc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Note)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from NoteMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/customid/ent/note_update.go
+++ b/entc/integration/customid/ent/note_update.go
@@ -429,9 +429,15 @@ func (nuo *NoteUpdateOne) Save(ctx context.Context) (*Note, error) {
 			}
 			mut = nuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, nuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, nuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Note)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from NoteMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/customid/ent/other_create.go
+++ b/entc/integration/customid/ent/other_create.go
@@ -81,9 +81,15 @@ func (oc *OtherCreate) Save(ctx context.Context) (*Other, error) {
 			}
 			mut = oc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, oc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, oc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Other)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from OtherMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/customid/ent/other_update.go
+++ b/entc/integration/customid/ent/other_update.go
@@ -164,9 +164,15 @@ func (ouo *OtherUpdateOne) Save(ctx context.Context) (*Other, error) {
 			}
 			mut = ouo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, ouo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, ouo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Other)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from OtherMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/customid/ent/pet_create.go
+++ b/entc/integration/customid/ent/pet_create.go
@@ -150,9 +150,15 @@ func (pc *PetCreate) Save(ctx context.Context) (*Pet, error) {
 			}
 			mut = pc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, pc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, pc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Pet)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from PetMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/customid/ent/pet_update.go
+++ b/entc/integration/customid/ent/pet_update.go
@@ -588,9 +588,15 @@ func (puo *PetUpdateOne) Save(ctx context.Context) (*Pet, error) {
 			}
 			mut = puo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, puo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, puo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Pet)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from PetMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/customid/ent/revision_create.go
+++ b/entc/integration/customid/ent/revision_create.go
@@ -71,9 +71,15 @@ func (rc *RevisionCreate) Save(ctx context.Context) (*Revision, error) {
 			}
 			mut = rc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, rc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, rc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Revision)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from RevisionMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/customid/ent/revision_update.go
+++ b/entc/integration/customid/ent/revision_update.go
@@ -164,9 +164,15 @@ func (ruo *RevisionUpdateOne) Save(ctx context.Context) (*Revision, error) {
 			}
 			mut = ruo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, ruo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, ruo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Revision)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from RevisionMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/customid/ent/session_create.go
+++ b/entc/integration/customid/ent/session_create.go
@@ -101,9 +101,15 @@ func (sc *SessionCreate) Save(ctx context.Context) (*Session, error) {
 			}
 			mut = sc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, sc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, sc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Session)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from SessionMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/customid/ent/session_update.go
+++ b/entc/integration/customid/ent/session_update.go
@@ -251,9 +251,15 @@ func (suo *SessionUpdateOne) Save(ctx context.Context) (*Session, error) {
 			}
 			mut = suo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, suo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, suo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Session)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from SessionMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/customid/ent/token_create.go
+++ b/entc/integration/customid/ent/token_create.go
@@ -99,9 +99,15 @@ func (tc *TokenCreate) Save(ctx context.Context) (*Token, error) {
 			}
 			mut = tc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, tc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, tc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Token)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from TokenMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/customid/ent/token_update.go
+++ b/entc/integration/customid/ent/token_update.go
@@ -279,9 +279,15 @@ func (tuo *TokenUpdateOne) Save(ctx context.Context) (*Token, error) {
 			}
 			mut = tuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, tuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, tuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Token)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from TokenMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/customid/ent/user_create.go
+++ b/entc/integration/customid/ent/user_create.go
@@ -136,9 +136,15 @@ func (uc *UserCreate) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/customid/ent/user_update.go
+++ b/entc/integration/customid/ent/user_update.go
@@ -629,9 +629,15 @@ func (uuo *UserUpdateOne) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/edgefield/ent/car_create.go
+++ b/entc/integration/edgefield/ent/car_create.go
@@ -107,9 +107,15 @@ func (cc *CarCreate) Save(ctx context.Context) (*Car, error) {
 			}
 			mut = cc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, cc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, cc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Car)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from CarMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/edgefield/ent/car_update.go
+++ b/entc/integration/edgefield/ent/car_update.go
@@ -344,9 +344,15 @@ func (cuo *CarUpdateOne) Save(ctx context.Context) (*Car, error) {
 			}
 			mut = cuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, cuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, cuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Car)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from CarMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/edgefield/ent/card_create.go
+++ b/entc/integration/edgefield/ent/card_create.go
@@ -95,9 +95,15 @@ func (cc *CardCreate) Save(ctx context.Context) (*Card, error) {
 			}
 			mut = cc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, cc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, cc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Card)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from CardMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/edgefield/ent/card_update.go
+++ b/entc/integration/edgefield/ent/card_update.go
@@ -315,9 +315,15 @@ func (cuo *CardUpdateOne) Save(ctx context.Context) (*Card, error) {
 			}
 			mut = cuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, cuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, cuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Card)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from CardMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/edgefield/ent/info_create.go
+++ b/entc/integration/edgefield/ent/info_create.go
@@ -95,9 +95,15 @@ func (ic *InfoCreate) Save(ctx context.Context) (*Info, error) {
 			}
 			mut = ic.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, ic.mutation); err != nil {
+		v, err := mut.Mutate(ctx, ic.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Info)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from InfoMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/edgefield/ent/info_update.go
+++ b/entc/integration/edgefield/ent/info_update.go
@@ -270,9 +270,15 @@ func (iuo *InfoUpdateOne) Save(ctx context.Context) (*Info, error) {
 			}
 			mut = iuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, iuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, iuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Info)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from InfoMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/edgefield/ent/metadata_create.go
+++ b/entc/integration/edgefield/ent/metadata_create.go
@@ -137,9 +137,15 @@ func (mc *MetadataCreate) Save(ctx context.Context) (*Metadata, error) {
 			}
 			mut = mc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, mc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, mc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Metadata)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from MetadataMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/edgefield/ent/metadata_update.go
+++ b/entc/integration/edgefield/ent/metadata_update.go
@@ -529,9 +529,15 @@ func (muo *MetadataUpdateOne) Save(ctx context.Context) (*Metadata, error) {
 			}
 			mut = muo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, muo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, muo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Metadata)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from MetadataMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/edgefield/ent/node_create.go
+++ b/entc/integration/edgefield/ent/node_create.go
@@ -115,9 +115,15 @@ func (nc *NodeCreate) Save(ctx context.Context) (*Node, error) {
 			}
 			mut = nc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, nc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, nc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Node)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from NodeMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/edgefield/ent/node_update.go
+++ b/entc/integration/edgefield/ent/node_update.go
@@ -402,9 +402,15 @@ func (nuo *NodeUpdateOne) Save(ctx context.Context) (*Node, error) {
 			}
 			mut = nuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, nuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, nuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Node)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from NodeMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/edgefield/ent/pet_create.go
+++ b/entc/integration/edgefield/ent/pet_create.go
@@ -81,9 +81,15 @@ func (pc *PetCreate) Save(ctx context.Context) (*Pet, error) {
 			}
 			mut = pc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, pc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, pc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Pet)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from PetMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/edgefield/ent/pet_update.go
+++ b/entc/integration/edgefield/ent/pet_update.go
@@ -262,9 +262,15 @@ func (puo *PetUpdateOne) Save(ctx context.Context) (*Pet, error) {
 			}
 			mut = puo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, puo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, puo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Pet)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from PetMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/edgefield/ent/post_create.go
+++ b/entc/integration/edgefield/ent/post_create.go
@@ -88,9 +88,15 @@ func (pc *PostCreate) Save(ctx context.Context) (*Post, error) {
 			}
 			mut = pc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, pc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, pc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Post)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from PostMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/edgefield/ent/post_update.go
+++ b/entc/integration/edgefield/ent/post_update.go
@@ -281,9 +281,15 @@ func (puo *PostUpdateOne) Save(ctx context.Context) (*Post, error) {
 			}
 			mut = puo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, puo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, puo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Post)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from PostMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/edgefield/ent/rental_create.go
+++ b/entc/integration/edgefield/ent/rental_create.go
@@ -103,9 +103,15 @@ func (rc *RentalCreate) Save(ctx context.Context) (*Rental, error) {
 			}
 			mut = rc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, rc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, rc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Rental)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from RentalMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/edgefield/ent/rental_update.go
+++ b/entc/integration/edgefield/ent/rental_update.go
@@ -364,9 +364,15 @@ func (ruo *RentalUpdateOne) Save(ctx context.Context) (*Rental, error) {
 			}
 			mut = ruo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, ruo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, ruo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Rental)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from RentalMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/edgefield/ent/user_create.go
+++ b/entc/integration/edgefield/ent/user_create.go
@@ -208,9 +208,15 @@ func (uc *UserCreate) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/edgefield/ent/user_update.go
+++ b/entc/integration/edgefield/ent/user_update.go
@@ -1037,9 +1037,15 @@ func (uuo *UserUpdateOne) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/ent/card_create.go
+++ b/entc/integration/ent/card_create.go
@@ -164,9 +164,15 @@ func (cc *CardCreate) Save(ctx context.Context) (*Card, error) {
 			}
 			mut = cc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, cc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, cc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Card)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from CardMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/ent/card_update.go
+++ b/entc/integration/ent/card_update.go
@@ -538,9 +538,15 @@ func (cuo *CardUpdateOne) Save(ctx context.Context) (*Card, error) {
 			}
 			mut = cuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, cuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, cuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Card)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from CardMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/ent/comment_create.go
+++ b/entc/integration/ent/comment_create.go
@@ -104,9 +104,15 @@ func (cc *CommentCreate) Save(ctx context.Context) (*Comment, error) {
 			}
 			mut = cc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, cc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, cc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Comment)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from CommentMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/ent/comment_update.go
+++ b/entc/integration/ent/comment_update.go
@@ -371,9 +371,15 @@ func (cuo *CommentUpdateOne) Save(ctx context.Context) (*Comment, error) {
 			}
 			mut = cuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, cuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, cuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Comment)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from CommentMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/ent/fieldtype_create.go
+++ b/entc/integration/ent/fieldtype_create.go
@@ -829,9 +829,15 @@ func (ftc *FieldTypeCreate) Save(ctx context.Context) (*FieldType, error) {
 			}
 			mut = ftc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, ftc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, ftc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*FieldType)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from FieldTypeMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/ent/fieldtype_update.go
+++ b/entc/integration/ent/fieldtype_update.go
@@ -3846,9 +3846,15 @@ func (ftuo *FieldTypeUpdateOne) Save(ctx context.Context) (*FieldType, error) {
 			}
 			mut = ftuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, ftuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, ftuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*FieldType)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from FieldTypeMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/ent/file_create.go
+++ b/entc/integration/ent/file_create.go
@@ -183,9 +183,15 @@ func (fc *FileCreate) Save(ctx context.Context) (*File, error) {
 			}
 			mut = fc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, fc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, fc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*File)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from FileMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/ent/file_update.go
+++ b/entc/integration/ent/file_update.go
@@ -719,9 +719,15 @@ func (fuo *FileUpdateOne) Save(ctx context.Context) (*File, error) {
 			}
 			mut = fuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, fuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, fuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*File)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from FileMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/ent/filetype_create.go
+++ b/entc/integration/ent/filetype_create.go
@@ -115,9 +115,15 @@ func (ftc *FileTypeCreate) Save(ctx context.Context) (*FileType, error) {
 			}
 			mut = ftc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, ftc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, ftc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*FileType)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from FileTypeMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/ent/filetype_update.go
+++ b/entc/integration/ent/filetype_update.go
@@ -407,9 +407,15 @@ func (ftuo *FileTypeUpdateOne) Save(ctx context.Context) (*FileType, error) {
 			}
 			mut = ftuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, ftuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, ftuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*FileType)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from FileTypeMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/ent/goods_create.go
+++ b/entc/integration/ent/goods_create.go
@@ -64,9 +64,15 @@ func (gc *GoodsCreate) Save(ctx context.Context) (*Goods, error) {
 			}
 			mut = gc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, gc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, gc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Goods)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from GoodsMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/ent/goods_update.go
+++ b/entc/integration/ent/goods_update.go
@@ -164,9 +164,15 @@ func (guo *GoodsUpdateOne) Save(ctx context.Context) (*Goods, error) {
 			}
 			mut = guo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, guo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, guo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Goods)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from GoodsMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/ent/group_create.go
+++ b/entc/integration/ent/group_create.go
@@ -179,9 +179,15 @@ func (gc *GroupCreate) Save(ctx context.Context) (*Group, error) {
 			}
 			mut = gc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, gc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, gc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Group)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from GroupMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/ent/group_update.go
+++ b/entc/integration/ent/group_update.go
@@ -850,9 +850,15 @@ func (guo *GroupUpdateOne) Save(ctx context.Context) (*Group, error) {
 			}
 			mut = guo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, guo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, guo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Group)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from GroupMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/ent/groupinfo_create.go
+++ b/entc/integration/ent/groupinfo_create.go
@@ -101,9 +101,15 @@ func (gic *GroupInfoCreate) Save(ctx context.Context) (*GroupInfo, error) {
 			}
 			mut = gic.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, gic.mutation); err != nil {
+		v, err := mut.Mutate(ctx, gic.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*GroupInfo)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from GroupInfoMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/ent/groupinfo_update.go
+++ b/entc/integration/ent/groupinfo_update.go
@@ -366,9 +366,15 @@ func (giuo *GroupInfoUpdateOne) Save(ctx context.Context) (*GroupInfo, error) {
 			}
 			mut = giuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, giuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, giuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*GroupInfo)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from GroupInfoMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/ent/item_create.go
+++ b/entc/integration/ent/item_create.go
@@ -94,9 +94,15 @@ func (ic *ItemCreate) Save(ctx context.Context) (*Item, error) {
 			}
 			mut = ic.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, ic.mutation); err != nil {
+		v, err := mut.Mutate(ctx, ic.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Item)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from ItemMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/ent/item_update.go
+++ b/entc/integration/ent/item_update.go
@@ -239,9 +239,15 @@ func (iuo *ItemUpdateOne) Save(ctx context.Context) (*Item, error) {
 			}
 			mut = iuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, iuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, iuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Item)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from ItemMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/ent/node_create.go
+++ b/entc/integration/ent/node_create.go
@@ -116,9 +116,15 @@ func (nc *NodeCreate) Save(ctx context.Context) (*Node, error) {
 			}
 			mut = nc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, nc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, nc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Node)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from NodeMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/ent/node_update.go
+++ b/entc/integration/ent/node_update.go
@@ -408,9 +408,15 @@ func (nuo *NodeUpdateOne) Save(ctx context.Context) (*Node, error) {
 			}
 			mut = nuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, nuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, nuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Node)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from NodeMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/ent/pet_create.go
+++ b/entc/integration/ent/pet_create.go
@@ -153,9 +153,15 @@ func (pc *PetCreate) Save(ctx context.Context) (*Pet, error) {
 			}
 			mut = pc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, pc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, pc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Pet)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from PetMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/ent/pet_update.go
+++ b/entc/integration/ent/pet_update.go
@@ -517,9 +517,15 @@ func (puo *PetUpdateOne) Save(ctx context.Context) (*Pet, error) {
 			}
 			mut = puo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, puo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, puo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Pet)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from PetMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/ent/spec_create.go
+++ b/entc/integration/ent/spec_create.go
@@ -80,9 +80,15 @@ func (sc *SpecCreate) Save(ctx context.Context) (*Spec, error) {
 			}
 			mut = sc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, sc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, sc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Spec)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from SpecMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/ent/spec_update.go
+++ b/entc/integration/ent/spec_update.go
@@ -291,9 +291,15 @@ func (suo *SpecUpdateOne) Save(ctx context.Context) (*Spec, error) {
 			}
 			mut = suo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, suo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, suo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Spec)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from SpecMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/ent/task_create.go
+++ b/entc/integration/ent/task_create.go
@@ -81,9 +81,15 @@ func (tc *TaskCreate) Save(ctx context.Context) (*Task, error) {
 			}
 			mut = tc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, tc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, tc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Task)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from TaskMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/ent/task_update.go
+++ b/entc/integration/ent/task_update.go
@@ -244,9 +244,15 @@ func (tuo *TaskUpdateOne) Save(ctx context.Context) (*Task, error) {
 			}
 			mut = tuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, tuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, tuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Task)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from TaskMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/ent/user_create.go
+++ b/entc/integration/ent/user_create.go
@@ -388,9 +388,15 @@ func (uc *UserCreate) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/ent/user_update.go
+++ b/entc/integration/ent/user_update.go
@@ -1925,9 +1925,15 @@ func (uuo *UserUpdateOne) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/gremlin/ent/card_create.go
+++ b/entc/integration/gremlin/ent/card_create.go
@@ -165,9 +165,15 @@ func (cc *CardCreate) Save(ctx context.Context) (*Card, error) {
 			}
 			mut = cc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, cc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, cc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Card)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from CardMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/gremlin/ent/card_update.go
+++ b/entc/integration/gremlin/ent/card_update.go
@@ -468,9 +468,15 @@ func (cuo *CardUpdateOne) Save(ctx context.Context) (*Card, error) {
 			}
 			mut = cuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, cuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, cuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Card)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from CardMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/gremlin/ent/comment_create.go
+++ b/entc/integration/gremlin/ent/comment_create.go
@@ -105,9 +105,15 @@ func (cc *CommentCreate) Save(ctx context.Context) (*Comment, error) {
 			}
 			mut = cc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, cc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, cc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Comment)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from CommentMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/gremlin/ent/comment_update.go
+++ b/entc/integration/gremlin/ent/comment_update.go
@@ -375,9 +375,15 @@ func (cuo *CommentUpdateOne) Save(ctx context.Context) (*Comment, error) {
 			}
 			mut = cuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, cuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, cuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Comment)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from CommentMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/gremlin/ent/fieldtype_create.go
+++ b/entc/integration/gremlin/ent/fieldtype_create.go
@@ -829,9 +829,15 @@ func (ftc *FieldTypeCreate) Save(ctx context.Context) (*FieldType, error) {
 			}
 			mut = ftc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, ftc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, ftc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*FieldType)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from FieldTypeMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/gremlin/ent/fieldtype_update.go
+++ b/entc/integration/gremlin/ent/fieldtype_update.go
@@ -3299,9 +3299,15 @@ func (ftuo *FieldTypeUpdateOne) Save(ctx context.Context) (*FieldType, error) {
 			}
 			mut = ftuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, ftuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, ftuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*FieldType)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from FieldTypeMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/gremlin/ent/file_create.go
+++ b/entc/integration/gremlin/ent/file_create.go
@@ -183,9 +183,15 @@ func (fc *FileCreate) Save(ctx context.Context) (*File, error) {
 			}
 			mut = fc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, fc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, fc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*File)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from FileMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/gremlin/ent/file_update.go
+++ b/entc/integration/gremlin/ent/file_update.go
@@ -606,9 +606,15 @@ func (fuo *FileUpdateOne) Save(ctx context.Context) (*File, error) {
 			}
 			mut = fuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, fuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, fuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*File)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from FileMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/gremlin/ent/filetype_create.go
+++ b/entc/integration/gremlin/ent/filetype_create.go
@@ -115,9 +115,15 @@ func (ftc *FileTypeCreate) Save(ctx context.Context) (*FileType, error) {
 			}
 			mut = ftc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, ftc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, ftc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*FileType)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from FileTypeMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/gremlin/ent/filetype_update.go
+++ b/entc/integration/gremlin/ent/filetype_update.go
@@ -371,9 +371,15 @@ func (ftuo *FileTypeUpdateOne) Save(ctx context.Context) (*FileType, error) {
 			}
 			mut = ftuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, ftuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, ftuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*FileType)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from FileTypeMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/gremlin/ent/goods_create.go
+++ b/entc/integration/gremlin/ent/goods_create.go
@@ -62,9 +62,15 @@ func (gc *GoodsCreate) Save(ctx context.Context) (*Goods, error) {
 			}
 			mut = gc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, gc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, gc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Goods)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from GoodsMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/gremlin/ent/goods_update.go
+++ b/entc/integration/gremlin/ent/goods_update.go
@@ -160,9 +160,15 @@ func (guo *GoodsUpdateOne) Save(ctx context.Context) (*Goods, error) {
 			}
 			mut = guo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, guo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, guo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Goods)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from GoodsMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/gremlin/ent/group_create.go
+++ b/entc/integration/gremlin/ent/group_create.go
@@ -178,9 +178,15 @@ func (gc *GroupCreate) Save(ctx context.Context) (*Group, error) {
 			}
 			mut = gc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, gc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, gc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Group)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from GroupMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/gremlin/ent/group_update.go
+++ b/entc/integration/gremlin/ent/group_update.go
@@ -677,9 +677,15 @@ func (guo *GroupUpdateOne) Save(ctx context.Context) (*Group, error) {
 			}
 			mut = guo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, guo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, guo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Group)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from GroupMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/gremlin/ent/groupinfo_create.go
+++ b/entc/integration/gremlin/ent/groupinfo_create.go
@@ -102,9 +102,15 @@ func (gic *GroupInfoCreate) Save(ctx context.Context) (*GroupInfo, error) {
 			}
 			mut = gic.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, gic.mutation); err != nil {
+		v, err := mut.Mutate(ctx, gic.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*GroupInfo)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from GroupInfoMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/gremlin/ent/groupinfo_update.go
+++ b/entc/integration/gremlin/ent/groupinfo_update.go
@@ -327,9 +327,15 @@ func (giuo *GroupInfoUpdateOne) Save(ctx context.Context) (*GroupInfo, error) {
 			}
 			mut = giuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, giuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, giuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*GroupInfo)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from GroupInfoMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/gremlin/ent/item_create.go
+++ b/entc/integration/gremlin/ent/item_create.go
@@ -93,9 +93,15 @@ func (ic *ItemCreate) Save(ctx context.Context) (*Item, error) {
 			}
 			mut = ic.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, ic.mutation); err != nil {
+		v, err := mut.Mutate(ctx, ic.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Item)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from ItemMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/gremlin/ent/item_update.go
+++ b/entc/integration/gremlin/ent/item_update.go
@@ -256,9 +256,15 @@ func (iuo *ItemUpdateOne) Save(ctx context.Context) (*Item, error) {
 			}
 			mut = iuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, iuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, iuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Item)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from ItemMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/gremlin/ent/node_create.go
+++ b/entc/integration/gremlin/ent/node_create.go
@@ -116,9 +116,15 @@ func (nc *NodeCreate) Save(ctx context.Context) (*Node, error) {
 			}
 			mut = nc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, nc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, nc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Node)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from NodeMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/gremlin/ent/node_update.go
+++ b/entc/integration/gremlin/ent/node_update.go
@@ -369,9 +369,15 @@ func (nuo *NodeUpdateOne) Save(ctx context.Context) (*Node, error) {
 			}
 			mut = nuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, nuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, nuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Node)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from NodeMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/gremlin/ent/pet_create.go
+++ b/entc/integration/gremlin/ent/pet_create.go
@@ -154,9 +154,15 @@ func (pc *PetCreate) Save(ctx context.Context) (*Pet, error) {
 			}
 			mut = pc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, pc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, pc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Pet)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from PetMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/gremlin/ent/pet_update.go
+++ b/entc/integration/gremlin/ent/pet_update.go
@@ -459,9 +459,15 @@ func (puo *PetUpdateOne) Save(ctx context.Context) (*Pet, error) {
 			}
 			mut = puo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, puo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, puo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Pet)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from PetMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/gremlin/ent/spec_create.go
+++ b/entc/integration/gremlin/ent/spec_create.go
@@ -77,9 +77,15 @@ func (sc *SpecCreate) Save(ctx context.Context) (*Spec, error) {
 			}
 			mut = sc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, sc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, sc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Spec)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from SpecMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/gremlin/ent/spec_update.go
+++ b/entc/integration/gremlin/ent/spec_update.go
@@ -243,9 +243,15 @@ func (suo *SpecUpdateOne) Save(ctx context.Context) (*Spec, error) {
 			}
 			mut = suo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, suo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, suo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Spec)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from SpecMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/gremlin/ent/task_create.go
+++ b/entc/integration/gremlin/ent/task_create.go
@@ -80,9 +80,15 @@ func (tc *TaskCreate) Save(ctx context.Context) (*Task, error) {
 			}
 			mut = tc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, tc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, tc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Task)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from TaskMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/gremlin/ent/task_update.go
+++ b/entc/integration/gremlin/ent/task_update.go
@@ -233,9 +233,15 @@ func (tuo *TaskUpdateOne) Save(ctx context.Context) (*Task, error) {
 			}
 			mut = tuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, tuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, tuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Task)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from TaskMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/gremlin/ent/user_create.go
+++ b/entc/integration/gremlin/ent/user_create.go
@@ -385,9 +385,15 @@ func (uc *UserCreate) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/gremlin/ent/user_update.go
+++ b/entc/integration/gremlin/ent/user_update.go
@@ -1466,9 +1466,15 @@ func (uuo *UserUpdateOne) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/hooks/ent/card_create.go
+++ b/entc/integration/hooks/ent/card_create.go
@@ -134,9 +134,15 @@ func (cc *CardCreate) Save(ctx context.Context) (*Card, error) {
 			}
 			mut = cc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, cc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, cc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Card)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from CardMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/hooks/ent/card_update.go
+++ b/entc/integration/hooks/ent/card_update.go
@@ -358,9 +358,15 @@ func (cuo *CardUpdateOne) Save(ctx context.Context) (*Card, error) {
 			}
 			mut = cuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, cuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, cuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Card)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from CardMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/hooks/ent/user_create.go
+++ b/entc/integration/hooks/ent/user_create.go
@@ -163,9 +163,15 @@ func (uc *UserCreate) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/hooks/ent/user_update.go
+++ b/entc/integration/hooks/ent/user_update.go
@@ -704,9 +704,15 @@ func (uuo *UserUpdateOne) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/hooks/hooks_test.go
+++ b/entc/integration/hooks/hooks_test.go
@@ -223,10 +223,10 @@ func TestUpdateAfterCreation(t *testing.T) {
 				return nil, err
 			}
 			existingUser, ok := value.(*ent.User)
-			require.True(t, ok, "value should be of type %T", existingUser)
+			require.Truef(t, ok, "value should be of type %T", existingUser)
 			require.Equal(t, existingUser.Version, 1, "version does not match the original value")
 
-			// Important to return a completely new model; don't just mutate the existing user.
+			// After the user was created, return its updated version (a new object).
 			newUser := m.Client().User.UpdateOneID(existingUser.ID).
 				SetVersion(2).
 				SaveX(ctx)

--- a/entc/integration/idtype/ent/user_create.go
+++ b/entc/integration/idtype/ent/user_create.go
@@ -117,9 +117,15 @@ func (uc *UserCreate) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/idtype/ent/user_update.go
+++ b/entc/integration/idtype/ent/user_update.go
@@ -520,9 +520,15 @@ func (uuo *UserUpdateOne) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/json/ent/user_create.go
+++ b/entc/integration/json/ent/user_create.go
@@ -123,9 +123,15 @@ func (uc *UserCreate) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/json/ent/user_update.go
+++ b/entc/integration/json/ent/user_update.go
@@ -462,9 +462,15 @@ func (uuo *UserUpdateOne) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/migrate/entv1/car_create.go
+++ b/entc/integration/migrate/entv1/car_create.go
@@ -81,9 +81,15 @@ func (cc *CarCreate) Save(ctx context.Context) (*Car, error) {
 			}
 			mut = cc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, cc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, cc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Car)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from CarMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/migrate/entv1/car_update.go
+++ b/entc/integration/migrate/entv1/car_update.go
@@ -250,9 +250,15 @@ func (cuo *CarUpdateOne) Save(ctx context.Context) (*Car, error) {
 			}
 			mut = cuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, cuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, cuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Car)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from CarMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/migrate/entv1/conversion_create.go
+++ b/entc/integration/migrate/entv1/conversion_create.go
@@ -187,9 +187,15 @@ func (cc *ConversionCreate) Save(ctx context.Context) (*Conversion, error) {
 			}
 			mut = cc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, cc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, cc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Conversion)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from ConversionMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/migrate/entv1/conversion_update.go
+++ b/entc/integration/migrate/entv1/conversion_update.go
@@ -809,9 +809,15 @@ func (cuo *ConversionUpdateOne) Save(ctx context.Context) (*Conversion, error) {
 			}
 			mut = cuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, cuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, cuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Conversion)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from ConversionMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/migrate/entv1/customtype_create.go
+++ b/entc/integration/migrate/entv1/customtype_create.go
@@ -75,9 +75,15 @@ func (ctc *CustomTypeCreate) Save(ctx context.Context) (*CustomType, error) {
 			}
 			mut = ctc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, ctc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, ctc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*CustomType)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from CustomTypeMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/migrate/entv1/customtype_update.go
+++ b/entc/integration/migrate/entv1/customtype_update.go
@@ -217,9 +217,15 @@ func (ctuo *CustomTypeUpdateOne) Save(ctx context.Context) (*CustomType, error) 
 			}
 			mut = ctuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, ctuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, ctuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*CustomType)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from CustomTypeMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/migrate/entv1/user_create.go
+++ b/entc/integration/migrate/entv1/user_create.go
@@ -278,9 +278,15 @@ func (uc *UserCreate) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/migrate/entv1/user_update.go
+++ b/entc/integration/migrate/entv1/user_update.go
@@ -1104,9 +1104,15 @@ func (uuo *UserUpdateOne) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/migrate/entv2/car_create.go
+++ b/entc/integration/migrate/entv2/car_create.go
@@ -88,9 +88,15 @@ func (cc *CarCreate) Save(ctx context.Context) (*Car, error) {
 			}
 			mut = cc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, cc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, cc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Car)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from CarMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/migrate/entv2/car_update.go
+++ b/entc/integration/migrate/entv2/car_update.go
@@ -307,9 +307,15 @@ func (cuo *CarUpdateOne) Save(ctx context.Context) (*Car, error) {
 			}
 			mut = cuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, cuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, cuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Car)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from CarMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/migrate/entv2/conversion_create.go
+++ b/entc/integration/migrate/entv2/conversion_create.go
@@ -187,9 +187,15 @@ func (cc *ConversionCreate) Save(ctx context.Context) (*Conversion, error) {
 			}
 			mut = cc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, cc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, cc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Conversion)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from ConversionMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/migrate/entv2/conversion_update.go
+++ b/entc/integration/migrate/entv2/conversion_update.go
@@ -641,9 +641,15 @@ func (cuo *ConversionUpdateOne) Save(ctx context.Context) (*Conversion, error) {
 			}
 			mut = cuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, cuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, cuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Conversion)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from ConversionMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/migrate/entv2/customtype_create.go
+++ b/entc/integration/migrate/entv2/customtype_create.go
@@ -104,9 +104,15 @@ func (ctc *CustomTypeCreate) Save(ctx context.Context) (*CustomType, error) {
 			}
 			mut = ctc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, ctc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, ctc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*CustomType)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from CustomTypeMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/migrate/entv2/customtype_update.go
+++ b/entc/integration/migrate/entv2/customtype_update.go
@@ -324,9 +324,15 @@ func (ctuo *CustomTypeUpdateOne) Save(ctx context.Context) (*CustomType, error) 
 			}
 			mut = ctuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, ctuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, ctuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*CustomType)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from CustomTypeMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/migrate/entv2/group_create.go
+++ b/entc/integration/migrate/entv2/group_create.go
@@ -61,9 +61,15 @@ func (gc *GroupCreate) Save(ctx context.Context) (*Group, error) {
 			}
 			mut = gc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, gc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, gc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Group)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from GroupMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/migrate/entv2/group_update.go
+++ b/entc/integration/migrate/entv2/group_update.go
@@ -164,9 +164,15 @@ func (guo *GroupUpdateOne) Save(ctx context.Context) (*Group, error) {
 			}
 			mut = guo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, guo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, guo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Group)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from GroupMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/migrate/entv2/media_create.go
+++ b/entc/integration/migrate/entv2/media_create.go
@@ -103,9 +103,15 @@ func (mc *MediaCreate) Save(ctx context.Context) (*Media, error) {
 			}
 			mut = mc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, mc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, mc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Media)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from MediaMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/migrate/entv2/media_update.go
+++ b/entc/integration/migrate/entv2/media_update.go
@@ -323,9 +323,15 @@ func (muo *MediaUpdateOne) Save(ctx context.Context) (*Media, error) {
 			}
 			mut = muo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, muo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, muo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Media)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from MediaMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/migrate/entv2/pet_create.go
+++ b/entc/integration/migrate/entv2/pet_create.go
@@ -95,9 +95,15 @@ func (pc *PetCreate) Save(ctx context.Context) (*Pet, error) {
 			}
 			mut = pc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, pc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, pc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Pet)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from PetMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/migrate/entv2/pet_update.go
+++ b/entc/integration/migrate/entv2/pet_update.go
@@ -303,9 +303,15 @@ func (puo *PetUpdateOne) Save(ctx context.Context) (*Pet, error) {
 			}
 			mut = puo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, puo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, puo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Pet)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from PetMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/migrate/entv2/user_create.go
+++ b/entc/integration/migrate/entv2/user_create.go
@@ -319,9 +319,15 @@ func (uc *UserCreate) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/migrate/entv2/user_update.go
+++ b/entc/integration/migrate/entv2/user_update.go
@@ -1208,9 +1208,15 @@ func (uuo *UserUpdateOne) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/migrate/versioned/user_create.go
+++ b/entc/integration/migrate/versioned/user_create.go
@@ -108,9 +108,15 @@ func (uc *UserCreate) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/migrate/versioned/user_update.go
+++ b/entc/integration/migrate/versioned/user_update.go
@@ -351,9 +351,15 @@ func (uuo *UserUpdateOne) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/multischema/ent/group_create.go
+++ b/entc/integration/multischema/ent/group_create.go
@@ -93,9 +93,15 @@ func (gc *GroupCreate) Save(ctx context.Context) (*Group, error) {
 			}
 			mut = gc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, gc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, gc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Group)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from GroupMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/multischema/ent/group_update.go
+++ b/entc/integration/multischema/ent/group_update.go
@@ -332,9 +332,15 @@ func (guo *GroupUpdateOne) Save(ctx context.Context) (*Group, error) {
 			}
 			mut = guo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, guo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, guo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Group)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from GroupMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/multischema/ent/pet_create.go
+++ b/entc/integration/multischema/ent/pet_create.go
@@ -97,9 +97,15 @@ func (pc *PetCreate) Save(ctx context.Context) (*Pet, error) {
 			}
 			mut = pc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, pc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, pc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Pet)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from PetMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/multischema/ent/pet_update.go
+++ b/entc/integration/multischema/ent/pet_update.go
@@ -302,9 +302,15 @@ func (puo *PetUpdateOne) Save(ctx context.Context) (*Pet, error) {
 			}
 			mut = puo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, puo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, puo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Pet)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from PetMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/multischema/ent/user_create.go
+++ b/entc/integration/multischema/ent/user_create.go
@@ -109,9 +109,15 @@ func (uc *UserCreate) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/multischema/ent/user_update.go
+++ b/entc/integration/multischema/ent/user_update.go
@@ -462,9 +462,15 @@ func (uuo *UserUpdateOne) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/privacy/ent/task_create.go
+++ b/entc/integration/privacy/ent/task_create.go
@@ -150,9 +150,15 @@ func (tc *TaskCreate) Save(ctx context.Context) (*Task, error) {
 			}
 			mut = tc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, tc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, tc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Task)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from TaskMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/privacy/ent/task_update.go
+++ b/entc/integration/privacy/ent/task_update.go
@@ -565,9 +565,15 @@ func (tuo *TaskUpdateOne) Save(ctx context.Context) (*Task, error) {
 			}
 			mut = tuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, tuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, tuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Task)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from TaskMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/privacy/ent/team_create.go
+++ b/entc/integration/privacy/ent/team_create.go
@@ -100,9 +100,15 @@ func (tc *TeamCreate) Save(ctx context.Context) (*Team, error) {
 			}
 			mut = tc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, tc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, tc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Team)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from TeamMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/privacy/ent/team_update.go
+++ b/entc/integration/privacy/ent/team_update.go
@@ -459,9 +459,15 @@ func (tuo *TeamUpdateOne) Save(ctx context.Context) (*Team, error) {
 			}
 			mut = tuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, tuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, tuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Team)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from TeamMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/privacy/ent/user_create.go
+++ b/entc/integration/privacy/ent/user_create.go
@@ -114,9 +114,15 @@ func (uc *UserCreate) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/privacy/ent/user_update.go
+++ b/entc/integration/privacy/ent/user_update.go
@@ -492,9 +492,15 @@ func (uuo *UserUpdateOne) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/template/ent/group_create.go
+++ b/entc/integration/template/ent/group_create.go
@@ -68,9 +68,15 @@ func (gc *GroupCreate) Save(ctx context.Context) (*Group, error) {
 			}
 			mut = gc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, gc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, gc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Group)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from GroupMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/template/ent/group_update.go
+++ b/entc/integration/template/ent/group_update.go
@@ -204,9 +204,15 @@ func (guo *GroupUpdateOne) Save(ctx context.Context) (*Group, error) {
 			}
 			mut = guo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, guo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, guo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Group)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from GroupMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/template/ent/pet_create.go
+++ b/entc/integration/template/ent/pet_create.go
@@ -103,9 +103,15 @@ func (pc *PetCreate) Save(ctx context.Context) (*Pet, error) {
 			}
 			mut = pc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, pc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, pc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Pet)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from PetMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/template/ent/pet_update.go
+++ b/entc/integration/template/ent/pet_update.go
@@ -344,9 +344,15 @@ func (puo *PetUpdateOne) Save(ctx context.Context) (*Pet, error) {
 			}
 			mut = puo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, puo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, puo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Pet)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from PetMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/template/ent/user_create.go
+++ b/entc/integration/template/ent/user_create.go
@@ -99,9 +99,15 @@ func (uc *UserCreate) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/entc/integration/template/ent/user_update.go
+++ b/entc/integration/template/ent/user_update.go
@@ -436,9 +436,15 @@ func (uuo *UserUpdateOne) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/edgeindex/ent/city_create.go
+++ b/examples/edgeindex/ent/city_create.go
@@ -84,9 +84,15 @@ func (cc *CityCreate) Save(ctx context.Context) (*City, error) {
 			}
 			mut = cc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, cc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, cc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*City)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from CityMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/edgeindex/ent/city_update.go
+++ b/examples/edgeindex/ent/city_update.go
@@ -310,9 +310,15 @@ func (cuo *CityUpdateOne) Save(ctx context.Context) (*City, error) {
 			}
 			mut = cuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, cuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, cuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*City)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from CityMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/edgeindex/ent/street_create.go
+++ b/examples/edgeindex/ent/street_create.go
@@ -88,9 +88,15 @@ func (sc *StreetCreate) Save(ctx context.Context) (*Street, error) {
 			}
 			mut = sc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, sc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, sc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Street)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from StreetMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/edgeindex/ent/street_update.go
+++ b/examples/edgeindex/ent/street_update.go
@@ -269,9 +269,15 @@ func (suo *StreetUpdateOne) Save(ctx context.Context) (*Street, error) {
 			}
 			mut = suo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, suo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, suo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Street)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from StreetMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/entcpkg/ent/user_create.go
+++ b/examples/entcpkg/ent/user_create.go
@@ -89,9 +89,15 @@ func (uc *UserCreate) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/entcpkg/ent/user_update.go
+++ b/examples/entcpkg/ent/user_update.go
@@ -291,9 +291,15 @@ func (uuo *UserUpdateOne) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/fs/ent/file_create.go
+++ b/examples/fs/ent/file_create.go
@@ -117,9 +117,15 @@ func (fc *FileCreate) Save(ctx context.Context) (*File, error) {
 			}
 			mut = fc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, fc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, fc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*File)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from FileMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/fs/ent/file_update.go
+++ b/examples/fs/ent/file_update.go
@@ -441,9 +441,15 @@ func (fuo *FileUpdateOne) Save(ctx context.Context) (*File, error) {
 			}
 			mut = fuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, fuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, fuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*File)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from FileMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/m2m2types/ent/group_create.go
+++ b/examples/m2m2types/ent/group_create.go
@@ -84,9 +84,15 @@ func (gc *GroupCreate) Save(ctx context.Context) (*Group, error) {
 			}
 			mut = gc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, gc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, gc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Group)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from GroupMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/m2m2types/ent/group_update.go
+++ b/examples/m2m2types/ent/group_update.go
@@ -310,9 +310,15 @@ func (guo *GroupUpdateOne) Save(ctx context.Context) (*Group, error) {
 			}
 			mut = guo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, guo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, guo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Group)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from GroupMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/m2m2types/ent/user_create.go
+++ b/examples/m2m2types/ent/user_create.go
@@ -90,9 +90,15 @@ func (uc *UserCreate) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/m2m2types/ent/user_update.go
+++ b/examples/m2m2types/ent/user_update.go
@@ -350,9 +350,15 @@ func (uuo *UserUpdateOne) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/m2mbidi/ent/user_create.go
+++ b/examples/m2mbidi/ent/user_create.go
@@ -89,9 +89,15 @@ func (uc *UserCreate) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/m2mbidi/ent/user_update.go
+++ b/examples/m2mbidi/ent/user_update.go
@@ -349,9 +349,15 @@ func (uuo *UserUpdateOne) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/m2mrecur/ent/user_create.go
+++ b/examples/m2mrecur/ent/user_create.go
@@ -104,9 +104,15 @@ func (uc *UserCreate) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/m2mrecur/ent/user_update.go
+++ b/examples/m2mrecur/ent/user_update.go
@@ -475,9 +475,15 @@ func (uuo *UserUpdateOne) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/o2m2types/ent/pet_create.go
+++ b/examples/o2m2types/ent/pet_create.go
@@ -88,9 +88,15 @@ func (pc *PetCreate) Save(ctx context.Context) (*Pet, error) {
 			}
 			mut = pc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, pc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, pc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Pet)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from PetMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/o2m2types/ent/pet_update.go
+++ b/examples/o2m2types/ent/pet_update.go
@@ -269,9 +269,15 @@ func (puo *PetUpdateOne) Save(ctx context.Context) (*Pet, error) {
 			}
 			mut = puo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, puo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, puo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Pet)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from PetMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/o2m2types/ent/user_create.go
+++ b/examples/o2m2types/ent/user_create.go
@@ -90,9 +90,15 @@ func (uc *UserCreate) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/o2m2types/ent/user_update.go
+++ b/examples/o2m2types/ent/user_update.go
@@ -350,9 +350,15 @@ func (uuo *UserUpdateOne) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/o2mrecur/ent/node_create.go
+++ b/examples/o2mrecur/ent/node_create.go
@@ -102,9 +102,15 @@ func (nc *NodeCreate) Save(ctx context.Context) (*Node, error) {
 			}
 			mut = nc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, nc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, nc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Node)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from NodeMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/o2mrecur/ent/node_update.go
+++ b/examples/o2mrecur/ent/node_update.go
@@ -415,9 +415,15 @@ func (nuo *NodeUpdateOne) Save(ctx context.Context) (*Node, error) {
 			}
 			mut = nuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, nuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, nuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Node)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from NodeMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/o2o2types/ent/card_create.go
+++ b/examples/o2o2types/ent/card_create.go
@@ -87,9 +87,15 @@ func (cc *CardCreate) Save(ctx context.Context) (*Card, error) {
 			}
 			mut = cc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, cc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, cc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Card)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from CardMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/o2o2types/ent/card_update.go
+++ b/examples/o2o2types/ent/card_update.go
@@ -293,9 +293,15 @@ func (cuo *CardUpdateOne) Save(ctx context.Context) (*Card, error) {
 			}
 			mut = cuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, cuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, cuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Card)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from CardMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/o2o2types/ent/user_create.go
+++ b/examples/o2o2types/ent/user_create.go
@@ -94,9 +94,15 @@ func (uc *UserCreate) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/o2o2types/ent/user_update.go
+++ b/examples/o2o2types/ent/user_update.go
@@ -309,9 +309,15 @@ func (uuo *UserUpdateOne) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/o2obidi/ent/user_create.go
+++ b/examples/o2obidi/ent/user_create.go
@@ -93,9 +93,15 @@ func (uc *UserCreate) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/o2obidi/ent/user_update.go
+++ b/examples/o2obidi/ent/user_update.go
@@ -308,9 +308,15 @@ func (uuo *UserUpdateOne) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/o2orecur/ent/node_create.go
+++ b/examples/o2orecur/ent/node_create.go
@@ -106,9 +106,15 @@ func (nc *NodeCreate) Save(ctx context.Context) (*Node, error) {
 			}
 			mut = nc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, nc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, nc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Node)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from NodeMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/o2orecur/ent/node_update.go
+++ b/examples/o2orecur/ent/node_update.go
@@ -374,9 +374,15 @@ func (nuo *NodeUpdateOne) Save(ctx context.Context) (*Node, error) {
 			}
 			mut = nuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, nuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, nuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Node)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from NodeMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/privacyadmin/ent/user_create.go
+++ b/examples/privacyadmin/ent/user_create.go
@@ -79,9 +79,15 @@ func (uc *UserCreate) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/privacyadmin/ent/user_update.go
+++ b/examples/privacyadmin/ent/user_update.go
@@ -199,9 +199,15 @@ func (uuo *UserUpdateOne) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/privacytenant/ent/group_create.go
+++ b/examples/privacytenant/ent/group_create.go
@@ -107,9 +107,15 @@ func (gc *GroupCreate) Save(ctx context.Context) (*Group, error) {
 			}
 			mut = gc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, gc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, gc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Group)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from GroupMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/privacytenant/ent/group_update.go
+++ b/examples/privacytenant/ent/group_update.go
@@ -416,9 +416,15 @@ func (guo *GroupUpdateOne) Save(ctx context.Context) (*Group, error) {
 			}
 			mut = guo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, guo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, guo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Group)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from GroupMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/privacytenant/ent/tenant_create.go
+++ b/examples/privacytenant/ent/tenant_create.go
@@ -68,9 +68,15 @@ func (tc *TenantCreate) Save(ctx context.Context) (*Tenant, error) {
 			}
 			mut = tc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, tc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, tc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Tenant)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from TenantMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/privacytenant/ent/tenant_update.go
+++ b/examples/privacytenant/ent/tenant_update.go
@@ -205,9 +205,15 @@ func (tuo *TenantUpdateOne) Save(ctx context.Context) (*Tenant, error) {
 			}
 			mut = tuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, tuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, tuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Tenant)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from TenantMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/privacytenant/ent/user_create.go
+++ b/examples/privacytenant/ent/user_create.go
@@ -113,9 +113,15 @@ func (uc *UserCreate) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/privacytenant/ent/user_update.go
+++ b/examples/privacytenant/ent/user_update.go
@@ -453,9 +453,15 @@ func (uuo *UserUpdateOne) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/start/ent/car_create.go
+++ b/examples/start/ent/car_create.go
@@ -95,9 +95,15 @@ func (cc *CarCreate) Save(ctx context.Context) (*Car, error) {
 			}
 			mut = cc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, cc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, cc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Car)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from CarMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/start/ent/car_update.go
+++ b/examples/start/ent/car_update.go
@@ -289,9 +289,15 @@ func (cuo *CarUpdateOne) Save(ctx context.Context) (*Car, error) {
 			}
 			mut = cuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, cuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, cuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Car)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from CarMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/start/ent/group_create.go
+++ b/examples/start/ent/group_create.go
@@ -84,9 +84,15 @@ func (gc *GroupCreate) Save(ctx context.Context) (*Group, error) {
 			}
 			mut = gc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, gc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, gc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Group)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from GroupMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/start/ent/group_update.go
+++ b/examples/start/ent/group_update.go
@@ -332,9 +332,15 @@ func (guo *GroupUpdateOne) Save(ctx context.Context) (*Group, error) {
 			}
 			mut = guo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, guo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, guo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Group)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from GroupMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/start/ent/user_create.go
+++ b/examples/start/ent/user_create.go
@@ -115,9 +115,15 @@ func (uc *UserCreate) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/start/ent/user_update.go
+++ b/examples/start/ent/user_update.go
@@ -515,9 +515,15 @@ func (uuo *UserUpdateOne) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/traversal/ent/group_create.go
+++ b/examples/traversal/ent/group_create.go
@@ -103,9 +103,15 @@ func (gc *GroupCreate) Save(ctx context.Context) (*Group, error) {
 			}
 			mut = gc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, gc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, gc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Group)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from GroupMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/traversal/ent/group_update.go
+++ b/examples/traversal/ent/group_update.go
@@ -395,9 +395,15 @@ func (guo *GroupUpdateOne) Save(ctx context.Context) (*Group, error) {
 			}
 			mut = guo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, guo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, guo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Group)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from GroupMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/traversal/ent/pet_create.go
+++ b/examples/traversal/ent/pet_create.go
@@ -103,9 +103,15 @@ func (pc *PetCreate) Save(ctx context.Context) (*Pet, error) {
 			}
 			mut = pc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, pc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, pc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Pet)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from PetMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/traversal/ent/pet_update.go
+++ b/examples/traversal/ent/pet_update.go
@@ -395,9 +395,15 @@ func (puo *PetUpdateOne) Save(ctx context.Context) (*Pet, error) {
 			}
 			mut = puo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, puo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, puo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*Pet)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from PetMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/traversal/ent/user_create.go
+++ b/examples/traversal/ent/user_create.go
@@ -136,9 +136,15 @@ func (uc *UserCreate) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/traversal/ent/user_update.go
+++ b/examples/traversal/ent/user_update.go
@@ -729,9 +729,15 @@ func (uuo *UserUpdateOne) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/version/ent/user_create.go
+++ b/examples/version/ent/user_create.go
@@ -83,9 +83,15 @@ func (uc *UserCreate) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uc.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uc.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uc.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }

--- a/examples/version/ent/user_update.go
+++ b/examples/version/ent/user_update.go
@@ -261,9 +261,15 @@ func (uuo *UserUpdateOne) Save(ctx context.Context) (*User, error) {
 			}
 			mut = uuo.hooks[i](mut)
 		}
-		if _, err := mut.Mutate(ctx, uuo.mutation); err != nil {
+		v, err := mut.Mutate(ctx, uuo.mutation)
+		if err != nil {
 			return nil, err
 		}
+		nv, ok := v.(*User)
+		if !ok {
+			return nil, fmt.Errorf("unexpected node type %T returned from UserMutation", v)
+		}
+		node = nv
 	}
 	return node, err
 }


### PR DESCRIPTION
This addresses the bug I reported in https://github.com/ent/ent/issues/2523.  I've broken the commits up so you can filter out the actual changes from the regeneration noise.

([Original PR here](https://github.com/ent/ent/pull/2524))
