### PR TITLE
Workaround for max params eager loading

### DIFF
--- a/dialect/sql/helpers.go
+++ b/dialect/sql/helpers.go
@@ -1,0 +1,34 @@
+package sql
+
+import (
+	"entgo.io/ent/dialect"
+)
+
+func MaxParams(dialectName string) int {
+	switch dialectName {
+	case dialect.Postgres:
+		return 65535
+	default:
+		return -1
+	}
+}
+
+func Chunked(fn func(start, end int) error, n int, maxPerChunk int) error {
+	if maxPerChunk == -1 {
+		return fn(0, n)
+	}
+
+	for start := 0; start < n; start += maxPerChunk {
+		end := start + maxPerChunk
+		if end > n {
+			end = n
+		}
+
+		err := fn(start, end)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/entc/gen/template/dialect/sql/query.tmpl
+++ b/entc/gen/template/dialect/sql/query.tmpl
@@ -276,6 +276,8 @@ func ({{ $receiver }} *{{ $builder }}) sqlQuery(ctx context.Context) *sql.Select
 	{{- $e := $.Scope.Edge }}
 	{{- $receiver := $.Scope.Rec }}
 	if query := {{ $receiver }}.{{ $e.EagerLoadField }}; query != nil {
+	err := sql.Chunked(func(start, end int) error {
+		nodes := nodes[start:end]
 		{{- if $e.M2M }}
 			edgeids := make([]driver.Value, len(nodes))
 			byid := make(map[{{ $.ID.Type }}]*{{ $.Name }})
@@ -320,12 +322,12 @@ func ({{ $receiver }} *{{ $builder }}) sqlQuery(ctx context.Context) *sql.Select
 				}
 			})
 			if err != nil {
-				return nil, err
+				return err
 			}
 			for _, n := range neighbors {
 				nodes, ok := nids[n.ID]
 				if !ok {
-					return nil, fmt.Errorf(`unexpected "{{ $e.Name }}" node returned %v`, n.ID)
+					return fmt.Errorf(`unexpected "{{ $e.Name }}" node returned %v`, n.ID)
 				}
 				for kn := range nodes {
 					kn.Edges.{{ $e.StructField }} = append(kn.Edges.{{ $e.StructField }}, n)
@@ -350,12 +352,12 @@ func ({{ $receiver }} *{{ $builder }}) sqlQuery(ctx context.Context) *sql.Select
 			query.Where({{ $e.Type.Package }}.IDIn(ids...))
 			neighbors, err := query.All(ctx)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			for _, n := range neighbors {
 				nodes, ok := nodeids[n.ID]
 				if !ok {
-					return nil, fmt.Errorf(`unexpected foreign-key "{{ $fk.Field.Name }}" returned %v`, n.ID)
+					return fmt.Errorf(`unexpected foreign-key "{{ $fk.Field.Name }}" returned %v`, n.ID)
 				}
 				for i := range nodes {
 					nodes[i].Edges.{{ $e.StructField }} = n
@@ -379,23 +381,28 @@ func ({{ $receiver }} *{{ $builder }}) sqlQuery(ctx context.Context) *sql.Select
 			}))
 			neighbors, err := query.All(ctx)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			for _, n := range neighbors {
 				{{- $fk := $e.ForeignKey }}
 				fk := n.{{ $fk.StructField }}
 				{{- if $fk.Field.Nillable }}
 					if fk == nil {
-						return nil, fmt.Errorf(`foreign-key "{{ $fk.Field.Name }}" is nil for node %v`, n.ID)
+						return fmt.Errorf(`foreign-key "{{ $fk.Field.Name }}" is nil for node %v`, n.ID)
 					}
 				{{- end }}
 				node, ok := nodeids[{{ if $fk.Field.Nillable }}*{{ end }}fk]
 				if !ok {
-					return nil, fmt.Errorf(`unexpected foreign-key "{{ $fk.Field.Name }}" returned %v for node %v`, {{ if $fk.Field.Nillable }}*{{ end }}fk, n.ID)
+					return fmt.Errorf(`unexpected foreign-key "{{ $fk.Field.Name }}" returned %v for node %v`, {{ if $fk.Field.Nillable }}*{{ end }}fk, n.ID)
 				}
 				node.Edges.{{ $e.StructField }} = {{ if $e.Unique }}n{{ else }}append(node.Edges.{{ $e.StructField }}, n){{ end }}
 			}
 		{{- end }}
+		return nil
+	}, len(nodes), sql.MaxParams({{ $receiver }}.driver.Dialect()))
+	if err != nil {
+		return nil, err
+	}
 	}
 {{ end }}
 

