### PR TITLE
Fix compile error caused by entc template when Entity name has initials TX

### DIFF
--- a/entc/gen/template/ent.tmpl
+++ b/entc/gen/template/ent.tmpl
@@ -111,11 +111,11 @@ func ({{ $receiver }} *{{ $.Name }}) Update() *{{ $.UpdateOneName }} {
 // Unwrap unwraps the {{ $.Name }} entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func ({{ $receiver }} *{{ $.Name }}) Unwrap() *{{ $.Name }} {
-	tx, ok := {{ $receiver }}.config.driver.(*txDriver)
+	_tx, ok := {{ $receiver }}.config.driver.(*txDriver)
 	if !ok {
 		panic("{{ $pkg }}: {{ $.Name }} is not a transactional entity")
 	}
-	{{ $receiver }}.config.driver = tx.drv
+	{{ $receiver }}.config.driver = _tx.drv
 	return {{ $receiver }}
 }
 

--- a/entc/integration/cascadelete/ent/comment.go
+++ b/entc/integration/cascadelete/ent/comment.go
@@ -114,11 +114,11 @@ func (c *Comment) Update() *CommentUpdateOne {
 // Unwrap unwraps the Comment entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (c *Comment) Unwrap() *Comment {
-	tx, ok := c.config.driver.(*txDriver)
+	_tx, ok := c.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Comment is not a transactional entity")
 	}
-	c.config.driver = tx.drv
+	c.config.driver = _tx.drv
 	return c
 }
 

--- a/entc/integration/cascadelete/ent/post.go
+++ b/entc/integration/cascadelete/ent/post.go
@@ -130,11 +130,11 @@ func (po *Post) Update() *PostUpdateOne {
 // Unwrap unwraps the Post entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (po *Post) Unwrap() *Post {
-	tx, ok := po.config.driver.(*txDriver)
+	_tx, ok := po.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Post is not a transactional entity")
 	}
-	po.config.driver = tx.drv
+	po.config.driver = _tx.drv
 	return po
 }
 

--- a/entc/integration/cascadelete/ent/user.go
+++ b/entc/integration/cascadelete/ent/user.go
@@ -100,11 +100,11 @@ func (u *User) Update() *UserUpdateOne {
 // Unwrap unwraps the User entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (u *User) Unwrap() *User {
-	tx, ok := u.config.driver.(*txDriver)
+	_tx, ok := u.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: User is not a transactional entity")
 	}
-	u.config.driver = tx.drv
+	u.config.driver = _tx.drv
 	return u
 }
 

--- a/entc/integration/config/ent/user.go
+++ b/entc/integration/config/ent/user.go
@@ -84,11 +84,11 @@ func (u *User) Update() *UserUpdateOne {
 // Unwrap unwraps the User entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (u *User) Unwrap() *User {
-	tx, ok := u.config.driver.(*txDriver)
+	_tx, ok := u.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: User is not a transactional entity")
 	}
-	u.config.driver = tx.drv
+	u.config.driver = _tx.drv
 	return u
 }
 

--- a/entc/integration/customid/ent/account.go
+++ b/entc/integration/customid/ent/account.go
@@ -101,11 +101,11 @@ func (a *Account) Update() *AccountUpdateOne {
 // Unwrap unwraps the Account entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (a *Account) Unwrap() *Account {
-	tx, ok := a.config.driver.(*txDriver)
+	_tx, ok := a.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Account is not a transactional entity")
 	}
-	a.config.driver = tx.drv
+	a.config.driver = _tx.drv
 	return a
 }
 

--- a/entc/integration/customid/ent/blob.go
+++ b/entc/integration/customid/ent/blob.go
@@ -140,11 +140,11 @@ func (b *Blob) Update() *BlobUpdateOne {
 // Unwrap unwraps the Blob entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (b *Blob) Unwrap() *Blob {
-	tx, ok := b.config.driver.(*txDriver)
+	_tx, ok := b.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Blob is not a transactional entity")
 	}
-	b.config.driver = tx.drv
+	b.config.driver = _tx.drv
 	return b
 }
 

--- a/entc/integration/customid/ent/car.go
+++ b/entc/integration/customid/ent/car.go
@@ -134,11 +134,11 @@ func (c *Car) Update() *CarUpdateOne {
 // Unwrap unwraps the Car entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (c *Car) Unwrap() *Car {
-	tx, ok := c.config.driver.(*txDriver)
+	_tx, ok := c.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Car is not a transactional entity")
 	}
-	c.config.driver = tx.drv
+	c.config.driver = _tx.drv
 	return c
 }
 

--- a/entc/integration/customid/ent/device.go
+++ b/entc/integration/customid/ent/device.go
@@ -123,11 +123,11 @@ func (d *Device) Update() *DeviceUpdateOne {
 // Unwrap unwraps the Device entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (d *Device) Unwrap() *Device {
-	tx, ok := d.config.driver.(*txDriver)
+	_tx, ok := d.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Device is not a transactional entity")
 	}
-	d.config.driver = tx.drv
+	d.config.driver = _tx.drv
 	return d
 }
 

--- a/entc/integration/customid/ent/doc.go
+++ b/entc/integration/customid/ent/doc.go
@@ -132,11 +132,11 @@ func (d *Doc) Update() *DocUpdateOne {
 // Unwrap unwraps the Doc entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (d *Doc) Unwrap() *Doc {
-	tx, ok := d.config.driver.(*txDriver)
+	_tx, ok := d.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Doc is not a transactional entity")
 	}
-	d.config.driver = tx.drv
+	d.config.driver = _tx.drv
 	return d
 }
 

--- a/entc/integration/customid/ent/group.go
+++ b/entc/integration/customid/ent/group.go
@@ -90,11 +90,11 @@ func (gr *Group) Update() *GroupUpdateOne {
 // Unwrap unwraps the Group entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (gr *Group) Unwrap() *Group {
-	tx, ok := gr.config.driver.(*txDriver)
+	_tx, ok := gr.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Group is not a transactional entity")
 	}
-	gr.config.driver = tx.drv
+	gr.config.driver = _tx.drv
 	return gr
 }
 

--- a/entc/integration/customid/ent/mixinid.go
+++ b/entc/integration/customid/ent/mixinid.go
@@ -83,11 +83,11 @@ func (mi *MixinID) Update() *MixinIDUpdateOne {
 // Unwrap unwraps the MixinID entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (mi *MixinID) Unwrap() *MixinID {
-	tx, ok := mi.config.driver.(*txDriver)
+	_tx, ok := mi.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: MixinID is not a transactional entity")
 	}
-	mi.config.driver = tx.drv
+	mi.config.driver = _tx.drv
 	return mi
 }
 

--- a/entc/integration/customid/ent/note.go
+++ b/entc/integration/customid/ent/note.go
@@ -130,11 +130,11 @@ func (n *Note) Update() *NoteUpdateOne {
 // Unwrap unwraps the Note entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (n *Note) Unwrap() *Note {
-	tx, ok := n.config.driver.(*txDriver)
+	_tx, ok := n.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Note is not a transactional entity")
 	}
-	n.config.driver = tx.drv
+	n.config.driver = _tx.drv
 	return n
 }
 

--- a/entc/integration/customid/ent/other.go
+++ b/entc/integration/customid/ent/other.go
@@ -64,11 +64,11 @@ func (o *Other) Update() *OtherUpdateOne {
 // Unwrap unwraps the Other entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (o *Other) Unwrap() *Other {
-	tx, ok := o.config.driver.(*txDriver)
+	_tx, ok := o.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Other is not a transactional entity")
 	}
-	o.config.driver = tx.drv
+	o.config.driver = _tx.drv
 	return o
 }
 

