### PR TITLE
cmd/internal: support go1.18 workspace in generate.go command

### DIFF
--- a/cmd/internal/base/base.go
+++ b/cmd/internal/base/base.go
@@ -210,7 +210,11 @@ func createDir(target string) error {
 	if target != defaultSchema {
 		return nil
 	}
-	if err := os.WriteFile("ent/generate.go", []byte(genFile), 0644); err != nil {
+	gf := genFile
+	if _, err := os.Stat("go.work"); err != nil {
+		gf = strings.ReplaceAll(gf, "-mod=mod ", "")
+	}
+	if err := os.WriteFile("ent/generate.go", []byte(gf), 0644); err != nil {
 		return fmt.Errorf("creating generate.go file: %w", err)
 	}
 	return nil


### PR DESCRIPTION
fix #2438 