--- a/entc/integration/ent/filetype_query.go
+++ b/entc/integration/ent/filetype_query.go
@@ -388,31 +388,38 @@ func (ftq *FileTypeQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Fi
 	}
 
 	if query := ftq.withFiles; query != nil {
-		fks := make([]driver.Value, 0, len(nodes))
-		nodeids := make(map[int]*FileType)
-		for i := range nodes {
-			fks = append(fks, nodes[i].ID)
-			nodeids[nodes[i].ID] = nodes[i]
-			nodes[i].Edges.Files = []*File{}
-		}
-		query.withFKs = true
-		query.Where(predicate.File(func(s *sql.Selector) {
-			s.Where(sql.InValues(filetype.FilesColumn, fks...))
-		}))
-		neighbors, err := query.All(ctx)
+		err := sql.Chunked(func(start, end int) error {
+			nodes := nodes[start:end]
+			fks := make([]driver.Value, 0, len(nodes))
+			nodeids := make(map[int]*FileType)
+			for i := range nodes {
+				fks = append(fks, nodes[i].ID)
+				nodeids[nodes[i].ID] = nodes[i]
+				nodes[i].Edges.Files = []*File{}
+			}
+			query.withFKs = true
+			query.Where(predicate.File(func(s *sql.Selector) {
+				s.Where(sql.InValues(filetype.FilesColumn, fks...))
+			}))
+			neighbors, err := query.All(ctx)
+			if err != nil {
+				return err
+			}
+			for _, n := range neighbors {
+				fk := n.file_type_files
+				if fk == nil {
+					return fmt.Errorf(`foreign-key "file_type_files" is nil for node %v`, n.ID)
+				}
+				node, ok := nodeids[*fk]
+				if !ok {
+					return fmt.Errorf(`unexpected foreign-key "file_type_files" returned %v for node %v`, *fk, n.ID)
+				}
+				node.Edges.Files = append(node.Edges.Files, n)
+			}
+			return nil
+		}, len(nodes), sql.MaxParams(ftq.driver.Dialect()))
 		if err != nil {
 			return nil, err
-		}
-		for _, n := range neighbors {
-			fk := n.file_type_files
-			if fk == nil {
-				return nil, fmt.Errorf(`foreign-key "file_type_files" is nil for node %v`, n.ID)
-			}
-			node, ok := nodeids[*fk]
-			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "file_type_files" returned %v for node %v`, *fk, n.ID)
-			}
-			node.Edges.Files = append(node.Edges.Files, n)
 		}
 	}
 

--- a/entc/integration/ent/group_query.go
+++ b/entc/integration/ent/group_query.go
@@ -506,142 +506,170 @@ func (gq *GroupQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Group,
 	}
 
 	if query := gq.withFiles; query != nil {
-		fks := make([]driver.Value, 0, len(nodes))
-		nodeids := make(map[int]*Group)
-		for i := range nodes {
-			fks = append(fks, nodes[i].ID)
-			nodeids[nodes[i].ID] = nodes[i]
-			nodes[i].Edges.Files = []*File{}
-		}
-		query.withFKs = true
-		query.Where(predicate.File(func(s *sql.Selector) {
-			s.Where(sql.InValues(group.FilesColumn, fks...))
-		}))
-		neighbors, err := query.All(ctx)
+		err := sql.Chunked(func(start, end int) error {
+			nodes := nodes[start:end]
+			fks := make([]driver.Value, 0, len(nodes))
+			nodeids := make(map[int]*Group)
+			for i := range nodes {
+				fks = append(fks, nodes[i].ID)
+				nodeids[nodes[i].ID] = nodes[i]
+				nodes[i].Edges.Files = []*File{}
+			}
+			query.withFKs = true
+			query.Where(predicate.File(func(s *sql.Selector) {
+				s.Where(sql.InValues(group.FilesColumn, fks...))
+			}))
+			neighbors, err := query.All(ctx)
+			if err != nil {
+				return err
+			}
+			for _, n := range neighbors {
+				fk := n.group_files
+				if fk == nil {
+					return fmt.Errorf(`foreign-key "group_files" is nil for node %v`, n.ID)
+				}
+				node, ok := nodeids[*fk]
+				if !ok {
+					return fmt.Errorf(`unexpected foreign-key "group_files" returned %v for node %v`, *fk, n.ID)
+				}
+				node.Edges.Files = append(node.Edges.Files, n)
+			}
+			return nil
+		}, len(nodes), sql.MaxParams(gq.driver.Dialect()))
 		if err != nil {
 			return nil, err
-		}
-		for _, n := range neighbors {
-			fk := n.group_files
-			if fk == nil {
-				return nil, fmt.Errorf(`foreign-key "group_files" is nil for node %v`, n.ID)
-			}
-			node, ok := nodeids[*fk]
-			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "group_files" returned %v for node %v`, *fk, n.ID)
-			}
-			node.Edges.Files = append(node.Edges.Files, n)
 		}
 	}
 
 	if query := gq.withBlocked; query != nil {
-		fks := make([]driver.Value, 0, len(nodes))
-		nodeids := make(map[int]*Group)
-		for i := range nodes {
-			fks = append(fks, nodes[i].ID)
-			nodeids[nodes[i].ID] = nodes[i]
-			nodes[i].Edges.Blocked = []*User{}
-		}
-		query.withFKs = true
-		query.Where(predicate.User(func(s *sql.Selector) {
-			s.Where(sql.InValues(group.BlockedColumn, fks...))
-		}))
-		neighbors, err := query.All(ctx)
+		err := sql.Chunked(func(start, end int) error {
+			nodes := nodes[start:end]
+			fks := make([]driver.Value, 0, len(nodes))
+			nodeids := make(map[int]*Group)
+			for i := range nodes {
+				fks = append(fks, nodes[i].ID)
+				nodeids[nodes[i].ID] = nodes[i]
+				nodes[i].Edges.Blocked = []*User{}
+			}
+			query.withFKs = true
+			query.Where(predicate.User(func(s *sql.Selector) {
+				s.Where(sql.InValues(group.BlockedColumn, fks...))
+			}))
+			neighbors, err := query.All(ctx)
+			if err != nil {
+				return err
+			}
+			for _, n := range neighbors {
+				fk := n.group_blocked
+				if fk == nil {
+					return fmt.Errorf(`foreign-key "group_blocked" is nil for node %v`, n.ID)
+				}
+				node, ok := nodeids[*fk]
+				if !ok {
+					return fmt.Errorf(`unexpected foreign-key "group_blocked" returned %v for node %v`, *fk, n.ID)
+				}
+				node.Edges.Blocked = append(node.Edges.Blocked, n)
+			}
+			return nil
+		}, len(nodes), sql.MaxParams(gq.driver.Dialect()))
 		if err != nil {
 			return nil, err
-		}
-		for _, n := range neighbors {
-			fk := n.group_blocked
-			if fk == nil {
-				return nil, fmt.Errorf(`foreign-key "group_blocked" is nil for node %v`, n.ID)
-			}
-			node, ok := nodeids[*fk]
-			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "group_blocked" returned %v for node %v`, *fk, n.ID)
-			}
-			node.Edges.Blocked = append(node.Edges.Blocked, n)
 		}
 	}
 
 	if query := gq.withUsers; query != nil {
-		edgeids := make([]driver.Value, len(nodes))
-		byid := make(map[int]*Group)
-		nids := make(map[int]map[*Group]struct{})
-		for i, node := range nodes {
-			edgeids[i] = node.ID
-			byid[node.ID] = node
-			node.Edges.Users = []*User{}
-		}
-		query.Where(func(s *sql.Selector) {
-			joinT := sql.Table(group.UsersTable)
-			s.Join(joinT).On(s.C(user.FieldID), joinT.C(group.UsersPrimaryKey[0]))
-			s.Where(sql.InValues(joinT.C(group.UsersPrimaryKey[1]), edgeids...))
-			columns := s.SelectedColumns()
-			s.Select(joinT.C(group.UsersPrimaryKey[1]))
-			s.AppendSelect(columns...)
-			s.SetDistinct(false)
-		})
-		neighbors, err := query.sqlAll(ctx, func(_ context.Context, spec *sqlgraph.QuerySpec) {
-			assign := spec.Assign
-			values := spec.ScanValues
-			spec.ScanValues = func(columns []string) ([]interface{}, error) {
-				values, err := values(columns[1:])
-				if err != nil {
-					return nil, err
-				}
-				return append([]interface{}{new(sql.NullInt64)}, values...), nil
+		err := sql.Chunked(func(start, end int) error {
+			nodes := nodes[start:end]
+			edgeids := make([]driver.Value, len(nodes))
+			byid := make(map[int]*Group)
+			nids := make(map[int]map[*Group]struct{})
+			for i, node := range nodes {
+				edgeids[i] = node.ID
+				byid[node.ID] = node
+				node.Edges.Users = []*User{}
 			}
-			spec.Assign = func(columns []string, values []interface{}) error {
-				outValue := int(values[0].(*sql.NullInt64).Int64)
-				inValue := int(values[1].(*sql.NullInt64).Int64)
-				if nids[inValue] == nil {
-					nids[inValue] = map[*Group]struct{}{byid[outValue]: struct{}{}}
-					return assign(columns[1:], values[1:])
+			query.Where(func(s *sql.Selector) {
+				joinT := sql.Table(group.UsersTable)
+				s.Join(joinT).On(s.C(user.FieldID), joinT.C(group.UsersPrimaryKey[0]))
+				s.Where(sql.InValues(joinT.C(group.UsersPrimaryKey[1]), edgeids...))
+				columns := s.SelectedColumns()
+				s.Select(joinT.C(group.UsersPrimaryKey[1]))
+				s.AppendSelect(columns...)
+				s.SetDistinct(false)
+			})
+			neighbors, err := query.sqlAll(ctx, func(_ context.Context, spec *sqlgraph.QuerySpec) {
+				assign := spec.Assign
+				values := spec.ScanValues
+				spec.ScanValues = func(columns []string) ([]interface{}, error) {
+					values, err := values(columns[1:])
+					if err != nil {
+						return nil, err
+					}
+					return append([]interface{}{new(sql.NullInt64)}, values...), nil
 				}
-				nids[inValue][byid[outValue]] = struct{}{}
-				return nil
+				spec.Assign = func(columns []string, values []interface{}) error {
+					outValue := int(values[0].(*sql.NullInt64).Int64)
+					inValue := int(values[1].(*sql.NullInt64).Int64)
+					if nids[inValue] == nil {
+						nids[inValue] = map[*Group]struct{}{byid[outValue]: struct{}{}}
+						return assign(columns[1:], values[1:])
+					}
+					nids[inValue][byid[outValue]] = struct{}{}
+					return nil
+				}
+			})
+			if err != nil {
+				return err
 			}
-		})
+			for _, n := range neighbors {
+				nodes, ok := nids[n.ID]
+				if !ok {
+					return fmt.Errorf(`unexpected "users" node returned %v`, n.ID)
+				}
+				for kn := range nodes {
+					kn.Edges.Users = append(kn.Edges.Users, n)
+				}
+			}
+			return nil
+		}, len(nodes), sql.MaxParams(gq.driver.Dialect()))
 		if err != nil {
 			return nil, err
-		}
-		for _, n := range neighbors {
-			nodes, ok := nids[n.ID]
-			if !ok {
-				return nil, fmt.Errorf(`unexpected "users" node returned %v`, n.ID)
-			}
-			for kn := range nodes {
-				kn.Edges.Users = append(kn.Edges.Users, n)
-			}
 		}
 	}
 
 	if query := gq.withInfo; query != nil {
-		ids := make([]int, 0, len(nodes))
-		nodeids := make(map[int][]*Group)
-		for i := range nodes {
-			if nodes[i].group_info == nil {
-				continue
+		err := sql.Chunked(func(start, end int) error {
+			nodes := nodes[start:end]
+			ids := make([]int, 0, len(nodes))
+			nodeids := make(map[int][]*Group)
+			for i := range nodes {
+				if nodes[i].group_info == nil {
+					continue
+				}
+				fk := *nodes[i].group_info
+				if _, ok := nodeids[fk]; !ok {
+					ids = append(ids, fk)
+				}
+				nodeids[fk] = append(nodeids[fk], nodes[i])
 			}
-			fk := *nodes[i].group_info
-			if _, ok := nodeids[fk]; !ok {
-				ids = append(ids, fk)
+			query.Where(groupinfo.IDIn(ids...))
+			neighbors, err := query.All(ctx)
+			if err != nil {
+				return err
 			}
-			nodeids[fk] = append(nodeids[fk], nodes[i])
-		}
-		query.Where(groupinfo.IDIn(ids...))
-		neighbors, err := query.All(ctx)
+			for _, n := range neighbors {
+				nodes, ok := nodeids[n.ID]
+				if !ok {
+					return fmt.Errorf(`unexpected foreign-key "group_info" returned %v`, n.ID)
+				}
+				for i := range nodes {
+					nodes[i].Edges.Info = n
+				}
+			}
+			return nil
+		}, len(nodes), sql.MaxParams(gq.driver.Dialect()))
 		if err != nil {
 			return nil, err
-		}
-		for _, n := range neighbors {
-			nodes, ok := nodeids[n.ID]
-			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "group_info" returned %v`, n.ID)
-			}
-			for i := range nodes {
-				nodes[i].Edges.Info = n
-			}
 		}
 	}
 