--- a/entc/integration/customid/ent/pet.go
+++ b/entc/integration/customid/ent/pet.go
@@ -169,11 +169,11 @@ func (pe *Pet) Update() *PetUpdateOne {
 // Unwrap unwraps the Pet entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (pe *Pet) Unwrap() *Pet {
-	tx, ok := pe.config.driver.(*txDriver)
+	_tx, ok := pe.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Pet is not a transactional entity")
 	}
-	pe.config.driver = tx.drv
+	pe.config.driver = _tx.drv
 	return pe
 }
 

--- a/entc/integration/customid/ent/revision.go
+++ b/entc/integration/customid/ent/revision.go
@@ -64,11 +64,11 @@ func (r *Revision) Update() *RevisionUpdateOne {
 // Unwrap unwraps the Revision entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (r *Revision) Unwrap() *Revision {
-	tx, ok := r.config.driver.(*txDriver)
+	_tx, ok := r.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Revision is not a transactional entity")
 	}
-	r.config.driver = tx.drv
+	r.config.driver = _tx.drv
 	return r
 }
 

--- a/entc/integration/customid/ent/session.go
+++ b/entc/integration/customid/ent/session.go
@@ -107,11 +107,11 @@ func (s *Session) Update() *SessionUpdateOne {
 // Unwrap unwraps the Session entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (s *Session) Unwrap() *Session {
-	tx, ok := s.config.driver.(*txDriver)
+	_tx, ok := s.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Session is not a transactional entity")
 	}
-	s.config.driver = tx.drv
+	s.config.driver = _tx.drv
 	return s
 }
 

--- a/entc/integration/customid/ent/token.go
+++ b/entc/integration/customid/ent/token.go
@@ -117,11 +117,11 @@ func (t *Token) Update() *TokenUpdateOne {
 // Unwrap unwraps the Token entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (t *Token) Unwrap() *Token {
-	tx, ok := t.config.driver.(*txDriver)
+	_tx, ok := t.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Token is not a transactional entity")
 	}
-	t.config.driver = tx.drv
+	t.config.driver = _tx.drv
 	return t
 }
 

--- a/entc/integration/customid/ent/user.go
+++ b/entc/integration/customid/ent/user.go
@@ -153,11 +153,11 @@ func (u *User) Update() *UserUpdateOne {
 // Unwrap unwraps the User entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (u *User) Unwrap() *User {
-	tx, ok := u.config.driver.(*txDriver)
+	_tx, ok := u.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: User is not a transactional entity")
 	}
-	u.config.driver = tx.drv
+	u.config.driver = _tx.drv
 	return u
 }
 

--- a/entc/integration/edgefield/ent/car.go
+++ b/entc/integration/edgefield/ent/car.go
@@ -101,11 +101,11 @@ func (c *Car) Update() *CarUpdateOne {
 // Unwrap unwraps the Car entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (c *Car) Unwrap() *Car {
-	tx, ok := c.config.driver.(*txDriver)
+	_tx, ok := c.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Car is not a transactional entity")
 	}
-	c.config.driver = tx.drv
+	c.config.driver = _tx.drv
 	return c
 }
 

--- a/entc/integration/edgefield/ent/card.go
+++ b/entc/integration/edgefield/ent/card.go
@@ -114,11 +114,11 @@ func (c *Card) Update() *CardUpdateOne {
 // Unwrap unwraps the Card entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (c *Card) Unwrap() *Card {
-	tx, ok := c.config.driver.(*txDriver)
+	_tx, ok := c.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Card is not a transactional entity")
 	}
-	c.config.driver = tx.drv
+	c.config.driver = _tx.drv
 	return c
 }
 

--- a/entc/integration/edgefield/ent/info.go
+++ b/entc/integration/edgefield/ent/info.go
@@ -109,11 +109,11 @@ func (i *Info) Update() *InfoUpdateOne {
 // Unwrap unwraps the Info entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (i *Info) Unwrap() *Info {
-	tx, ok := i.config.driver.(*txDriver)
+	_tx, ok := i.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Info is not a transactional entity")
 	}
-	i.config.driver = tx.drv
+	i.config.driver = _tx.drv
 	return i
 }
 

--- a/entc/integration/edgefield/ent/metadata.go
+++ b/entc/integration/edgefield/ent/metadata.go
@@ -149,11 +149,11 @@ func (m *Metadata) Update() *MetadataUpdateOne {
 // Unwrap unwraps the Metadata entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (m *Metadata) Unwrap() *Metadata {
-	tx, ok := m.config.driver.(*txDriver)
+	_tx, ok := m.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Metadata is not a transactional entity")
 	}
-	m.config.driver = tx.drv
+	m.config.driver = _tx.drv
 	return m
 }
 

--- a/entc/integration/edgefield/ent/node.go
+++ b/entc/integration/edgefield/ent/node.go
@@ -132,11 +132,11 @@ func (n *Node) Update() *NodeUpdateOne {
 // Unwrap unwraps the Node entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (n *Node) Unwrap() *Node {
-	tx, ok := n.config.driver.(*txDriver)
+	_tx, ok := n.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Node is not a transactional entity")
 	}
-	n.config.driver = tx.drv
+	n.config.driver = _tx.drv
 	return n
 }
 

--- a/entc/integration/edgefield/ent/pet.go
+++ b/entc/integration/edgefield/ent/pet.go
@@ -104,11 +104,11 @@ func (pe *Pet) Update() *PetUpdateOne {
 // Unwrap unwraps the Pet entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (pe *Pet) Unwrap() *Pet {
-	tx, ok := pe.config.driver.(*txDriver)
+	_tx, ok := pe.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Pet is not a transactional entity")
 	}
-	pe.config.driver = tx.drv
+	pe.config.driver = _tx.drv
 	return pe
 }
 

--- a/entc/integration/edgefield/ent/post.go
+++ b/entc/integration/edgefield/ent/post.go
@@ -115,11 +115,11 @@ func (po *Post) Update() *PostUpdateOne {
 // Unwrap unwraps the Post entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (po *Post) Unwrap() *Post {
-	tx, ok := po.config.driver.(*txDriver)
+	_tx, ok := po.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Post is not a transactional entity")
 	}
-	po.config.driver = tx.drv
+	po.config.driver = _tx.drv
 	return po
 }
 

--- a/entc/integration/edgefield/ent/rental.go
+++ b/entc/integration/edgefield/ent/rental.go
@@ -148,11 +148,11 @@ func (r *Rental) Update() *RentalUpdateOne {
 // Unwrap unwraps the Rental entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (r *Rental) Unwrap() *Rental {
-	tx, ok := r.config.driver.(*txDriver)
+	_tx, ok := r.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Rental is not a transactional entity")
 	}
-	r.config.driver = tx.drv
+	r.config.driver = _tx.drv
 	return r
 }
 

--- a/entc/integration/edgefield/ent/user.go
+++ b/entc/integration/edgefield/ent/user.go
@@ -240,11 +240,11 @@ func (u *User) Update() *UserUpdateOne {
 // Unwrap unwraps the User entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (u *User) Unwrap() *User {
-	tx, ok := u.config.driver.(*txDriver)
+	_tx, ok := u.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: User is not a transactional entity")
 	}
-	u.config.driver = tx.drv
+	u.config.driver = _tx.drv
 	return u
 }
 

--- a/entc/integration/edgeschema/ent/friendship.go
+++ b/entc/integration/edgeschema/ent/friendship.go
@@ -148,11 +148,11 @@ func (f *Friendship) Update() *FriendshipUpdateOne {
 // Unwrap unwraps the Friendship entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (f *Friendship) Unwrap() *Friendship {
-	tx, ok := f.config.driver.(*txDriver)
+	_tx, ok := f.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Friendship is not a transactional entity")
 	}
