### PR TITLE
Add `pgdriver` instructions and clean up some unnecessary code

### DIFF
--- a/doc/md/sql-integration.md
+++ b/doc/md/sql-integration.md
@@ -13,23 +13,23 @@ First option:
 package main
 
 import (
-    "time"
+  "time"
 
-    "<your_project>/ent"
-    "entgo.io/ent/dialect/sql"
+  "<your_project>/ent"
+  "entgo.io/ent/dialect/sql"
 )
 
 func Open() (*ent.Client, error) {
-    drv, err := sql.Open("mysql", "<mysql-dsn>")
-    if err != nil {
-    	return nil, err
-    }
-    // Get the underlying sql.DB object of the driver.
-    db := drv.DB()
-    db.SetMaxIdleConns(10)
-    db.SetMaxOpenConns(100)
-    db.SetConnMaxLifetime(time.Hour)
-    return ent.NewClient(ent.Driver(drv)), nil
+  drv, err := sql.Open("mysql", "<mysql-dsn>")
+  // handle err
+  
+  // Get the underlying sql.DB object of the driver.
+  db := drv.DB()
+  db.SetMaxIdleConns(10)
+  db.SetMaxOpenConns(100)
+  db.SetConnMaxLifetime(time.Hour)
+
+  return ent.NewClient(ent.Driver(drv)), nil
 }
 ```
 
@@ -39,24 +39,24 @@ Second option:
 package main
 
 import (
-    "database/sql"
-    "time"
+  "database/sql"
+  "time"
 
-    "<your_project>/ent"
-    entsql "entgo.io/ent/dialect/sql"
+  "<your_project>/ent"
+  entsql "entgo.io/ent/dialect/sql"
 )
 
 func Open() (*ent.Client, error) {
-    db, err := sql.Open("mysql", "<mysql-dsn>")
-    if err != nil {
-    	return nil, err
-    }
-    db.SetMaxIdleConns(10)
-    db.SetMaxOpenConns(100)
-    db.SetConnMaxLifetime(time.Hour)
-    // Create an ent.Driver from `db`.
-    drv := entsql.OpenDB("mysql", db)
-    return ent.NewClient(ent.Driver(drv)), nil
+  db, err := sql.Open("mysql", "<mysql-dsn>")
+  // handle err
+
+  db.SetMaxIdleConns(10)
+  db.SetMaxOpenConns(100)
+  db.SetConnMaxLifetime(time.Hour)
+  // Create an ent.Driver from `db`.
+  drv := entsql.OpenDB("mysql", db)
+
+  return ent.NewClient(ent.Driver(drv)), nil
 }
 ```
 
