### PR TITLE
Fix snake casing code for multibyte (i.e. non-ASCII) characters

### DIFF
--- a/entc/gen/func.go
+++ b/entc/gen/func.go
@@ -175,14 +175,20 @@ func snake(s string) string {
 		j int
 		b strings.Builder
 	)
-	for i := 0; i < len(s); i++ {
-		r := rune(s[i])
-		// Put '_' if it is not a start or end of a word, current letter is uppercase,
+	// Split a string on Unicode code point boundaries
+	// e.g. "Beløb" => [B e l ø b]
+	// This method works on non-ASCII characters such as 'ø'
+	codePoints := strings.Split(s, "")
+	for i := 0; i < len(codePoints); i++ {
+		r := []rune(codePoints[i])[0]
+		// Put '_' if it is not the start or end of a word, the current letter is uppercase,
 		// and previous is lowercase (cases like: "UserInfo"), or next letter is also
-		// a lowercase and previous letter is not "_".
-		if i > 0 && i < len(s)-1 && unicode.IsUpper(r) {
-			if unicode.IsLower(rune(s[i-1])) ||
-				j != i-1 && unicode.IsLower(rune(s[i+1])) && unicode.IsLetter(rune(s[i-1])) {
+		// lowercase and previous letter is not "_".
+		if i > 0 && i < len(codePoints)-1 && unicode.IsUpper(r) {
+			nextRune := []rune(codePoints[i+1])[0]
+			prevRune := []rune(codePoints[i-1])[0]
+			if unicode.IsLower(prevRune) ||
+				j != i-1 && unicode.IsLower(nextRune) && unicode.IsLetter(prevRune) {
 				j = i
 				b.WriteString("_")
 			}

--- a/entc/gen/func_test.go
+++ b/entc/gen/func_test.go
@@ -1,0 +1,34 @@
+// Copyright 2019-present Facebook Inc. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
+package gen
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	ChineseString           = "金额"
+	ChineseStringSnakeCased = "金额"
+
+	DanishString           = "MÆNGDEPenge"
+	DanishStringSnakeCased = "mængde_penge"
+
+	EnglishString           = "TotalAmount"
+	EnglishStringSnakeCased = "total_amount"
+
+	GreekString           = "ΧρηματικόΠοσό"
+	GreekStringSnakeCased = "χρηματικό_ποσό"
+)
+
+func TestSnakeCasing(t *testing.T) {
+	require := require.New(t)
+
+	require.Equal(ChineseStringSnakeCased, snake(ChineseString))
+	require.Equal(DanishStringSnakeCased, snake(DanishString))
+	require.Equal(EnglishStringSnakeCased, snake(EnglishString))
+	require.Equal(GreekStringSnakeCased, snake(GreekString))
+}


### PR DESCRIPTION
This PR resolves the problem in https://github.com/ent/ent/issues/2564

Ent users who already have non-ASCII chars in their DB field names will need to recreate/migrate their database tables (hopefully this shouldn't affect many users)