-	f.config.driver = tx.drv
+	f.config.driver = _tx.drv
 	return f
 }
 

--- a/entc/integration/edgeschema/ent/group.go
+++ b/entc/integration/edgeschema/ent/group.go
@@ -112,11 +112,11 @@ func (gr *Group) Update() *GroupUpdateOne {
 // Unwrap unwraps the Group entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (gr *Group) Unwrap() *Group {
-	tx, ok := gr.config.driver.(*txDriver)
+	_tx, ok := gr.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Group is not a transactional entity")
 	}
-	gr.config.driver = tx.drv
+	gr.config.driver = _tx.drv
 	return gr
 }
 

--- a/entc/integration/edgeschema/ent/relationship.go
+++ b/entc/integration/edgeschema/ent/relationship.go
@@ -129,11 +129,11 @@ func (r *Relationship) Update() *RelationshipUpdateOne {
 // Unwrap unwraps the Relationship entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (r *Relationship) Unwrap() *Relationship {
-	tx, ok := r.config.driver.(*txDriver)
+	_tx, ok := r.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Relationship is not a transactional entity")
 	}
-	r.config.driver = tx.drv
+	r.config.driver = _tx.drv
 	return r
 }
 

--- a/entc/integration/edgeschema/ent/tweet.go
+++ b/entc/integration/edgeschema/ent/tweet.go
@@ -144,11 +144,11 @@ func (t *Tweet) Update() *TweetUpdateOne {
 // Unwrap unwraps the Tweet entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (t *Tweet) Unwrap() *Tweet {
-	tx, ok := t.config.driver.(*txDriver)
+	_tx, ok := t.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Tweet is not a transactional entity")
 	}
-	t.config.driver = tx.drv
+	t.config.driver = _tx.drv
 	return t
 }
 

--- a/entc/integration/edgeschema/ent/tweetlike.go
+++ b/entc/integration/edgeschema/ent/tweetlike.go
@@ -133,11 +133,11 @@ func (tl *TweetLike) Update() *TweetLikeUpdateOne {
 // Unwrap unwraps the TweetLike entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (tl *TweetLike) Unwrap() *TweetLike {
-	tx, ok := tl.config.driver.(*txDriver)
+	_tx, ok := tl.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: TweetLike is not a transactional entity")
 	}
-	tl.config.driver = tx.drv
+	tl.config.driver = _tx.drv
 	return tl
 }
 

--- a/entc/integration/edgeschema/ent/user.go
+++ b/entc/integration/edgeschema/ent/user.go
@@ -240,11 +240,11 @@ func (u *User) Update() *UserUpdateOne {
 // Unwrap unwraps the User entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (u *User) Unwrap() *User {
-	tx, ok := u.config.driver.(*txDriver)
+	_tx, ok := u.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: User is not a transactional entity")
 	}
-	u.config.driver = tx.drv
+	u.config.driver = _tx.drv
 	return u
 }
 

--- a/entc/integration/edgeschema/ent/usergroup.go
+++ b/entc/integration/edgeschema/ent/usergroup.go
@@ -141,11 +141,11 @@ func (ug *UserGroup) Update() *UserGroupUpdateOne {
 // Unwrap unwraps the UserGroup entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (ug *UserGroup) Unwrap() *UserGroup {
-	tx, ok := ug.config.driver.(*txDriver)
+	_tx, ok := ug.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: UserGroup is not a transactional entity")
 	}
-	ug.config.driver = tx.drv
+	ug.config.driver = _tx.drv
 	return ug
 }
 

--- a/entc/integration/edgeschema/ent/usertweet.go
+++ b/entc/integration/edgeschema/ent/usertweet.go
@@ -141,11 +141,11 @@ func (ut *UserTweet) Update() *UserTweetUpdateOne {
 // Unwrap unwraps the UserTweet entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (ut *UserTweet) Unwrap() *UserTweet {
-	tx, ok := ut.config.driver.(*txDriver)
+	_tx, ok := ut.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: UserTweet is not a transactional entity")
 	}
-	ut.config.driver = tx.drv
+	ut.config.driver = _tx.drv
 	return ut
 }
 

--- a/entc/integration/ent/card.go
+++ b/entc/integration/ent/card.go
@@ -173,11 +173,11 @@ func (c *Card) Update() *CardUpdateOne {
 // Unwrap unwraps the Card entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (c *Card) Unwrap() *Card {
-	tx, ok := c.config.driver.(*txDriver)
+	_tx, ok := c.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Card is not a transactional entity")
 	}
-	c.config.driver = tx.drv
+	c.config.driver = _tx.drv
 	return c
 }
 

--- a/entc/integration/ent/comment.go
+++ b/entc/integration/ent/comment.go
@@ -101,11 +101,11 @@ func (c *Comment) Update() *CommentUpdateOne {
 // Unwrap unwraps the Comment entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (c *Comment) Unwrap() *Comment {
-	tx, ok := c.config.driver.(*txDriver)
+	_tx, ok := c.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Comment is not a transactional entity")
 	}
-	c.config.driver = tx.drv
+	c.config.driver = _tx.drv
 	return c
 }
 

--- a/entc/integration/ent/fieldtype.go
+++ b/entc/integration/ent/fieldtype.go
@@ -650,11 +650,11 @@ func (ft *FieldType) Update() *FieldTypeUpdateOne {
 // Unwrap unwraps the FieldType entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (ft *FieldType) Unwrap() *FieldType {
-	tx, ok := ft.config.driver.(*txDriver)
+	_tx, ok := ft.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: FieldType is not a transactional entity")
 	}
-	ft.config.driver = tx.drv
+	ft.config.driver = _tx.drv
 	return ft
 }
 

--- a/entc/integration/ent/file.go
+++ b/entc/integration/ent/file.go
@@ -209,11 +209,11 @@ func (f *File) Update() *FileUpdateOne {
 // Unwrap unwraps the File entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (f *File) Unwrap() *File {
-	tx, ok := f.config.driver.(*txDriver)
+	_tx, ok := f.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: File is not a transactional entity")
 	}
-	f.config.driver = tx.drv
+	f.config.driver = _tx.drv
 	return f
 }
 

--- a/entc/integration/ent/filetype.go
+++ b/entc/integration/ent/filetype.go
@@ -116,11 +116,11 @@ func (ft *FileType) Update() *FileTypeUpdateOne {
 // Unwrap unwraps the FileType entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (ft *FileType) Unwrap() *FileType {
-	tx, ok := ft.config.driver.(*txDriver)
+	_tx, ok := ft.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: FileType is not a transactional entity")
 	}
-	ft.config.driver = tx.drv
+	ft.config.driver = _tx.drv
 	return ft
 }
 

--- a/entc/integration/ent/goods.go
+++ b/entc/integration/ent/goods.go
@@ -64,11 +64,11 @@ func (_go *Goods) Update() *GoodsUpdateOne {
 // Unwrap unwraps the Goods entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (_go *Goods) Unwrap() *Goods {
-	tx, ok := _go.config.driver.(*txDriver)
+	_tx, ok := _go.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Goods is not a transactional entity")
 	}
-	_go.config.driver = tx.drv
+	_go.config.driver = _tx.drv
 	return _go
 }
 

--- a/entc/integration/ent/group.go
+++ b/entc/integration/ent/group.go
@@ -203,11 +203,11 @@ func (gr *Group) Update() *GroupUpdateOne {
 // Unwrap unwraps the Group entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (gr *Group) Unwrap() *Group {
-	tx, ok := gr.config.driver.(*txDriver)
+	_tx, ok := gr.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Group is not a transactional entity")
 	}
-	gr.config.driver = tx.drv
+	gr.config.driver = _tx.drv
 	return gr
 }
 