@@ -66,45 +66,46 @@ func Open() (*ent.Client, error) {
 package main
 
 import (
-	"context"
-	"database/sql"
-	"database/sql/driver"
+  "context"
+  "database/sql"
+  "database/sql/driver"
 
-	"<project>/ent"
+  "<project>/ent"
 
-	"contrib.go.opencensus.io/integrations/ocsql"
-	"entgo.io/ent/dialect"
-	entsql "entgo.io/ent/dialect/sql"
-	"github.com/go-sql-driver/mysql"
+  "contrib.go.opencensus.io/integrations/ocsql"
+  "entgo.io/ent/dialect"
+  entsql "entgo.io/ent/dialect/sql"
+  "github.com/go-sql-driver/mysql"
 )
 
 type connector struct {
-	dsn string
+  dsn string
 }
 
 func (c connector) Connect(context.Context) (driver.Conn, error) {
-	return c.Driver().Open(c.dsn)
+  return c.Driver().Open(c.dsn)
 }
 
 func (connector) Driver() driver.Driver {
-	return ocsql.Wrap(
-		mysql.MySQLDriver{},
-		ocsql.WithAllTraceOptions(),
-		ocsql.WithRowsClose(false),
-		ocsql.WithRowsNext(false),
-		ocsql.WithDisableErrSkip(true),
-	)
+  return ocsql.Wrap(
+    mysql.MySQLDriver{},
+    ocsql.WithAllTraceOptions(),
+    ocsql.WithRowsClose(false),
+    ocsql.WithRowsNext(false),
+    ocsql.WithDisableErrSkip(true),
+  )
 }
 
 // Open new connection and start stats recorder.
 func Open(dsn string) *ent.Client {
-	db := sql.OpenDB(connector{dsn})
-	// Create an ent.Driver from `db`.
-	drv := entsql.OpenDB(dialect.MySQL, db)
-	return ent.NewClient(ent.Driver(drv))
+  db := sql.OpenDB(connector{dsn})
+
+  // Create an ent.Driver from `db`.
+  drv := entsql.OpenDB(dialect.MySQL, db)
+
+  return ent.NewClient(ent.Driver(drv))
 }
 ```
-
 
 ## Use pgx with PostgreSQL
 
@@ -112,41 +113,70 @@ func Open(dsn string) *ent.Client {
 package main
 
 import (
-	"context"
-	"database/sql"
-	"log"
+  "context"
+  "database/sql"
+  "log"
 
-	"<project>/ent"
+  "<project>/ent"
 
-	"entgo.io/ent/dialect"
-	entsql "entgo.io/ent/dialect/sql"
-	_ "github.com/jackc/pgx/v4/stdlib"
+  "entgo.io/ent/dialect"
+  entsql "entgo.io/ent/dialect/sql"
+  _ "github.com/jackc/pgx/v4/stdlib"
 )
 
 // Open new connection
 func Open(databaseUrl string) *ent.Client {
-	db, err := sql.Open("pgx", databaseUrl)
-	if err != nil {
-		log.Fatal(err)
-	}
+  db, err := sql.Open("pgx", databaseUrl)
+  // handle err
 
-	// Create an ent.Driver from `db`.
-	drv := entsql.OpenDB(dialect.Postgres, db)
-	return ent.NewClient(ent.Driver(drv))
+  // Create an ent.Driver from `db`.
+  drv := entsql.OpenDB(dialect.Postgres, db)
+
+  return ent.NewClient(ent.Driver(drv))
 }
 
 func main() {
-	client := Open("postgresql://user:password@127.0.0.1/database")
+  client := Open("postgresql://user:password@127.0.0.1/database")
 
-	// Your code. For example:
-	ctx := context.Background()
-	if err := client.Schema.Create(ctx); err != nil {
-		log.Fatal(err)
-	}
-	users, err := client.User.Query().All(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
-	log.Println(users)
+  // Your code. For example:
+  users, err := client.User.Query().All(ctx)
+  // handle err
+}
+```
+
+## Use [pgdriver](https://github.com/uptrace/bun/tree/master/driver/pgdriver) with PostgreSQL
+
+```go
+package main
+
+import (
+  "context"
+  "database/sql"
+  "log"
+
+  "<project>/ent"
+
+  "entgo.io/ent/dialect"
+  entsql "entgo.io/ent/dialect/sql"
+  "github.com/uptrace/bun/driver/pgdriver"
+)
+
+// Open new connection
+func Open(databaseUrl string) *ent.Client {
+  db, err := sql.OpenDB("pgx", pgdriver.NewConnector(pgdriver.WithDSN(databaseUrl)))
+  // handle err
+
+  // Create an ent.Driver from `db`.
+  drv := entsql.OpenDB(dialect.Postgres, db)
+
+  return ent.NewClient(ent.Driver(drv))
+}
+
+func main() {
+  client := Open("postgresql://user:password@127.0.0.1/database")
+
+  // Your code. For example:
+  users, err := client.User.Query().All(ctx)
+  // handle err
 }
 ```


### PR DESCRIPTION
Coming from Bun I know that Bun uses [`pgdriver`](https://github.com/uptrace/bun/tree/master/driver/pgdriver) which is [faster](https://github.com/go-bun/bun-benchmark) than [`pgx`](https://github.com/jackc/pgx):

```
BenchmarkInsert/pg-12 	    7254	    148380 ns/op	     900 B/op	      13 allocs/op
BenchmarkInsert/pgx-12         	    6494	    166391 ns/op	    2076 B/op	      26 allocs/op
BenchmarkSelect/pg-12          	    9100	    132952 ns/op	    1417 B/op	      18 allocs/op
BenchmarkSelect/pgx-12         	    8199	    154920 ns/op	    3679 B/op	      60 allocs/op
```

`pgdriver` is fully `database/sql` compatible and has many amazing features/adavntages: https://bun.uptrace.dev/postgres/#pgdriver.