--- a/entc/integration/ent/user_query.go
+++ b/entc/integration/ent/user_query.go
@@ -759,415 +759,492 @@ func (uq *UserQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*User, e
 	}
 
 	if query := uq.withCard; query != nil {
-		fks := make([]driver.Value, 0, len(nodes))
-		nodeids := make(map[int]*User)
-		for i := range nodes {
-			fks = append(fks, nodes[i].ID)
-			nodeids[nodes[i].ID] = nodes[i]
-		}
-		query.withFKs = true
-		query.Where(predicate.Card(func(s *sql.Selector) {
-			s.Where(sql.InValues(user.CardColumn, fks...))
-		}))
-		neighbors, err := query.All(ctx)
+		err := sql.Chunked(func(start, end int) error {
+			nodes := nodes[start:end]
+			fks := make([]driver.Value, 0, len(nodes))
+			nodeids := make(map[int]*User)
+			for i := range nodes {
+				fks = append(fks, nodes[i].ID)
+				nodeids[nodes[i].ID] = nodes[i]
+			}
+			query.withFKs = true
+			query.Where(predicate.Card(func(s *sql.Selector) {
+				s.Where(sql.InValues(user.CardColumn, fks...))
+			}))
+			neighbors, err := query.All(ctx)
+			if err != nil {
+				return err
+			}
+			for _, n := range neighbors {
+				fk := n.user_card
+				if fk == nil {
+					return fmt.Errorf(`foreign-key "user_card" is nil for node %v`, n.ID)
+				}
+				node, ok := nodeids[*fk]
+				if !ok {
+					return fmt.Errorf(`unexpected foreign-key "user_card" returned %v for node %v`, *fk, n.ID)
+				}
+				node.Edges.Card = n
+			}
+			return nil
+		}, len(nodes), sql.MaxParams(uq.driver.Dialect()))
 		if err != nil {
 			return nil, err
-		}
-		for _, n := range neighbors {
-			fk := n.user_card
-			if fk == nil {
-				return nil, fmt.Errorf(`foreign-key "user_card" is nil for node %v`, n.ID)
-			}
-			node, ok := nodeids[*fk]
-			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "user_card" returned %v for node %v`, *fk, n.ID)
-			}
-			node.Edges.Card = n
 		}
 	}
 
 	if query := uq.withPets; query != nil {
-		fks := make([]driver.Value, 0, len(nodes))
-		nodeids := make(map[int]*User)
-		for i := range nodes {
-			fks = append(fks, nodes[i].ID)
-			nodeids[nodes[i].ID] = nodes[i]
-			nodes[i].Edges.Pets = []*Pet{}
-		}
-		query.withFKs = true
-		query.Where(predicate.Pet(func(s *sql.Selector) {
-			s.Where(sql.InValues(user.PetsColumn, fks...))
-		}))
-		neighbors, err := query.All(ctx)
+		err := sql.Chunked(func(start, end int) error {
+			nodes := nodes[start:end]
+			fks := make([]driver.Value, 0, len(nodes))
+			nodeids := make(map[int]*User)
+			for i := range nodes {
+				fks = append(fks, nodes[i].ID)
+				nodeids[nodes[i].ID] = nodes[i]
+				nodes[i].Edges.Pets = []*Pet{}
+			}
+			query.withFKs = true
+			query.Where(predicate.Pet(func(s *sql.Selector) {
+				s.Where(sql.InValues(user.PetsColumn, fks...))
+			}))
+			neighbors, err := query.All(ctx)
+			if err != nil {
+				return err
+			}
+			for _, n := range neighbors {
+				fk := n.user_pets
+				if fk == nil {
+					return fmt.Errorf(`foreign-key "user_pets" is nil for node %v`, n.ID)
+				}
+				node, ok := nodeids[*fk]
+				if !ok {
+					return fmt.Errorf(`unexpected foreign-key "user_pets" returned %v for node %v`, *fk, n.ID)
+				}
+				node.Edges.Pets = append(node.Edges.Pets, n)
+			}
+			return nil
+		}, len(nodes), sql.MaxParams(uq.driver.Dialect()))
 		if err != nil {
 			return nil, err
-		}
-		for _, n := range neighbors {
-			fk := n.user_pets
-			if fk == nil {
-				return nil, fmt.Errorf(`foreign-key "user_pets" is nil for node %v`, n.ID)
-			}
-			node, ok := nodeids[*fk]
-			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "user_pets" returned %v for node %v`, *fk, n.ID)
-			}
-			node.Edges.Pets = append(node.Edges.Pets, n)
 		}
 	}
 
 	if query := uq.withFiles; query != nil {
-		fks := make([]driver.Value, 0, len(nodes))
-		nodeids := make(map[int]*User)
-		for i := range nodes {
-			fks = append(fks, nodes[i].ID)
-			nodeids[nodes[i].ID] = nodes[i]
-			nodes[i].Edges.Files = []*File{}
-		}
-		query.withFKs = true
-		query.Where(predicate.File(func(s *sql.Selector) {
-			s.Where(sql.InValues(user.FilesColumn, fks...))
-		}))
-		neighbors, err := query.All(ctx)
+		err := sql.Chunked(func(start, end int) error {
+			nodes := nodes[start:end]
+			fks := make([]driver.Value, 0, len(nodes))
+			nodeids := make(map[int]*User)
+			for i := range nodes {
+				fks = append(fks, nodes[i].ID)
+				nodeids[nodes[i].ID] = nodes[i]
+				nodes[i].Edges.Files = []*File{}
+			}
+			query.withFKs = true
+			query.Where(predicate.File(func(s *sql.Selector) {
+				s.Where(sql.InValues(user.FilesColumn, fks...))
+			}))
+			neighbors, err := query.All(ctx)
+			if err != nil {
+				return err
+			}
+			for _, n := range neighbors {
+				fk := n.user_files
+				if fk == nil {
+					return fmt.Errorf(`foreign-key "user_files" is nil for node %v`, n.ID)
+				}
+				node, ok := nodeids[*fk]
+				if !ok {
+					return fmt.Errorf(`unexpected foreign-key "user_files" returned %v for node %v`, *fk, n.ID)
+				}
+				node.Edges.Files = append(node.Edges.Files, n)
+			}
+			return nil
+		}, len(nodes), sql.MaxParams(uq.driver.Dialect()))
 		if err != nil {
 			return nil, err
-		}
-		for _, n := range neighbors {
-			fk := n.user_files
-			if fk == nil {
-				return nil, fmt.Errorf(`foreign-key "user_files" is nil for node %v`, n.ID)
-			}
-			node, ok := nodeids[*fk]
-			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "user_files" returned %v for node %v`, *fk, n.ID)
-			}
-			node.Edges.Files = append(node.Edges.Files, n)
 		}
 	}
 
 	if query := uq.withGroups; query != nil {
-		edgeids := make([]driver.Value, len(nodes))
-		byid := make(map[int]*User)
-		nids := make(map[int]map[*User]struct{})
-		for i, node := range nodes {
-			edgeids[i] = node.ID
-			byid[node.ID] = node
-			node.Edges.Groups = []*Group{}
-		}
-		query.Where(func(s *sql.Selector) {
-			joinT := sql.Table(user.GroupsTable)
-			s.Join(joinT).On(s.C(group.FieldID), joinT.C(user.GroupsPrimaryKey[1]))
-			s.Where(sql.InValues(joinT.C(user.GroupsPrimaryKey[0]), edgeids...))
-			columns := s.SelectedColumns()
-			s.Select(joinT.C(user.GroupsPrimaryKey[0]))
-			s.AppendSelect(columns...)
-			s.SetDistinct(false)
-		})
-		neighbors, err := query.sqlAll(ctx, func(_ context.Context, spec *sqlgraph.QuerySpec) {
-			assign := spec.Assign
-			values := spec.ScanValues
-			spec.ScanValues = func(columns []string) ([]interface{}, error) {
-				values, err := values(columns[1:])
-				if err != nil {
-					return nil, err
-				}
-				return append([]interface{}{new(sql.NullInt64)}, values...), nil
+		err := sql.Chunked(func(start, end int) error {
+			nodes := nodes[start:end]
+			edgeids := make([]driver.Value, len(nodes))
+			byid := make(map[int]*User)
+			nids := make(map[int]map[*User]struct{})
+			for i, node := range nodes {
+				edgeids[i] = node.ID
+				byid[node.ID] = node
+				node.Edges.Groups = []*Group{}
 			}
-			spec.Assign = func(columns []string, values []interface{}) error {
-				outValue := int(values[0].(*sql.NullInt64).Int64)
-				inValue := int(values[1].(*sql.NullInt64).Int64)
-				if nids[inValue] == nil {
-					nids[inValue] = map[*User]struct{}{byid[outValue]: struct{}{}}
-					return assign(columns[1:], values[1:])
+			query.Where(func(s *sql.Selector) {
+				joinT := sql.Table(user.GroupsTable)
+				s.Join(joinT).On(s.C(group.FieldID), joinT.C(user.GroupsPrimaryKey[1]))
+				s.Where(sql.InValues(joinT.C(user.GroupsPrimaryKey[0]), edgeids...))
+				columns := s.SelectedColumns()
+				s.Select(joinT.C(user.GroupsPrimaryKey[0]))
+				s.AppendSelect(columns...)
+				s.SetDistinct(false)
+			})
+			neighbors, err := query.sqlAll(ctx, func(_ context.Context, spec *sqlgraph.QuerySpec) {
+				assign := spec.Assign
+				values := spec.ScanValues
+				spec.ScanValues = func(columns []string) ([]interface{}, error) {
+					values, err := values(columns[1:])
+					if err != nil {
+						return nil, err
+					}
+					return append([]interface{}{new(sql.NullInt64)}, values...), nil
 				}
-				nids[inValue][byid[outValue]] = struct{}{}
-				return nil
+				spec.Assign = func(columns []string, values []interface{}) error {
+					outValue := int(values[0].(*sql.NullInt64).Int64)
+					inValue := int(values[1].(*sql.NullInt64).Int64)
+					if nids[inValue] == nil {
+						nids[inValue] = map[*User]struct{}{byid[outValue]: struct{}{}}
+						return assign(columns[1:], values[1:])
+					}
+					nids[inValue][byid[outValue]] = struct{}{}
+					return nil
+				}
+			})
+			if err != nil {
+				return err
 			}
-		})
+			for _, n := range neighbors {
+				nodes, ok := nids[n.ID]
+				if !ok {
+					return fmt.Errorf(`unexpected "groups" node returned %v`, n.ID)
+				}
+				for kn := range nodes {
+					kn.Edges.Groups = append(kn.Edges.Groups, n)
+				}
+			}
+			return nil
+		}, len(nodes), sql.MaxParams(uq.driver.Dialect()))
 		if err != nil {
 			return nil, err
-		}
-		for _, n := range neighbors {
-			nodes, ok := nids[n.ID]
-			if !ok {
-				return nil, fmt.Errorf(`unexpected "groups" node returned %v`, n.ID)
-			}
-			for kn := range nodes {
-				kn.Edges.Groups = append(kn.Edges.Groups, n)
-			}
 		}
 	}
 
 	if query := uq.withFriends; query != nil {
-		edgeids := make([]driver.Value, len(nodes))
-		byid := make(map[int]*User)
-		nids := make(map[int]map[*User]struct{})
-		for i, node := range nodes {
-			edgeids[i] = node.ID
-			byid[node.ID] = node
-			node.Edges.Friends = []*User{}
-		}
-		query.Where(func(s *sql.Selector) {
-			joinT := sql.Table(user.FriendsTable)
-			s.Join(joinT).On(s.C(user.FieldID), joinT.C(user.FriendsPrimaryKey[1]))
-			s.Where(sql.InValues(joinT.C(user.FriendsPrimaryKey[0]), edgeids...))
-			columns := s.SelectedColumns()
-			s.Select(joinT.C(user.FriendsPrimaryKey[0]))
-			s.AppendSelect(columns...)
-			s.SetDistinct(false)
-		})
-		neighbors, err := query.sqlAll(ctx, func(_ context.Context, spec *sqlgraph.QuerySpec) {
-			assign := spec.Assign
-			values := spec.ScanValues
-			spec.ScanValues = func(columns []string) ([]interface{}, error) {
-				values, err := values(columns[1:])
-				if err != nil {
-					return nil, err
-				}
-				return append([]interface{}{new(sql.NullInt64)}, values...), nil
+		err := sql.Chunked(func(start, end int) error {
+			nodes := nodes[start:end]
+			edgeids := make([]driver.Value, len(nodes))
+			byid := make(map[int]*User)
+			nids := make(map[int]map[*User]struct{})
+			for i, node := range nodes {
+				edgeids[i] = node.ID
+				byid[node.ID] = node
+				node.Edges.Friends = []*User{}
 			}
-			spec.Assign = func(columns []string, values []interface{}) error {
-				outValue := int(values[0].(*sql.NullInt64).Int64)
-				inValue := int(values[1].(*sql.NullInt64).Int64)
-				if nids[inValue] == nil {
-					nids[inValue] = map[*User]struct{}{byid[outValue]: struct{}{}}
-					return assign(columns[1:], values[1:])
+			query.Where(func(s *sql.Selector) {
+				joinT := sql.Table(user.FriendsTable)
+				s.Join(joinT).On(s.C(user.FieldID), joinT.C(user.FriendsPrimaryKey[1]))
+				s.Where(sql.InValues(joinT.C(user.FriendsPrimaryKey[0]), edgeids...))
+				columns := s.SelectedColumns()
+				s.Select(joinT.C(user.FriendsPrimaryKey[0]))
+				s.AppendSelect(columns...)
+				s.SetDistinct(false)
+			})
+			neighbors, err := query.sqlAll(ctx, func(_ context.Context, spec *sqlgraph.QuerySpec) {
+				assign := spec.Assign
+				values := spec.ScanValues
+				spec.ScanValues = func(columns []string) ([]interface{}, error) {
+					values, err := values(columns[1:])
+					if err != nil {
+						return nil, err
+					}
+					return append([]interface{}{new(sql.NullInt64)}, values...), nil
 				}
-				nids[inValue][byid[outValue]] = struct{}{}
-				return nil
+				spec.Assign = func(columns []string, values []interface{}) error {
+					outValue := int(values[0].(*sql.NullInt64).Int64)
+					inValue := int(values[1].(*sql.NullInt64).Int64)
+					if nids[inValue] == nil {
+						nids[inValue] = map[*User]struct{}{byid[outValue]: struct{}{}}
+						return assign(columns[1:], values[1:])
+					}
+					nids[inValue][byid[outValue]] = struct{}{}
+					return nil
+				}
+			})
+			if err != nil {
+				return err
 			}
-		})
+			for _, n := range neighbors {
+				nodes, ok := nids[n.ID]
+				if !ok {
+					return fmt.Errorf(`unexpected "friends" node returned %v`, n.ID)
+				}
+				for kn := range nodes {
+					kn.Edges.Friends = append(kn.Edges.Friends, n)
+				}
+			}
+			return nil
+		}, len(nodes), sql.MaxParams(uq.driver.Dialect()))
 		if err != nil {
 			return nil, err
-		}
-		for _, n := range neighbors {
-			nodes, ok := nids[n.ID]
-			if !ok {
-				return nil, fmt.Errorf(`unexpected "friends" node returned %v`, n.ID)
-			}
-			for kn := range nodes {
-				kn.Edges.Friends = append(kn.Edges.Friends, n)
-			}
 		}
 	}
 
 	if query := uq.withFollowers; query != nil {
-		edgeids := make([]driver.Value, len(nodes))
-		byid := make(map[int]*User)
-		nids := make(map[int]map[*User]struct{})
-		for i, node := range nodes {
-			edgeids[i] = node.ID
-			byid[node.ID] = node
-			node.Edges.Followers = []*User{}
-		}
-		query.Where(func(s *sql.Selector) {
-			joinT := sql.Table(user.FollowersTable)
-			s.Join(joinT).On(s.C(user.FieldID), joinT.C(user.FollowersPrimaryKey[0]))
-			s.Where(sql.InValues(joinT.C(user.FollowersPrimaryKey[1]), edgeids...))
-			columns := s.SelectedColumns()
-			s.Select(joinT.C(user.FollowersPrimaryKey[1]))
-			s.AppendSelect(columns...)
-			s.SetDistinct(false)
-		})
-		neighbors, err := query.sqlAll(ctx, func(_ context.Context, spec *sqlgraph.QuerySpec) {
-			assign := spec.Assign
-			values := spec.ScanValues
-			spec.ScanValues = func(columns []string) ([]interface{}, error) {
-				values, err := values(columns[1:])
-				if err != nil {
-					return nil, err
-				}
-				return append([]interface{}{new(sql.NullInt64)}, values...), nil
+		err := sql.Chunked(func(start, end int) error {
+			nodes := nodes[start:end]
+			edgeids := make([]driver.Value, len(nodes))
+			byid := make(map[int]*User)
+			nids := make(map[int]map[*User]struct{})
+			for i, node := range nodes {
+				edgeids[i] = node.ID
+				byid[node.ID] = node
+				node.Edges.Followers = []*User{}
 			}
-			spec.Assign = func(columns []string, values []interface{}) error {
-				outValue := int(values[0].(*sql.NullInt64).Int64)
-				inValue := int(values[1].(*sql.NullInt64).Int64)
-				if nids[inValue] == nil {
-					nids[inValue] = map[*User]struct{}{byid[outValue]: struct{}{}}
-					return assign(columns[1:], values[1:])
+			query.Where(func(s *sql.Selector) {
+				joinT := sql.Table(user.FollowersTable)
+				s.Join(joinT).On(s.C(user.FieldID), joinT.C(user.FollowersPrimaryKey[0]))
+				s.Where(sql.InValues(joinT.C(user.FollowersPrimaryKey[1]), edgeids...))
+				columns := s.SelectedColumns()
+				s.Select(joinT.C(user.FollowersPrimaryKey[1]))
+				s.AppendSelect(columns...)
+				s.SetDistinct(false)
+			})
+			neighbors, err := query.sqlAll(ctx, func(_ context.Context, spec *sqlgraph.QuerySpec) {
+				assign := spec.Assign
+				values := spec.ScanValues
+				spec.ScanValues = func(columns []string) ([]interface{}, error) {
+					values, err := values(columns[1:])
+					if err != nil {
+						return nil, err
+					}
+					return append([]interface{}{new(sql.NullInt64)}, values...), nil
 				}
-				nids[inValue][byid[outValue]] = struct{}{}
-				return nil
+				spec.Assign = func(columns []string, values []interface{}) error {
+					outValue := int(values[0].(*sql.NullInt64).Int64)
+					inValue := int(values[1].(*sql.NullInt64).Int64)
+					if nids[inValue] == nil {
+						nids[inValue] = map[*User]struct{}{byid[outValue]: struct{}{}}
+						return assign(columns[1:], values[1:])
+					}
+					nids[inValue][byid[outValue]] = struct{}{}
+					return nil
+				}
+			})
+			if err != nil {
+				return err
 			}
-		})
+			for _, n := range neighbors {
+				nodes, ok := nids[n.ID]
+				if !ok {
+					return fmt.Errorf(`unexpected "followers" node returned %v`, n.ID)
+				}
+				for kn := range nodes {
+					kn.Edges.Followers = append(kn.Edges.Followers, n)
+				}
+			}
+			return nil
+		}, len(nodes), sql.MaxParams(uq.driver.Dialect()))
 		if err != nil {
 			return nil, err
-		}
-		for _, n := range neighbors {
-			nodes, ok := nids[n.ID]
-			if !ok {
-				return nil, fmt.Errorf(`unexpected "followers" node returned %v`, n.ID)
-			}
-			for kn := range nodes {
-				kn.Edges.Followers = append(kn.Edges.Followers, n)
-			}
 		}
 	}
 
 	if query := uq.withFollowing; query != nil {
-		edgeids := make([]driver.Value, len(nodes))
-		byid := make(map[int]*User)
-		nids := make(map[int]map[*User]struct{})
-		for i, node := range nodes {
-			edgeids[i] = node.ID
-			byid[node.ID] = node
-			node.Edges.Following = []*User{}
-		}
-		query.Where(func(s *sql.Selector) {
-			joinT := sql.Table(user.FollowingTable)
-			s.Join(joinT).On(s.C(user.FieldID), joinT.C(user.FollowingPrimaryKey[1]))
-			s.Where(sql.InValues(joinT.C(user.FollowingPrimaryKey[0]), edgeids...))
-			columns := s.SelectedColumns()
-			s.Select(joinT.C(user.FollowingPrimaryKey[0]))
-			s.AppendSelect(columns...)
-			s.SetDistinct(false)
-		})
-		neighbors, err := query.sqlAll(ctx, func(_ context.Context, spec *sqlgraph.QuerySpec) {
-			assign := spec.Assign
-			values := spec.ScanValues
-			spec.ScanValues = func(columns []string) ([]interface{}, error) {
-				values, err := values(columns[1:])
-				if err != nil {
-					return nil, err
-				}
-				return append([]interface{}{new(sql.NullInt64)}, values...), nil
+		err := sql.Chunked(func(start, end int) error {
+			nodes := nodes[start:end]
+			edgeids := make([]driver.Value, len(nodes))
+			byid := make(map[int]*User)
+			nids := make(map[int]map[*User]struct{})
+			for i, node := range nodes {
+				edgeids[i] = node.ID
+				byid[node.ID] = node
+				node.Edges.Following = []*User{}
 			}
-			spec.Assign = func(columns []string, values []interface{}) error {
-				outValue := int(values[0].(*sql.NullInt64).Int64)
-				inValue := int(values[1].(*sql.NullInt64).Int64)
-				if nids[inValue] == nil {
-					nids[inValue] = map[*User]struct{}{byid[outValue]: struct{}{}}
-					return assign(columns[1:], values[1:])
+			query.Where(func(s *sql.Selector) {
+				joinT := sql.Table(user.FollowingTable)
+				s.Join(joinT).On(s.C(user.FieldID), joinT.C(user.FollowingPrimaryKey[1]))
+				s.Where(sql.InValues(joinT.C(user.FollowingPrimaryKey[0]), edgeids...))
+				columns := s.SelectedColumns()
+				s.Select(joinT.C(user.FollowingPrimaryKey[0]))
+				s.AppendSelect(columns...)
+				s.SetDistinct(false)
+			})
+			neighbors, err := query.sqlAll(ctx, func(_ context.Context, spec *sqlgraph.QuerySpec) {
+				assign := spec.Assign
+				values := spec.ScanValues
+				spec.ScanValues = func(columns []string) ([]interface{}, error) {
+					values, err := values(columns[1:])
+					if err != nil {
+						return nil, err
+					}
+					return append([]interface{}{new(sql.NullInt64)}, values...), nil
 				}
-				nids[inValue][byid[outValue]] = struct{}{}
-				return nil
+				spec.Assign = func(columns []string, values []interface{}) error {
+					outValue := int(values[0].(*sql.NullInt64).Int64)
+					inValue := int(values[1].(*sql.NullInt64).Int64)
+					if nids[inValue] == nil {
+						nids[inValue] = map[*User]struct{}{byid[outValue]: struct{}{}}
+						return assign(columns[1:], values[1:])
+					}
+					nids[inValue][byid[outValue]] = struct{}{}
+					return nil
+				}
+			})
+			if err != nil {
+				return err
 			}
-		})
+			for _, n := range neighbors {
+				nodes, ok := nids[n.ID]
+				if !ok {
+					return fmt.Errorf(`unexpected "following" node returned %v`, n.ID)
+				}
+				for kn := range nodes {
+					kn.Edges.Following = append(kn.Edges.Following, n)
+				}
+			}
+			return nil
+		}, len(nodes), sql.MaxParams(uq.driver.Dialect()))
 		if err != nil {
 			return nil, err
-		}
-		for _, n := range neighbors {
-			nodes, ok := nids[n.ID]
-			if !ok {
-				return nil, fmt.Errorf(`unexpected "following" node returned %v`, n.ID)
-			}
-			for kn := range nodes {
-				kn.Edges.Following = append(kn.Edges.Following, n)
-			}
 		}
 	}
 
 	if query := uq.withTeam; query != nil {
-		fks := make([]driver.Value, 0, len(nodes))
-		nodeids := make(map[int]*User)
-		for i := range nodes {
-			fks = append(fks, nodes[i].ID)
-			nodeids[nodes[i].ID] = nodes[i]
-		}
-		query.withFKs = true
-		query.Where(predicate.Pet(func(s *sql.Selector) {
-			s.Where(sql.InValues(user.TeamColumn, fks...))
-		}))
-		neighbors, err := query.All(ctx)
+		err := sql.Chunked(func(start, end int) error {
+			nodes := nodes[start:end]
+			fks := make([]driver.Value, 0, len(nodes))
+			nodeids := make(map[int]*User)
+			for i := range nodes {
+				fks = append(fks, nodes[i].ID)
+				nodeids[nodes[i].ID] = nodes[i]
+			}
+			query.withFKs = true
+			query.Where(predicate.Pet(func(s *sql.Selector) {
+				s.Where(sql.InValues(user.TeamColumn, fks...))
+			}))
+			neighbors, err := query.All(ctx)
+			if err != nil {
+				return err
+			}
+			for _, n := range neighbors {
+				fk := n.user_team
+				if fk == nil {
+					return fmt.Errorf(`foreign-key "user_team" is nil for node %v`, n.ID)
+				}
+				node, ok := nodeids[*fk]
+				if !ok {
+					return fmt.Errorf(`unexpected foreign-key "user_team" returned %v for node %v`, *fk, n.ID)
+				}
+				node.Edges.Team = n
+			}
+			return nil
+		}, len(nodes), sql.MaxParams(uq.driver.Dialect()))
 		if err != nil {
 			return nil, err
-		}
-		for _, n := range neighbors {
-			fk := n.user_team
-			if fk == nil {
-				return nil, fmt.Errorf(`foreign-key "user_team" is nil for node %v`, n.ID)
-			}
-			node, ok := nodeids[*fk]
-			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "user_team" returned %v for node %v`, *fk, n.ID)
-			}
-			node.Edges.Team = n
 		}
 	}
 
 	if query := uq.withSpouse; query != nil {
-		ids := make([]int, 0, len(nodes))
-		nodeids := make(map[int][]*User)
-		for i := range nodes {
-			if nodes[i].user_spouse == nil {
-				continue
+		err := sql.Chunked(func(start, end int) error {
+			nodes := nodes[start:end]
+			ids := make([]int, 0, len(nodes))
+			nodeids := make(map[int][]*User)
+			for i := range nodes {
+				if nodes[i].user_spouse == nil {
+					continue
+				}
+				fk := *nodes[i].user_spouse
+				if _, ok := nodeids[fk]; !ok {
+					ids = append(ids, fk)
+				}
+				nodeids[fk] = append(nodeids[fk], nodes[i])
 			}
-			fk := *nodes[i].user_spouse
-			if _, ok := nodeids[fk]; !ok {
-				ids = append(ids, fk)
+			query.Where(user.IDIn(ids...))
+			neighbors, err := query.All(ctx)
+			if err != nil {
+				return err
 			}
-			nodeids[fk] = append(nodeids[fk], nodes[i])
-		}
-		query.Where(user.IDIn(ids...))
-		neighbors, err := query.All(ctx)
+			for _, n := range neighbors {
+				nodes, ok := nodeids[n.ID]
+				if !ok {
+					return fmt.Errorf(`unexpected foreign-key "user_spouse" returned %v`, n.ID)
+				}
+				for i := range nodes {
+					nodes[i].Edges.Spouse = n
+				}
+			}
+			return nil
+		}, len(nodes), sql.MaxParams(uq.driver.Dialect()))
 		if err != nil {
 			return nil, err
-		}
-		for _, n := range neighbors {
-			nodes, ok := nodeids[n.ID]
-			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "user_spouse" returned %v`, n.ID)
-			}
-			for i := range nodes {
-				nodes[i].Edges.Spouse = n
-			}
 		}
 	}
 
 	if query := uq.withChildren; query != nil {
-		fks := make([]driver.Value, 0, len(nodes))
-		nodeids := make(map[int]*User)
-		for i := range nodes {
-			fks = append(fks, nodes[i].ID)
-			nodeids[nodes[i].ID] = nodes[i]
-			nodes[i].Edges.Children = []*User{}
-		}
-		query.withFKs = true
-		query.Where(predicate.User(func(s *sql.Selector) {
-			s.Where(sql.InValues(user.ChildrenColumn, fks...))
-		}))
-		neighbors, err := query.All(ctx)
+		err := sql.Chunked(func(start, end int) error {
+			nodes := nodes[start:end]
+			fks := make([]driver.Value, 0, len(nodes))
+			nodeids := make(map[int]*User)
+			for i := range nodes {
+				fks = append(fks, nodes[i].ID)
+				nodeids[nodes[i].ID] = nodes[i]
+				nodes[i].Edges.Children = []*User{}
+			}
+			query.withFKs = true
+			query.Where(predicate.User(func(s *sql.Selector) {
+				s.Where(sql.InValues(user.ChildrenColumn, fks...))
+			}))
+			neighbors, err := query.All(ctx)
+			if err != nil {
+				return err
+			}
+			for _, n := range neighbors {
+				fk := n.user_parent
+				if fk == nil {
+					return fmt.Errorf(`foreign-key "user_parent" is nil for node %v`, n.ID)
+				}
+				node, ok := nodeids[*fk]
+				if !ok {
+					return fmt.Errorf(`unexpected foreign-key "user_parent" returned %v for node %v`, *fk, n.ID)
+				}
+				node.Edges.Children = append(node.Edges.Children, n)
+			}
+			return nil
+		}, len(nodes), sql.MaxParams(uq.driver.Dialect()))
 		if err != nil {
 			return nil, err
-		}
-		for _, n := range neighbors {
-			fk := n.user_parent
-			if fk == nil {
-				return nil, fmt.Errorf(`foreign-key "user_parent" is nil for node %v`, n.ID)
-			}
-			node, ok := nodeids[*fk]
-			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "user_parent" returned %v for node %v`, *fk, n.ID)
-			}
-			node.Edges.Children = append(node.Edges.Children, n)
 		}
 	}
 
 	if query := uq.withParent; query != nil {
-		ids := make([]int, 0, len(nodes))
-		nodeids := make(map[int][]*User)
-		for i := range nodes {
-			if nodes[i].user_parent == nil {
-				continue
+		err := sql.Chunked(func(start, end int) error {
+			nodes := nodes[start:end]
+			ids := make([]int, 0, len(nodes))
+			nodeids := make(map[int][]*User)
+			for i := range nodes {
+				if nodes[i].user_parent == nil {
+					continue
+				}
+				fk := *nodes[i].user_parent
+				if _, ok := nodeids[fk]; !ok {
+					ids = append(ids, fk)
+				}
+				nodeids[fk] = append(nodeids[fk], nodes[i])
 			}
-			fk := *nodes[i].user_parent
-			if _, ok := nodeids[fk]; !ok {
-				ids = append(ids, fk)
+			query.Where(user.IDIn(ids...))
+			neighbors, err := query.All(ctx)
+			if err != nil {
+				return err
 			}
-			nodeids[fk] = append(nodeids[fk], nodes[i])
-		}
-		query.Where(user.IDIn(ids...))
-		neighbors, err := query.All(ctx)
+			for _, n := range neighbors {
+				nodes, ok := nodeids[n.ID]
+				if !ok {
+					return fmt.Errorf(`unexpected foreign-key "user_parent" returned %v`, n.ID)
+				}
+				for i := range nodes {
+					nodes[i].Edges.Parent = n
+				}
+			}
+			return nil
+		}, len(nodes), sql.MaxParams(uq.driver.Dialect()))
 		if err != nil {
 			return nil, err
-		}
-		for _, n := range neighbors {
-			nodes, ok := nodeids[n.ID]
-			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "user_parent" returned %v`, n.ID)
-			}
-			for i := range nodes {
-				nodes[i].Edges.Parent = n
-			}
 		}
 	}
 


### PR DESCRIPTION
opening this PR to discuss a possible fix for this problem, I can polish this if we can settle on a good direction for this.

the issue we're having is that if we're querying more than 65535 records and doing eager-loading then we'll hit:
```
pq: got 70000 parameters but PostgreSQL only supports 65535 parameters
```

the simplest solution is probably to just document a warning for this and that the user (me in this case) should chunk the requests, but that comes with some risks... (ie a record being inserted in between etc.)

the solution I'm proposing here is fairly simple as well, though it needs to be cleaned up more ... not sure where these helper functions should go? maybe on the Driver?

an alternative I ran into which might be even better (but more work / complexity): https://klotzandrew.com/blog/postgres-passing-65535-parameter-limit