--- a/entc/integration/ent/groupinfo.go
+++ b/entc/integration/ent/groupinfo.go
@@ -108,11 +108,11 @@ func (gi *GroupInfo) Update() *GroupInfoUpdateOne {
 // Unwrap unwraps the GroupInfo entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (gi *GroupInfo) Unwrap() *GroupInfo {
-	tx, ok := gi.config.driver.(*txDriver)
+	_tx, ok := gi.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: GroupInfo is not a transactional entity")
 	}
-	gi.config.driver = tx.drv
+	gi.config.driver = _tx.drv
 	return gi
 }
 

--- a/entc/integration/ent/item.go
+++ b/entc/integration/ent/item.go
@@ -72,11 +72,11 @@ func (i *Item) Update() *ItemUpdateOne {
 // Unwrap unwraps the Item entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (i *Item) Unwrap() *Item {
-	tx, ok := i.config.driver.(*txDriver)
+	_tx, ok := i.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Item is not a transactional entity")
 	}
-	i.config.driver = tx.drv
+	i.config.driver = _tx.drv
 	return i
 }
 

--- a/entc/integration/ent/node.go
+++ b/entc/integration/ent/node.go
@@ -134,11 +134,11 @@ func (n *Node) Update() *NodeUpdateOne {
 // Unwrap unwraps the Node entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (n *Node) Unwrap() *Node {
-	tx, ok := n.config.driver.(*txDriver)
+	_tx, ok := n.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Node is not a transactional entity")
 	}
-	n.config.driver = tx.drv
+	n.config.driver = _tx.drv
 	return n
 }
 

--- a/entc/integration/ent/pet.go
+++ b/entc/integration/ent/pet.go
@@ -176,11 +176,11 @@ func (pe *Pet) Update() *PetUpdateOne {
 // Unwrap unwraps the Pet entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (pe *Pet) Unwrap() *Pet {
-	tx, ok := pe.config.driver.(*txDriver)
+	_tx, ok := pe.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Pet is not a transactional entity")
 	}
-	pe.config.driver = tx.drv
+	pe.config.driver = _tx.drv
 	return pe
 }
 

--- a/entc/integration/ent/spec.go
+++ b/entc/integration/ent/spec.go
@@ -90,11 +90,11 @@ func (s *Spec) Update() *SpecUpdateOne {
 // Unwrap unwraps the Spec entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (s *Spec) Unwrap() *Spec {
-	tx, ok := s.config.driver.(*txDriver)
+	_tx, ok := s.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Spec is not a transactional entity")
 	}
-	s.config.driver = tx.drv
+	s.config.driver = _tx.drv
 	return s
 }
 

--- a/entc/integration/ent/task.go
+++ b/entc/integration/ent/task.go
@@ -74,11 +74,11 @@ func (t *Task) Update() *TaskUpdateOne {
 // Unwrap unwraps the Task entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (t *Task) Unwrap() *Task {
-	tx, ok := t.config.driver.(*txDriver)
+	_tx, ok := t.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Task is not a transactional entity")
 	}
-	t.config.driver = tx.drv
+	t.config.driver = _tx.drv
 	return t
 }
 

--- a/entc/integration/ent/user.go
+++ b/entc/integration/ent/user.go
@@ -392,11 +392,11 @@ func (u *User) Update() *UserUpdateOne {
 // Unwrap unwraps the User entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (u *User) Unwrap() *User {
-	tx, ok := u.config.driver.(*txDriver)
+	_tx, ok := u.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: User is not a transactional entity")
 	}
-	u.config.driver = tx.drv
+	u.config.driver = _tx.drv
 	return u
 }
 

--- a/entc/integration/gremlin/ent/card.go
+++ b/entc/integration/gremlin/ent/card.go
@@ -118,11 +118,11 @@ func (c *Card) Update() *CardUpdateOne {
 // Unwrap unwraps the Card entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (c *Card) Unwrap() *Card {
-	tx, ok := c.config.driver.(*txDriver)
+	_tx, ok := c.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Card is not a transactional entity")
 	}
-	c.config.driver = tx.drv
+	c.config.driver = _tx.drv
 	return c
 }
 

--- a/entc/integration/gremlin/ent/comment.go
+++ b/entc/integration/gremlin/ent/comment.go
@@ -62,11 +62,11 @@ func (c *Comment) Update() *CommentUpdateOne {
 // Unwrap unwraps the Comment entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (c *Comment) Unwrap() *Comment {
-	tx, ok := c.config.driver.(*txDriver)
+	_tx, ok := c.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Comment is not a transactional entity")
 	}
-	c.config.driver = tx.drv
+	c.config.driver = _tx.drv
 	return c
 }
 

--- a/entc/integration/gremlin/ent/fieldtype.go
+++ b/entc/integration/gremlin/ent/fieldtype.go
@@ -314,11 +314,11 @@ func (ft *FieldType) Update() *FieldTypeUpdateOne {
 // Unwrap unwraps the FieldType entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (ft *FieldType) Unwrap() *FieldType {
-	tx, ok := ft.config.driver.(*txDriver)
+	_tx, ok := ft.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: FieldType is not a transactional entity")
 	}
-	ft.config.driver = tx.drv
+	ft.config.driver = _tx.drv
 	return ft
 }
 

--- a/entc/integration/gremlin/ent/file.go
+++ b/entc/integration/gremlin/ent/file.go
@@ -136,11 +136,11 @@ func (f *File) Update() *FileUpdateOne {
 // Unwrap unwraps the File entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (f *File) Unwrap() *File {
-	tx, ok := f.config.driver.(*txDriver)
+	_tx, ok := f.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: File is not a transactional entity")
 	}
-	f.config.driver = tx.drv
+	f.config.driver = _tx.drv
 	return f
 }
 

--- a/entc/integration/gremlin/ent/filetype.go
+++ b/entc/integration/gremlin/ent/filetype.go
@@ -85,11 +85,11 @@ func (ft *FileType) Update() *FileTypeUpdateOne {
 // Unwrap unwraps the FileType entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (ft *FileType) Unwrap() *FileType {
-	tx, ok := ft.config.driver.(*txDriver)
+	_tx, ok := ft.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: FileType is not a transactional entity")
 	}
-	ft.config.driver = tx.drv
+	ft.config.driver = _tx.drv
 	return ft
 }
 

--- a/entc/integration/gremlin/ent/goods.go
+++ b/entc/integration/gremlin/ent/goods.go
@@ -46,11 +46,11 @@ func (_go *Goods) Update() *GoodsUpdateOne {
 // Unwrap unwraps the Goods entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (_go *Goods) Unwrap() *Goods {
-	tx, ok := _go.config.driver.(*txDriver)
+	_tx, ok := _go.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Goods is not a transactional entity")
 	}
-	_go.config.driver = tx.drv
+	_go.config.driver = _tx.drv
 	return _go
 }
 

--- a/entc/integration/gremlin/ent/group.go
+++ b/entc/integration/gremlin/ent/group.go
@@ -148,11 +148,11 @@ func (gr *Group) Update() *GroupUpdateOne {
 // Unwrap unwraps the Group entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (gr *Group) Unwrap() *Group {
-	tx, ok := gr.config.driver.(*txDriver)
+	_tx, ok := gr.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Group is not a transactional entity")
 	}
-	gr.config.driver = tx.drv
+	gr.config.driver = _tx.drv
 	return gr
 }
 

--- a/entc/integration/gremlin/ent/groupinfo.go
+++ b/entc/integration/gremlin/ent/groupinfo.go
@@ -80,11 +80,11 @@ func (gi *GroupInfo) Update() *GroupInfoUpdateOne {
 // Unwrap unwraps the GroupInfo entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (gi *GroupInfo) Unwrap() *GroupInfo {
-	tx, ok := gi.config.driver.(*txDriver)
+	_tx, ok := gi.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: GroupInfo is not a transactional entity")
 	}
