### PR TITLE
schema comment: load column comment, pass to atlas migration

### DIFF
--- a/dialect/sql/schema/atlas.go
+++ b/dialect/sql/schema/atlas.go
@@ -505,6 +505,9 @@ func (m *Migrate) aColumns(b atBuilder, t1 *Table, t2 *schema.Table) error {
 		if c1.Increment {
 			b.atIncrementC(t2, c2)
 		}
+		if c1.Comment != "" {
+			c2.AddAttrs(&schema.Comment{Text: c1.Comment})
+		}
 		t2.AddColumns(c2)
 	}
 	return nil

--- a/dialect/sql/schema/schema.go
+++ b/dialect/sql/schema/schema.go
@@ -187,6 +187,7 @@ type Column struct {
 	Default    interface{}       // default value.
 	Enums      []string          // enum values.
 	Collation  string            // collation type (utf8mb4_unicode_ci, utf8mb4_general_ci)
+	Comment    string            // column comment
 	typ        string            // row column type (used for Rows.Scan).
 	indexes    Indexes           // linked indexes.
 	foreign    *ForeignKey       // linked foreign-key.

--- a/entc/gen/template/migrate/schema.tmpl
+++ b/entc/gen/template/migrate/schema.tmpl
@@ -33,6 +33,7 @@ var (
 			{{- range $c := $t.Columns }}
 				{ Name: "{{ $c.Name }}", Type: field.{{ $c.Type.ConstName }},
 				{{- if $c.Unique }} Unique: true,{{ end }}
+				{{- with $c.Comment }} Comment: "{{ $c.Comment }}",{{ end }}
 				{{- if $c.Increment }} Increment: true,{{ end }}
 				{{- if $c.Nullable }} Nullable: {{ $c.Nullable }},{{ end }}
 				{{- with $c.Size }} Size: {{ . }},{{ end }}

--- a/entc/gen/type.go
+++ b/entc/gen/type.go
@@ -1215,6 +1215,7 @@ func (f Field) Column() *schema.Column {
 		Nullable: f.Optional,
 		Size:     f.size(),
 		Enums:    f.EnumValues(),
+		Comment:  f.Comment(),
 	}
 	switch {
 	case f.Default && (f.Type.Numeric() || f.Type.Type == field.TypeBool):

--- a/entc/gen/type.go
+++ b/entc/gen/type.go
@@ -1215,7 +1215,7 @@ func (f Field) Column() *schema.Column {
 		Nullable: f.Optional,
 		Size:     f.size(),
 		Enums:    f.EnumValues(),
-		Comment:  f.Comment(),
+		Comment:  strings.ReplaceAll(f.Comment(), "\n", "\\n"),
 	}
 	switch {
 	case f.Default && (f.Type.Numeric() || f.Type.Type == field.TypeBool):

--- a/entc/integration/config/ent/migrate/schema.go
+++ b/entc/integration/config/ent/migrate/schema.go
@@ -16,7 +16,7 @@ var (
 	// UsersColumns holds the columns for the "Users" table.
 	UsersColumns = []*schema.Column{
 		{Name: "user_id", Type: field.TypeInt},
-		{Name: "name", Type: field.TypeString, Nullable: true, Size: 128},
+		{Name: "name", Type: field.TypeString, Comment: "Comment line1\nComment line2", Nullable: true, Size: 128},
 		{Name: "label", Type: field.TypeString, Nullable: true},
 	}
 	// UsersTable holds the schema information for the "Users" table.

--- a/entc/integration/ent/migrate/schema.go
+++ b/entc/integration/ent/migrate/schema.go
@@ -20,7 +20,7 @@ var (
 		{Name: "update_time", Type: field.TypeTime},
 		{Name: "balance", Type: field.TypeFloat64, Default: 0},
 		{Name: "number", Type: field.TypeString},
-		{Name: "name", Type: field.TypeString, Nullable: true},
+		{Name: "name", Type: field.TypeString, Comment: "Exact name written on card", Nullable: true},
 		{Name: "user_card", Type: field.TypeInt, Unique: true, Nullable: true},
 	}
 	// CardsTable holds the schema information for the "cards" table.
@@ -247,7 +247,7 @@ var (
 		{Name: "expire", Type: field.TypeTime},
 		{Name: "type", Type: field.TypeString, Nullable: true, Size: 255},
 		{Name: "max_users", Type: field.TypeInt, Nullable: true, Default: 10},
-		{Name: "name", Type: field.TypeString},
+		{Name: "name", Type: field.TypeString, Comment: "field with multiple validators"},
 		{Name: "group_info", Type: field.TypeInt},
 	}
 	// GroupsTable holds the schema information for the "groups" table.

--- a/entc/integration/hooks/ent/migrate/schema.go
+++ b/entc/integration/hooks/ent/migrate/schema.go
@@ -16,9 +16,9 @@ var (
 	CardsColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "number", Type: field.TypeString, Default: "unknown"},
-		{Name: "name", Type: field.TypeString, Nullable: true},
+		{Name: "name", Type: field.TypeString, Comment: "Exact name written on card", Nullable: true},
 		{Name: "created_at", Type: field.TypeTime},
-		{Name: "in_hook", Type: field.TypeString},
+		{Name: "in_hook", Type: field.TypeString, Comment: "A mandatory field that is set by the hook"},
 		{Name: "user_cards", Type: field.TypeInt, Nullable: true},
 	}
 	// CardsTable holds the schema information for the "cards" table.

--- a/examples/version/ent/migrate/schema.go
+++ b/examples/version/ent/migrate/schema.go
@@ -15,7 +15,7 @@ var (
 	// UsersColumns holds the columns for the "users" table.
 	UsersColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
-		{Name: "version", Type: field.TypeInt64},
+		{Name: "version", Type: field.TypeInt64, Comment: "Unix time of when the latest update occurred"},
 		{Name: "status", Type: field.TypeEnum, Enums: []string{"online", "offline"}},
 	}
 	// UsersTable holds the schema information for the "users" table.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module entgo.io/ent
 go 1.17
 
 require (
-	ariga.io/atlas v0.3.8-0.20220505085539-5ec35b058386
+	ariga.io/atlas v0.4.1
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/go-openapi/inflect v0.19.0
 	github.com/go-sql-driver/mysql v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ ariga.io/atlas v0.3.8-0.20220504080252-21a1b71b3247 h1:ddEd4VgszWybh2EffinaIG3z/
 ariga.io/atlas v0.3.8-0.20220504080252-21a1b71b3247/go.mod h1:D/d0a5QyMFU2R5E8ArmpnWbMjFP9LOr0TsQNbKqhT20=
 ariga.io/atlas v0.3.8-0.20220505085539-5ec35b058386 h1:is98hS6Y0DOC9WEWSOOesrHrzZrt7xNswjQJov7K2EU=
 ariga.io/atlas v0.3.8-0.20220505085539-5ec35b058386/go.mod h1:D/d0a5QyMFU2R5E8ArmpnWbMjFP9LOr0TsQNbKqhT20=
+ariga.io/atlas v0.4.1 h1:ElhwKE2F28aTQqvnIzHO65oa7Oxn6VcO5blKlp9FzQ4=
+ariga.io/atlas v0.4.1/go.mod h1:CKqqlJeTdRfEmnHaCcNPHg8DD6GPx1TxNPZ1NFknKHU=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=


### PR DESCRIPTION
Context: 
  We uses atlas to generate versioned migration .sql files. 

Problem: 
  The columns' comments defined in schema are not generated to ent/migrate/schema.go. Thus, the .sql files generated by atlas doesn't contain column comments such as (`name` varchar(255) NOT NULL COMMENT "name of entity") in MySQL.