-	gi.config.driver = tx.drv
+	gi.config.driver = _tx.drv
 	return gi
 }
 

--- a/entc/integration/gremlin/ent/item.go
+++ b/entc/integration/gremlin/ent/item.go
@@ -50,11 +50,11 @@ func (i *Item) Update() *ItemUpdateOne {
 // Unwrap unwraps the Item entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (i *Item) Unwrap() *Item {
-	tx, ok := i.config.driver.(*txDriver)
+	_tx, ok := i.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Item is not a transactional entity")
 	}
-	i.config.driver = tx.drv
+	i.config.driver = _tx.drv
 	return i
 }
 

--- a/entc/integration/gremlin/ent/node.go
+++ b/entc/integration/gremlin/ent/node.go
@@ -103,11 +103,11 @@ func (n *Node) Update() *NodeUpdateOne {
 // Unwrap unwraps the Node entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (n *Node) Unwrap() *Node {
-	tx, ok := n.config.driver.(*txDriver)
+	_tx, ok := n.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Node is not a transactional entity")
 	}
-	n.config.driver = tx.drv
+	n.config.driver = _tx.drv
 	return n
 }
 

--- a/entc/integration/gremlin/ent/pet.go
+++ b/entc/integration/gremlin/ent/pet.go
@@ -116,11 +116,11 @@ func (pe *Pet) Update() *PetUpdateOne {
 // Unwrap unwraps the Pet entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (pe *Pet) Unwrap() *Pet {
-	tx, ok := pe.config.driver.(*txDriver)
+	_tx, ok := pe.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Pet is not a transactional entity")
 	}
-	pe.config.driver = tx.drv
+	pe.config.driver = _tx.drv
 	return pe
 }
 

--- a/entc/integration/gremlin/ent/spec.go
+++ b/entc/integration/gremlin/ent/spec.go
@@ -72,11 +72,11 @@ func (s *Spec) Update() *SpecUpdateOne {
 // Unwrap unwraps the Spec entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (s *Spec) Unwrap() *Spec {
-	tx, ok := s.config.driver.(*txDriver)
+	_tx, ok := s.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Spec is not a transactional entity")
 	}
-	s.config.driver = tx.drv
+	s.config.driver = _tx.drv
 	return s
 }
 

--- a/entc/integration/gremlin/ent/task.go
+++ b/entc/integration/gremlin/ent/task.go
@@ -51,11 +51,11 @@ func (t *Task) Update() *TaskUpdateOne {
 // Unwrap unwraps the Task entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (t *Task) Unwrap() *Task {
-	tx, ok := t.config.driver.(*txDriver)
+	_tx, ok := t.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Task is not a transactional entity")
 	}
-	t.config.driver = tx.drv
+	t.config.driver = _tx.drv
 	return t
 }
 

--- a/entc/integration/gremlin/ent/user.go
+++ b/entc/integration/gremlin/ent/user.go
@@ -299,11 +299,11 @@ func (u *User) Update() *UserUpdateOne {
 // Unwrap unwraps the User entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (u *User) Unwrap() *User {
-	tx, ok := u.config.driver.(*txDriver)
+	_tx, ok := u.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: User is not a transactional entity")
 	}
-	u.config.driver = tx.drv
+	u.config.driver = _tx.drv
 	return u
 }
 

--- a/entc/integration/hooks/ent/card.go
+++ b/entc/integration/hooks/ent/card.go
@@ -145,11 +145,11 @@ func (c *Card) Update() *CardUpdateOne {
 // Unwrap unwraps the Card entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (c *Card) Unwrap() *Card {
-	tx, ok := c.config.driver.(*txDriver)
+	_tx, ok := c.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Card is not a transactional entity")
 	}
-	c.config.driver = tx.drv
+	c.config.driver = _tx.drv
 	return c
 }
 

--- a/entc/integration/hooks/ent/user.go
+++ b/entc/integration/hooks/ent/user.go
@@ -171,11 +171,11 @@ func (u *User) Update() *UserUpdateOne {
 // Unwrap unwraps the User entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (u *User) Unwrap() *User {
-	tx, ok := u.config.driver.(*txDriver)
+	_tx, ok := u.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: User is not a transactional entity")
 	}
-	u.config.driver = tx.drv
+	u.config.driver = _tx.drv
 	return u
 }
 

--- a/entc/integration/idtype/ent/user.go
+++ b/entc/integration/idtype/ent/user.go
@@ -147,11 +147,11 @@ func (u *User) Update() *UserUpdateOne {
 // Unwrap unwraps the User entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (u *User) Unwrap() *User {
-	tx, ok := u.config.driver.(*txDriver)
+	_tx, ok := u.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: User is not a transactional entity")
 	}
-	u.config.driver = tx.drv
+	u.config.driver = _tx.drv
 	return u
 }
 

--- a/entc/integration/json/ent/user.go
+++ b/entc/integration/json/ent/user.go
@@ -150,11 +150,11 @@ func (u *User) Update() *UserUpdateOne {
 // Unwrap unwraps the User entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (u *User) Unwrap() *User {
-	tx, ok := u.config.driver.(*txDriver)
+	_tx, ok := u.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: User is not a transactional entity")
 	}
-	u.config.driver = tx.drv
+	u.config.driver = _tx.drv
 	return u
 }
 

--- a/entc/integration/migrate/entv1/car.go
+++ b/entc/integration/migrate/entv1/car.go
@@ -106,11 +106,11 @@ func (c *Car) Update() *CarUpdateOne {
 // Unwrap unwraps the Car entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (c *Car) Unwrap() *Car {
-	tx, ok := c.config.driver.(*txDriver)
+	_tx, ok := c.config.driver.(*txDriver)
 	if !ok {
 		panic("entv1: Car is not a transactional entity")
 	}
-	c.config.driver = tx.drv
+	c.config.driver = _tx.drv
 	return c
 }
 

--- a/entc/integration/migrate/entv1/conversion.go
+++ b/entc/integration/migrate/entv1/conversion.go
@@ -138,11 +138,11 @@ func (c *Conversion) Update() *ConversionUpdateOne {
 // Unwrap unwraps the Conversion entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (c *Conversion) Unwrap() *Conversion {
-	tx, ok := c.config.driver.(*txDriver)
+	_tx, ok := c.config.driver.(*txDriver)
 	if !ok {
 		panic("entv1: Conversion is not a transactional entity")
 	}
-	c.config.driver = tx.drv
+	c.config.driver = _tx.drv
 	return c
 }
 

--- a/entc/integration/migrate/entv1/customtype.go
+++ b/entc/integration/migrate/entv1/customtype.go
@@ -74,11 +74,11 @@ func (ct *CustomType) Update() *CustomTypeUpdateOne {
 // Unwrap unwraps the CustomType entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (ct *CustomType) Unwrap() *CustomType {
-	tx, ok := ct.config.driver.(*txDriver)
+	_tx, ok := ct.config.driver.(*txDriver)
 	if !ok {
 		panic("entv1: CustomType is not a transactional entity")
 	}
-	ct.config.driver = tx.drv
+	ct.config.driver = _tx.drv
 	return ct
 }
 

--- a/entc/integration/migrate/entv1/user.go
+++ b/entc/integration/migrate/entv1/user.go
@@ -274,11 +274,11 @@ func (u *User) Update() *UserUpdateOne {
 // Unwrap unwraps the User entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (u *User) Unwrap() *User {
-	tx, ok := u.config.driver.(*txDriver)
+	_tx, ok := u.config.driver.(*txDriver)
 	if !ok {
 		panic("entv1: User is not a transactional entity")
 	}
-	u.config.driver = tx.drv
+	u.config.driver = _tx.drv
 	return u
 }
 

--- a/entc/integration/migrate/entv2/car.go
+++ b/entc/integration/migrate/entv2/car.go
@@ -116,11 +116,11 @@ func (c *Car) Update() *CarUpdateOne {
 // Unwrap unwraps the Car entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (c *Car) Unwrap() *Car {
-	tx, ok := c.config.driver.(*txDriver)
+	_tx, ok := c.config.driver.(*txDriver)
 	if !ok {
 		panic("entv2: Car is not a transactional entity")
 	}
-	c.config.driver = tx.drv
+	c.config.driver = _tx.drv
 	return c
 }
 

--- a/entc/integration/migrate/entv2/conversion.go
+++ b/entc/integration/migrate/entv2/conversion.go
@@ -138,11 +138,11 @@ func (c *Conversion) Update() *ConversionUpdateOne {
 // Unwrap unwraps the Conversion entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (c *Conversion) Unwrap() *Conversion {
-	tx, ok := c.config.driver.(*txDriver)
+	_tx, ok := c.config.driver.(*txDriver)
 	if !ok {
 		panic("entv2: Conversion is not a transactional entity")
 	}
-	c.config.driver = tx.drv
+	c.config.driver = _tx.drv
 	return c
 }
 

--- a/entc/integration/migrate/entv2/customtype.go
+++ b/entc/integration/migrate/entv2/customtype.go
@@ -93,11 +93,11 @@ func (ct *CustomType) Update() *CustomTypeUpdateOne {
 // Unwrap unwraps the CustomType entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (ct *CustomType) Unwrap() *CustomType {
-	tx, ok := ct.config.driver.(*txDriver)
+	_tx, ok := ct.config.driver.(*txDriver)
 	if !ok {
 		panic("entv2: CustomType is not a transactional entity")
 	}
-	ct.config.driver = tx.drv
+	ct.config.driver = _tx.drv
 	return ct
 }
 

--- a/entc/integration/migrate/entv2/group.go
+++ b/entc/integration/migrate/entv2/group.go
@@ -64,11 +64,11 @@ func (gr *Group) Update() *GroupUpdateOne {
 // Unwrap unwraps the Group entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (gr *Group) Unwrap() *Group {
-	tx, ok := gr.config.driver.(*txDriver)
+	_tx, ok := gr.config.driver.(*txDriver)
 	if !ok {
 		panic("entv2: Group is not a transactional entity")
 	}
-	gr.config.driver = tx.drv
+	gr.config.driver = _tx.drv
 	return gr
 }
 

--- a/entc/integration/migrate/entv2/media.go
+++ b/entc/integration/migrate/entv2/media.go
@@ -90,11 +90,11 @@ func (m *Media) Update() *MediaUpdateOne {
 // Unwrap unwraps the Media entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (m *Media) Unwrap() *Media {
-	tx, ok := m.config.driver.(*txDriver)
+	_tx, ok := m.config.driver.(*txDriver)
 	if !ok {
 		panic("entv2: Media is not a transactional entity")
 	}
-	m.config.driver = tx.drv
+	m.config.driver = _tx.drv
 	return m
 }
 

--- a/entc/integration/migrate/entv2/pet.go
+++ b/entc/integration/migrate/entv2/pet.go
@@ -116,11 +116,11 @@ func (pe *Pet) Update() *PetUpdateOne {
 // Unwrap unwraps the Pet entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (pe *Pet) Unwrap() *Pet {
-	tx, ok := pe.config.driver.(*txDriver)
+	_tx, ok := pe.config.driver.(*txDriver)
 	if !ok {
 		panic("entv2: Pet is not a transactional entity")
 	}
-	pe.config.driver = tx.drv
+	pe.config.driver = _tx.drv
 	return pe
 }
 

--- a/entc/integration/migrate/entv2/user.go
+++ b/entc/integration/migrate/entv2/user.go
@@ -271,11 +271,11 @@ func (u *User) Update() *UserUpdateOne {
 // Unwrap unwraps the User entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (u *User) Unwrap() *User {
-	tx, ok := u.config.driver.(*txDriver)
+	_tx, ok := u.config.driver.(*txDriver)
 	if !ok {
 		panic("entv2: User is not a transactional entity")
 	}
-	u.config.driver = tx.drv
+	u.config.driver = _tx.drv
 	return u
 }
 

--- a/entc/integration/migrate/versioned/user.go
+++ b/entc/integration/migrate/versioned/user.go
@@ -98,11 +98,11 @@ func (u *User) Update() *UserUpdateOne {
 // Unwrap unwraps the User entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (u *User) Unwrap() *User {
-	tx, ok := u.config.driver.(*txDriver)
+	_tx, ok := u.config.driver.(*txDriver)
 	if !ok {
 		panic("versioned: User is not a transactional entity")
 	}
-	u.config.driver = tx.drv
+	u.config.driver = _tx.drv
 	return u
 }
 

--- a/entc/integration/multischema/ent/group.go
+++ b/entc/integration/multischema/ent/group.go
@@ -100,11 +100,11 @@ func (gr *Group) Update() *GroupUpdateOne {
 // Unwrap unwraps the Group entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (gr *Group) Unwrap() *Group {
-	tx, ok := gr.config.driver.(*txDriver)
+	_tx, ok := gr.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Group is not a transactional entity")
 	}
-	gr.config.driver = tx.drv
+	gr.config.driver = _tx.drv
 	return gr
 }
 

--- a/entc/integration/multischema/ent/pet.go
+++ b/entc/integration/multischema/ent/pet.go
@@ -114,11 +114,11 @@ func (pe *Pet) Update() *PetUpdateOne {
 // Unwrap unwraps the Pet entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (pe *Pet) Unwrap() *Pet {
-	tx, ok := pe.config.driver.(*txDriver)
+	_tx, ok := pe.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Pet is not a transactional entity")
 	}
-	pe.config.driver = tx.drv
+	pe.config.driver = _tx.drv
 	return pe
 }
 

--- a/entc/integration/multischema/ent/user.go
+++ b/entc/integration/multischema/ent/user.go
@@ -116,11 +116,11 @@ func (u *User) Update() *UserUpdateOne {
 // Unwrap unwraps the User entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (u *User) Unwrap() *User {
-	tx, ok := u.config.driver.(*txDriver)
+	_tx, ok := u.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: User is not a transactional entity")
 	}
-	u.config.driver = tx.drv
+	u.config.driver = _tx.drv
 	return u
 }
 

--- a/entc/integration/privacy/ent/task.go
+++ b/entc/integration/privacy/ent/task.go
@@ -159,11 +159,11 @@ func (t *Task) Update() *TaskUpdateOne {
 // Unwrap unwraps the Task entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (t *Task) Unwrap() *Task {
-	tx, ok := t.config.driver.(*txDriver)
+	_tx, ok := t.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Task is not a transactional entity")
 	}
-	t.config.driver = tx.drv
+	t.config.driver = _tx.drv
 	return t
 }
 

--- a/entc/integration/privacy/ent/team.go
+++ b/entc/integration/privacy/ent/team.go
@@ -116,11 +116,11 @@ func (t *Team) Update() *TeamUpdateOne {
 // Unwrap unwraps the Team entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (t *Team) Unwrap() *Team {
-	tx, ok := t.config.driver.(*txDriver)
+	_tx, ok := t.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Team is not a transactional entity")
 	}
-	t.config.driver = tx.drv
+	t.config.driver = _tx.drv
 	return t
 }
 

--- a/entc/integration/privacy/ent/user.go
+++ b/entc/integration/privacy/ent/user.go
@@ -124,11 +124,11 @@ func (u *User) Update() *UserUpdateOne {
 // Unwrap unwraps the User entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (u *User) Unwrap() *User {
-	tx, ok := u.config.driver.(*txDriver)
+	_tx, ok := u.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: User is not a transactional entity")
 	}
-	u.config.driver = tx.drv
+	u.config.driver = _tx.drv
 	return u
 }
 

--- a/entc/integration/template/ent/group.go
+++ b/entc/integration/template/ent/group.go
@@ -72,11 +72,11 @@ func (gr *Group) Update() *GroupUpdateOne {
 // Unwrap unwraps the Group entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (gr *Group) Unwrap() *Group {
-	tx, ok := gr.config.driver.(*txDriver)
+	_tx, ok := gr.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Group is not a transactional entity")
 	}
-	gr.config.driver = tx.drv
+	gr.config.driver = _tx.drv
 	return gr
 }
 

--- a/entc/integration/template/ent/pet.go
+++ b/entc/integration/template/ent/pet.go
@@ -125,11 +125,11 @@ func (pe *Pet) Update() *PetUpdateOne {
 // Unwrap unwraps the Pet entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (pe *Pet) Unwrap() *Pet {
-	tx, ok := pe.config.driver.(*txDriver)
+	_tx, ok := pe.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Pet is not a transactional entity")
 	}
-	pe.config.driver = tx.drv
+	pe.config.driver = _tx.drv
 	return pe
 }
 

--- a/entc/integration/template/ent/user.go
+++ b/entc/integration/template/ent/user.go
@@ -116,11 +116,11 @@ func (u *User) Update() *UserUpdateOne {
 // Unwrap unwraps the User entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (u *User) Unwrap() *User {
-	tx, ok := u.config.driver.(*txDriver)
+	_tx, ok := u.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: User is not a transactional entity")
 	}
-	u.config.driver = tx.drv
+	u.config.driver = _tx.drv
 	return u
 }
 

--- a/examples/edgeindex/ent/city.go
+++ b/examples/edgeindex/ent/city.go
@@ -100,11 +100,11 @@ func (c *City) Update() *CityUpdateOne {
 // Unwrap unwraps the City entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (c *City) Unwrap() *City {
-	tx, ok := c.config.driver.(*txDriver)
+	_tx, ok := c.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: City is not a transactional entity")
 	}
-	c.config.driver = tx.drv
+	c.config.driver = _tx.drv
 	return c
 }
 

--- a/examples/edgeindex/ent/street.go
+++ b/examples/edgeindex/ent/street.go
@@ -116,11 +116,11 @@ func (s *Street) Update() *StreetUpdateOne {
 // Unwrap unwraps the Street entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (s *Street) Unwrap() *Street {
-	tx, ok := s.config.driver.(*txDriver)
+	_tx, ok := s.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Street is not a transactional entity")
 	}
-	s.config.driver = tx.drv
+	s.config.driver = _tx.drv
 	return s
 }
 

--- a/examples/entcpkg/ent/user.go
+++ b/examples/entcpkg/ent/user.go
@@ -85,11 +85,11 @@ func (u *User) Update() *UserUpdateOne {
 // Unwrap unwraps the User entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (u *User) Unwrap() *User {
-	tx, ok := u.config.driver.(*txDriver)
+	_tx, ok := u.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: User is not a transactional entity")
 	}
-	u.config.driver = tx.drv
+	u.config.driver = _tx.drv
 	return u
 }
 

--- a/examples/fs/ent/file.go
+++ b/examples/fs/ent/file.go
@@ -139,11 +139,11 @@ func (f *File) Update() *FileUpdateOne {
 // Unwrap unwraps the File entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (f *File) Unwrap() *File {
-	tx, ok := f.config.driver.(*txDriver)
+	_tx, ok := f.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: File is not a transactional entity")
 	}
-	f.config.driver = tx.drv
+	f.config.driver = _tx.drv
 	return f
 }
 

--- a/examples/m2m2types/ent/group.go
+++ b/examples/m2m2types/ent/group.go
@@ -100,11 +100,11 @@ func (gr *Group) Update() *GroupUpdateOne {
 // Unwrap unwraps the Group entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (gr *Group) Unwrap() *Group {
-	tx, ok := gr.config.driver.(*txDriver)
+	_tx, ok := gr.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Group is not a transactional entity")
 	}
-	gr.config.driver = tx.drv
+	gr.config.driver = _tx.drv
 	return gr
 }
 

--- a/examples/m2m2types/ent/user.go
+++ b/examples/m2m2types/ent/user.go
@@ -108,11 +108,11 @@ func (u *User) Update() *UserUpdateOne {
 // Unwrap unwraps the User entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (u *User) Unwrap() *User {
-	tx, ok := u.config.driver.(*txDriver)
+	_tx, ok := u.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: User is not a transactional entity")
 	}
-	u.config.driver = tx.drv
+	u.config.driver = _tx.drv
 	return u
 }
 

--- a/examples/m2mbidi/ent/user.go
+++ b/examples/m2mbidi/ent/user.go
@@ -108,11 +108,11 @@ func (u *User) Update() *UserUpdateOne {
 // Unwrap unwraps the User entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (u *User) Unwrap() *User {
-	tx, ok := u.config.driver.(*txDriver)
+	_tx, ok := u.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: User is not a transactional entity")
 	}
-	u.config.driver = tx.drv
+	u.config.driver = _tx.drv
 	return u
 }
 

--- a/examples/m2mrecur/ent/user.go
+++ b/examples/m2mrecur/ent/user.go
@@ -124,11 +124,11 @@ func (u *User) Update() *UserUpdateOne {
 // Unwrap unwraps the User entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (u *User) Unwrap() *User {
-	tx, ok := u.config.driver.(*txDriver)
+	_tx, ok := u.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: User is not a transactional entity")
 	}
-	u.config.driver = tx.drv
+	u.config.driver = _tx.drv
 	return u
 }
 

--- a/examples/o2m2types/ent/pet.go
+++ b/examples/o2m2types/ent/pet.go
@@ -116,11 +116,11 @@ func (pe *Pet) Update() *PetUpdateOne {
 // Unwrap unwraps the Pet entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (pe *Pet) Unwrap() *Pet {
-	tx, ok := pe.config.driver.(*txDriver)
+	_tx, ok := pe.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Pet is not a transactional entity")
 	}
-	pe.config.driver = tx.drv
+	pe.config.driver = _tx.drv
 	return pe
 }
 

--- a/examples/o2m2types/ent/user.go
+++ b/examples/o2m2types/ent/user.go
@@ -108,11 +108,11 @@ func (u *User) Update() *UserUpdateOne {
 // Unwrap unwraps the User entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (u *User) Unwrap() *User {
-	tx, ok := u.config.driver.(*txDriver)
+	_tx, ok := u.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: User is not a transactional entity")
 	}
-	u.config.driver = tx.drv
+	u.config.driver = _tx.drv
 	return u
 }
 

--- a/examples/o2mrecur/ent/node.go
+++ b/examples/o2mrecur/ent/node.go
@@ -129,11 +129,11 @@ func (n *Node) Update() *NodeUpdateOne {
 // Unwrap unwraps the Node entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (n *Node) Unwrap() *Node {
-	tx, ok := n.config.driver.(*txDriver)
+	_tx, ok := n.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Node is not a transactional entity")
 	}
-	n.config.driver = tx.drv
+	n.config.driver = _tx.drv
 	return n
 }
 

--- a/examples/o2o2types/ent/card.go
+++ b/examples/o2o2types/ent/card.go
@@ -127,11 +127,11 @@ func (c *Card) Update() *CardUpdateOne {
 // Unwrap unwraps the Card entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (c *Card) Unwrap() *Card {
-	tx, ok := c.config.driver.(*txDriver)
+	_tx, ok := c.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Card is not a transactional entity")
 	}
-	c.config.driver = tx.drv
+	c.config.driver = _tx.drv
 	return c
 }
 

--- a/examples/o2o2types/ent/user.go
+++ b/examples/o2o2types/ent/user.go
@@ -114,11 +114,11 @@ func (u *User) Update() *UserUpdateOne {
 // Unwrap unwraps the User entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (u *User) Unwrap() *User {
-	tx, ok := u.config.driver.(*txDriver)
+	_tx, ok := u.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: User is not a transactional entity")
 	}
-	u.config.driver = tx.drv
+	u.config.driver = _tx.drv
 	return u
 }
 

--- a/examples/o2obidi/ent/user.go
+++ b/examples/o2obidi/ent/user.go
@@ -123,11 +123,11 @@ func (u *User) Update() *UserUpdateOne {
 // Unwrap unwraps the User entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (u *User) Unwrap() *User {
-	tx, ok := u.config.driver.(*txDriver)
+	_tx, ok := u.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: User is not a transactional entity")
 	}
-	u.config.driver = tx.drv
+	u.config.driver = _tx.drv
 	return u
 }
 

--- a/examples/o2orecur/ent/node.go
+++ b/examples/o2orecur/ent/node.go
@@ -134,11 +134,11 @@ func (n *Node) Update() *NodeUpdateOne {
 // Unwrap unwraps the Node entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (n *Node) Unwrap() *Node {
-	tx, ok := n.config.driver.(*txDriver)
+	_tx, ok := n.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Node is not a transactional entity")
 	}
-	n.config.driver = tx.drv
+	n.config.driver = _tx.drv
 	return n
 }
 

--- a/examples/privacyadmin/ent/user.go
+++ b/examples/privacyadmin/ent/user.go
@@ -74,11 +74,11 @@ func (u *User) Update() *UserUpdateOne {
 // Unwrap unwraps the User entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (u *User) Unwrap() *User {
-	tx, ok := u.config.driver.(*txDriver)
+	_tx, ok := u.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: User is not a transactional entity")
 	}
-	u.config.driver = tx.drv
+	u.config.driver = _tx.drv
 	return u
 }
 

--- a/examples/privacytenant/ent/group.go
+++ b/examples/privacytenant/ent/group.go
@@ -132,11 +132,11 @@ func (gr *Group) Update() *GroupUpdateOne {
 // Unwrap unwraps the Group entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (gr *Group) Unwrap() *Group {
-	tx, ok := gr.config.driver.(*txDriver)
+	_tx, ok := gr.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Group is not a transactional entity")
 	}
-	gr.config.driver = tx.drv
+	gr.config.driver = _tx.drv
 	return gr
 }
 

--- a/examples/privacytenant/ent/tenant.go
+++ b/examples/privacytenant/ent/tenant.go
@@ -74,11 +74,11 @@ func (t *Tenant) Update() *TenantUpdateOne {
 // Unwrap unwraps the Tenant entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (t *Tenant) Unwrap() *Tenant {
-	tx, ok := t.config.driver.(*txDriver)
+	_tx, ok := t.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Tenant is not a transactional entity")
 	}
-	t.config.driver = tx.drv
+	t.config.driver = _tx.drv
 	return t
 }
 

--- a/examples/privacytenant/ent/user.go
+++ b/examples/privacytenant/ent/user.go
@@ -145,11 +145,11 @@ func (u *User) Update() *UserUpdateOne {
 // Unwrap unwraps the User entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (u *User) Unwrap() *User {
-	tx, ok := u.config.driver.(*txDriver)
+	_tx, ok := u.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: User is not a transactional entity")
 	}
-	u.config.driver = tx.drv
+	u.config.driver = _tx.drv
 	return u
 }
 

--- a/examples/start/ent/car.go
+++ b/examples/start/ent/car.go
@@ -127,11 +127,11 @@ func (c *Car) Update() *CarUpdateOne {
 // Unwrap unwraps the Car entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (c *Car) Unwrap() *Car {
-	tx, ok := c.config.driver.(*txDriver)
+	_tx, ok := c.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Car is not a transactional entity")
 	}
-	c.config.driver = tx.drv
+	c.config.driver = _tx.drv
 	return c
 }
 

--- a/examples/start/ent/group.go
+++ b/examples/start/ent/group.go
@@ -100,11 +100,11 @@ func (gr *Group) Update() *GroupUpdateOne {
 // Unwrap unwraps the Group entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (gr *Group) Unwrap() *Group {
-	tx, ok := gr.config.driver.(*txDriver)
+	_tx, ok := gr.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Group is not a transactional entity")
 	}
-	gr.config.driver = tx.drv
+	gr.config.driver = _tx.drv
 	return gr
 }
 

--- a/examples/start/ent/user.go
+++ b/examples/start/ent/user.go
@@ -124,11 +124,11 @@ func (u *User) Update() *UserUpdateOne {
 // Unwrap unwraps the User entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (u *User) Unwrap() *User {
-	tx, ok := u.config.driver.(*txDriver)
+	_tx, ok := u.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: User is not a transactional entity")
 	}
-	u.config.driver = tx.drv
+	u.config.driver = _tx.drv
 	return u
 }
 

--- a/examples/traversal/ent/group.go
+++ b/examples/traversal/ent/group.go
@@ -132,11 +132,11 @@ func (gr *Group) Update() *GroupUpdateOne {
 // Unwrap unwraps the Group entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (gr *Group) Unwrap() *Group {
-	tx, ok := gr.config.driver.(*txDriver)
+	_tx, ok := gr.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Group is not a transactional entity")
 	}
-	gr.config.driver = tx.drv
+	gr.config.driver = _tx.drv
 	return gr
 }
 

--- a/examples/traversal/ent/pet.go
+++ b/examples/traversal/ent/pet.go
@@ -132,11 +132,11 @@ func (pe *Pet) Update() *PetUpdateOne {
 // Unwrap unwraps the Pet entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (pe *Pet) Unwrap() *Pet {
-	tx, ok := pe.config.driver.(*txDriver)
+	_tx, ok := pe.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: Pet is not a transactional entity")
 	}
-	pe.config.driver = tx.drv
+	pe.config.driver = _tx.drv
 	return pe
 }
 

--- a/examples/traversal/ent/user.go
+++ b/examples/traversal/ent/user.go
@@ -156,11 +156,11 @@ func (u *User) Update() *UserUpdateOne {
 // Unwrap unwraps the User entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (u *User) Unwrap() *User {
-	tx, ok := u.config.driver.(*txDriver)
+	_tx, ok := u.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: User is not a transactional entity")
 	}
-	u.config.driver = tx.drv
+	u.config.driver = _tx.drv
 	return u
 }
 

--- a/examples/version/ent/user.go
+++ b/examples/version/ent/user.go
@@ -83,11 +83,11 @@ func (u *User) Update() *UserUpdateOne {
 // Unwrap unwraps the User entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (u *User) Unwrap() *User {
-	tx, ok := u.config.driver.(*txDriver)
+	_tx, ok := u.config.driver.(*txDriver)
 	if !ok {
 		panic("ent: User is not a transactional entity")
 	}
-	u.config.driver = tx.drv
+	u.config.driver = _tx.drv
 	return u
 }
 


### PR DESCRIPTION
When creating an Entity with initials "TX", e.g. TumorXrays,

the code generated by entc cannot compile, because of a name clash in the generated transaction (**tx**) ```Unwrap()``` function:

```go
func (tx *TumorXrays) Unwrap() *TumorXrays {
	tx, ok := tx.config.driver.(*txDriver)
	...
```