### PR TITLE
dialect/sql/schema: file based type store

### DIFF
--- a/dialect/sql/schema/atlas.go
+++ b/dialect/sql/schema/atlas.go
@@ -273,7 +273,7 @@ func WithSumFile() MigrateOption {
 	}
 }
 
-// WithDeterministicGlobalUniqueID instructs atlas to use a file based type store when
+// WithUniversalID instructs atlas to use a file based type store when
 // global unique ids are enabled. For more information see the setupAtlas method on Migrate.
 //
 // ATTENTION:
@@ -281,7 +281,7 @@ func WithSumFile() MigrateOption {
 // dynamically when computing the diff between a deployed database and the current schema. In cases where there
 // exist multiple deployments, the allocated ranges for the same type might be different from each other,
 // depending on when the deployment took part.
-func WithDeterministicGlobalUniqueID() MigrateOption {
+func WithUniversalID() MigrateOption {
 	return func(m *Migrate) {
 		m.universalID = true
 		m.atlas.typeStoreConsent = true
@@ -315,7 +315,7 @@ type (
 	}
 )
 
-var errConsent = errors.New("sql/schema: use WithDeterministicGlobalUniqueID() instead of WithGlobalUniqueID(true) and WithDir(): ") // TODO(masseelch): add link to docs here
+var errConsent = errors.New("sql/schema: use WithUniversalID() instead of WithGlobalUniqueID(true) when using WithDir(): https://entgo.io/docs/migrate#universal-ids")
 
 func (m *Migrate) setupAtlas() error {
 	// Using one of the Atlas options, opt-in to Atlas migration.
@@ -351,7 +351,7 @@ func (m *Migrate) setupAtlas() error {
 		// If global unique ids and a migration directory is given, enable the file based type store for pk ranges.
 		m.typeStore = &dirTypeStore{dir: m.atlas.dir}
 		// To guard the user against a possible bug due to backward incompatibility, the file based type store must
-		// be enabled by an option. For more information see the comment of WithDeterministicGlobalUniqueID function.
+		// be enabled by an option. For more information see the comment of WithUniversalID function.
 		if !m.atlas.typeStoreConsent {
 			return errConsent
 		}

--- a/dialect/sql/schema/atlas.go
+++ b/dialect/sql/schema/atlas.go
@@ -652,7 +652,6 @@ const entTypes = ".ent_types"
 // This behaviour is enabled automatically when using versioned migrations.
 type dirTypeStore struct {
 	dir migrate.Dir
-	// newTypes []string // store types added in this run
 }
 
 // load the types from the types file.

--- a/dialect/sql/schema/atlas.go
+++ b/dialect/sql/schema/atlas.go
@@ -7,8 +7,10 @@ package schema
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"sort"
 	"strings"
 
@@ -271,16 +273,32 @@ func WithSumFile() MigrateOption {
 	}
 }
 
+// WithDeterministicGlobalUniqueID instructs atlas to use a file based type store when
+// global unique ids are enabled. For more information see the setupAtlas method on Migrate.
+//
+// ATTENTION:
+// The file based PK range store is not backward compatible, since the allocated ranges were computed
+// dynamically when computing the diff between a deployed database and the current schema. In cases where there
+// exist multiple deployments, the allocated ranges for the same type might be different from each other,
+// depending on when the deployment took part.
+func WithDeterministicGlobalUniqueID() MigrateOption {
+	return func(m *Migrate) {
+		m.universalID = true
+		m.atlas.typeStoreConsent = true
+	}
+}
+
 type (
 	// atlasOptions describes the options for atlas.
 	atlasOptions struct {
-		enabled bool
-		diff    []DiffHook
-		apply   []ApplyHook
-		skip    ChangeKind
-		dir     migrate.Dir
-		fmt     migrate.Formatter
-		genSum  bool
+		enabled          bool
+		diff             []DiffHook
+		apply            []ApplyHook
+		skip             ChangeKind
+		dir              migrate.Dir
+		fmt              migrate.Formatter
+		genSum           bool
+		typeStoreConsent bool
 	}
 
 	// atBuilder must be implemented by the different drivers in
@@ -293,8 +311,11 @@ type (
 		atIncrementC(*schema.Table, *schema.Column)
 		atIncrementT(*schema.Table, int64)
 		atIndex(*Index, *schema.Table, *schema.Index) error
+		atTypeRangeSQL(t ...string) string
 	}
 )
+
+var errConsent = errors.New("sql/schema: use WithDeterministicGlobalUniqueID() instead of WithGlobalUniqueID(true) and WithDir(): ") // TODO(masseelch): add link to docs here
 
 func (m *Migrate) setupAtlas() error {
 	// Using one of the Atlas options, opt-in to Atlas migration.
@@ -325,6 +346,16 @@ func (m *Migrate) setupAtlas() error {
 	}
 	if m.atlas.dir != nil && m.atlas.fmt == nil {
 		m.atlas.fmt = sqltool.GolangMigrateFormatter
+	}
+	if m.universalID && m.atlas.dir != nil {
+		// If global unique ids and a migration directory is given, enable the file based type store for pk ranges.
+		m.typeStore = &dirTypeStore{dir: m.atlas.dir}
+		// To guard the user against a possible bug due to backward incompatibility, the file based type store must
+		// be enabled by an option. For more information see the comment of WithDeterministicGlobalUniqueID function.
+		if !m.atlas.typeStoreConsent {
+			return errConsent
+		}
+		m.atlas.diff = append(m.atlas.diff, m.ensureTypeTable)
 	}
 	return nil
 }
@@ -537,6 +568,46 @@ func (m *Migrate) aIndexes(b atBuilder, t1 *Table, t2 *schema.Table) error {
 	return nil
 }
 
+func (m *Migrate) ensureTypeTable(next Differ) Differ {
+	return DiffFunc(func(current, desired *schema.Schema) ([]schema.Change, error) {
+		// If there is a types table but no types file yet, the user most likely
+		// switched from online migration to migration files.
+		if len(m.dbTypeRanges) == 0 {
+			var (
+				at = schema.NewTable(TypeTable)
+				et = NewTable(TypeTable).
+					AddPrimary(&Column{Name: "id", Type: field.TypeUint, Increment: true}).
+					AddColumn(&Column{Name: "type", Type: field.TypeString, Unique: true})
+			)
+			m.atTable(et, at)
+			if err := m.aColumns(m, et, at); err != nil {
+				return nil, err
+			}
+			desired.Tables = append(desired.Tables, at)
+		}
+		changes, err := next.Diff(current, desired)
+		if err != nil {
+			return nil, err
+		}
+		if len(m.dbTypeRanges) > 0 && len(m.fileTypeRanges) == 0 {
+			// Check if all types added by the diff process are present in the "old" types table.
+			for _, t := range m.typeRanges {
+				if indexOf(m.dbTypeRanges, t) < 0 {
+					return nil, fmt.Errorf("unexpected missing type range for %q", t)
+				}
+			}
+			// Override the types file created in the diff process with the "old" allocated types ranges.
+			if err := m.typeStore.(*dirTypeStore).save(m.dbTypeRanges); err != nil {
+				return nil, err
+			}
+			// Change the type range allocations since they will be added to the migration files when
+			// writing the migration plan to migration files.
+			m.typeRanges = m.dbTypeRanges
+		}
+		return changes, nil
+	})
+}
+
 func setAtChecks(t1 *Table, t2 *schema.Table) {
 	if check := t1.Annotation.Check; check != "" {
 		t2.AddChecks(&schema.Check{
@@ -574,3 +645,52 @@ func descIndexes(idx *Index) map[string]bool {
 	}
 	return descs
 }
+
+const entTypes = ".ent_types"
+
+// dirTypeStore stores and read pk information from a text file stored alongside generated versioned migrations.
+// This behaviour is enabled automatically when using versioned migrations.
+type dirTypeStore struct {
+	dir migrate.Dir
+	// newTypes []string // store types added in this run
+}
+
+// load the types from the types file.
+func (s *dirTypeStore) load(context.Context, dialect.ExecQuerier) ([]string, error) {
+	f, err := s.dir.Open(entTypes)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return nil, fmt.Errorf("reading types file: %w", err)
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+	var ts []string
+	if err := json.NewDecoder(f).Decode(&ts); err != nil {
+		return nil, fmt.Errorf("decoding types: %w", err)
+	}
+	return ts, nil
+}
+
+// add a new type entry to the types file.
+func (s *dirTypeStore) add(ctx context.Context, conn dialect.ExecQuerier, t string) error {
+	ts, err := s.load(ctx, conn)
+	if err != nil {
+		return fmt.Errorf("adding type %q: %w", t, err)
+	}
+	return s.save(append(ts, t))
+}
+
+// save takes the given allocation range and writes them to the types file.
+// The types file will be overridden.
+func (s *dirTypeStore) save(ts []string) error {
+	b, err := json.Marshal(ts)
+	if err != nil {
+		return fmt.Errorf("encoding types: %w", err)
+	}
+	if err := s.dir.WriteFile(entTypes, b); err != nil {
+		return fmt.Errorf("writing types file: %w", err)
+	}
+	return nil
+}
+
+var _ typeStore = (*dirTypeStore)(nil)

--- a/dialect/sql/schema/atlas.go
+++ b/dialect/sql/schema/atlas.go
@@ -583,6 +583,9 @@ func (m *Migrate) ensureTypeTable(next Differ) Differ {
 			if err := m.aColumns(m, et, at); err != nil {
 				return nil, err
 			}
+			if err := m.aIndexes(m, et, at); err != nil {
+				return nil, err
+			}
 			desired.Tables = append(desired.Tables, at)
 		}
 		changes, err := next.Diff(current, desired)
@@ -590,12 +593,6 @@ func (m *Migrate) ensureTypeTable(next Differ) Differ {
 			return nil, err
 		}
 		if len(m.dbTypeRanges) > 0 && len(m.fileTypeRanges) == 0 {
-			// Check if all types added by the diff process are present in the "old" types table.
-			for _, t := range m.typeRanges {
-				if indexOf(m.dbTypeRanges, t) < 0 {
-					return nil, fmt.Errorf("unexpected missing type range for %q", t)
-				}
-			}
 			// Override the types file created in the diff process with the "old" allocated types ranges.
 			if err := m.typeStore.(*dirTypeStore).save(m.dbTypeRanges); err != nil {
 				return nil, err

--- a/dialect/sql/schema/atlas_test.go
+++ b/dialect/sql/schema/atlas_test.go
@@ -1,0 +1,33 @@
+// Copyright 2019-present Facebook Inc. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
+package schema
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"ariga.io/atlas/sql/migrate"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDirTypeStore(t *testing.T) {
+	ex := []string{"a", "b", "c"}
+	p := t.TempDir()
+	d, err := migrate.NewLocalDir(p)
+	require.NoError(t, err)
+
+	s := &dirTypeStore{d}
+	require.NoError(t, s.save(ex))
+	require.FileExists(t, filepath.Join(p, entTypes))
+	c, err := os.ReadFile(filepath.Join(p, entTypes))
+	require.NoError(t, err)
+	require.Contains(t, string(c), atlasDirective)
+
+	ac, err := s.load(context.Background(), nil)
+	require.NoError(t, err)
+	require.Equal(t, ex, ac)
+}

--- a/dialect/sql/schema/migrate.go
+++ b/dialect/sql/schema/migrate.go
@@ -197,11 +197,11 @@ func (m *Migrate) NamedDiff(ctx context.Context, name string, tables ...*Table) 
 			return err
 		}
 		m.fileTypeRanges = m.typeRanges
-		dbExists, err := m.tableExist(ctx, m, TypeTable)
+		ex, err := m.tableExist(ctx, m, TypeTable)
 		if err != nil {
 			return err
 		}
-		if dbExists {
+		if ex {
 			m.dbTypeRanges, err = (&dbTypeStore{m}).load(ctx, m)
 			if err != nil {
 				return err
@@ -221,7 +221,7 @@ func (m *Migrate) NamedDiff(ctx context.Context, name string, tables ...*Table) 
 		if len(newTypes) > 0 {
 			plan.Changes = append(plan.Changes, &migrate.Change{
 				Cmd:     m.atTypeRangeSQL(newTypes...),
-				Comment: fmt.Sprintf(`add pk ranges for %s tables`, strings.Join(newTypes, ",")),
+				Comment: fmt.Sprintf("add pk ranges for %s tables", strings.Join(newTypes, ",")),
 			})
 		}
 	}

--- a/dialect/sql/schema/migrate.go
+++ b/dialect/sql/schema/migrate.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strings"
 
 	"ariga.io/atlas/sql/migrate"
 	"entgo.io/ent/dialect"
@@ -114,7 +115,9 @@ type Migrate struct {
 	atlas           *atlasOptions // migrate with atlas.
 	typeRanges      []string      // types order by their range.
 	hooks           []Hook        // hooks to apply before creation
-	typeStore       typeStore
+	typeStore       typeStore     // the typeStore to read and save type ranges
+	fileTypeRanges  []string      // used internally by ensureTypeTable hook
+	dbTypeRanges    []string      // used internally by ensureTypeTable hook
 }
 
 // NewMigrate create a migration structure for the given SQL driver.
@@ -163,33 +166,17 @@ func (m *Migrate) Create(ctx context.Context, tables ...*Table) error {
 	return creator.Create(ctx, tables...)
 }
 
-// Diff compares the state read from the StateReader with the state defined by Ent.
-// Changes will be written to migration files by the configures Planner.
+// Diff compares the state read from the connected database with the state defined by Ent.
+// Changes will be written to migration files by the configured Planner.
 func (m *Migrate) Diff(ctx context.Context, tables ...*Table) error {
 	return m.NamedDiff(ctx, "changes", tables...)
 }
 
-// NamedDiff compares the state read from the StateReader with the state defined by Ent.
-// Changes will be written to migration files by the configures Planner.
+// NamedDiff compares the state read from the connected database with the state defined by Ent.
+// Changes will be written to migration files by the configured Planner.
 func (m *Migrate) NamedDiff(ctx context.Context, name string, tables ...*Table) error {
 	if m.atlas.dir == nil {
 		return errors.New("no migration directory given")
-	}
-	if err := m.init(ctx, m); err != nil {
-		return err
-	}
-	if m.universalID {
-		if err := m.types(ctx, m); err != nil {
-			return err
-		}
-	}
-	plan, err := m.atDiff(ctx, m, name, tables...)
-	if err != nil {
-		return err
-	}
-	// Skip if the plan has no changes.
-	if len(plan.Changes) == 0 {
-		return nil
 	}
 	opts := []migrate.PlannerOption{
 		migrate.WithFormatter(m.atlas.fmt),
@@ -201,6 +188,46 @@ func (m *Migrate) NamedDiff(ctx context.Context, name string, tables ...*Table) 
 		}
 	} else {
 		opts = append(opts, migrate.DisableChecksum())
+	}
+	if err := m.init(ctx, m); err != nil {
+		return err
+	}
+	if m.universalID {
+		if err := m.types(ctx, m); err != nil {
+			return err
+		}
+		m.fileTypeRanges = m.typeRanges
+		dbExists, err := m.tableExist(ctx, m, TypeTable)
+		if err != nil {
+			return err
+		}
+		if dbExists {
+			m.dbTypeRanges, err = (&dbTypeStore{m}).load(ctx, m)
+			if err != nil {
+				return err
+			}
+		}
+		defer func() {
+			m.fileTypeRanges = nil
+			m.dbTypeRanges = nil
+		}()
+	}
+	plan, err := m.atDiff(ctx, m, name, tables...)
+	if err != nil {
+		return err
+	}
+	if m.universalID {
+		newTypes := m.typeRanges[len(m.dbTypeRanges):]
+		if len(newTypes) > 0 {
+			plan.Changes = append(plan.Changes, &migrate.Change{
+				Cmd:     m.atTypeRangeSQL(newTypes...),
+				Comment: fmt.Sprintf(`add pk ranges for %s tables`, strings.Join(newTypes, ",")),
+			})
+		}
+	}
+	// Skip if the plan has no changes.
+	if len(plan.Changes) == 0 {
+		return nil
 	}
 	return migrate.NewPlanner(nil, m.atlas.dir, opts...).WritePlan(plan)
 }

--- a/dialect/sql/schema/migrate_test.go
+++ b/dialect/sql/schema/migrate_test.go
@@ -119,11 +119,11 @@ func TestMigrate_Diff(t *testing.T) {
 	// consent for the file based type store has to be given explicitly.
 	_, err = NewMigrate(db, WithDir(d), WithGlobalUniqueID(true))
 	require.ErrorIs(t, err, errConsent)
-	require.Contains(t, err.Error(), "WithDeterministicGlobalUniqueID")
+	require.Contains(t, err.Error(), "WithUniversalID")
 	require.Contains(t, err.Error(), "WithGlobalUniqueID")
 	require.Contains(t, err.Error(), "WithDir")
 
-	m, err = NewMigrate(db, WithFormatter(f), WithDir(d), WithDeterministicGlobalUniqueID(), WithSumFile())
+	m, err = NewMigrate(db, WithFormatter(f), WithDir(d), WithUniversalID(), WithSumFile())
 	require.NoError(t, err)
 	require.IsType(t, &dirTypeStore{}, m.typeStore)
 	require.NoError(t, m.Diff(context.Background(),
@@ -183,7 +183,7 @@ func TestMigrate_Diff(t *testing.T) {
 	p = t.TempDir()
 	d, err = migrate.NewLocalDir(p)
 	require.NoError(t, err)
-	m, err = NewMigrate(db, WithFormatter(f), WithDir(d), WithDeterministicGlobalUniqueID())
+	m, err = NewMigrate(db, WithFormatter(f), WithDir(d), WithUniversalID())
 	require.NoError(t, err)
 
 	require.NoError(t, m.Diff(context.Background(),

--- a/dialect/sql/schema/mysql.go
+++ b/dialect/sql/schema/mysql.go
@@ -970,3 +970,10 @@ func indexType(idx *Index, d string) (string, bool) {
 	}
 	return "", false
 }
+
+func (MySQL) atTypeRangeSQL(ts ...string) string {
+	for i := range ts {
+		ts[i] = fmt.Sprintf("('%s')", ts[i])
+	}
+	return fmt.Sprintf("INSERT INTO `%s` (`type`) VALUES %s", TypeTable, strings.Join(ts, ", "))
+}

--- a/dialect/sql/schema/postgres.go
+++ b/dialect/sql/schema/postgres.go
@@ -784,3 +784,10 @@ func (d *Postgres) atIndex(idx1 *Index, t2 *schema.Table, idx2 *schema.Index) er
 	}
 	return nil
 }
+
+func (Postgres) atTypeRangeSQL(ts ...string) string {
+	for i := range ts {
+		ts[i] = fmt.Sprintf("('%s')", ts[i])
+	}
+	return fmt.Sprintf(`INSERT INTO "%s" ("type") VALUES %s`, TypeTable, strings.Join(ts, ", "))
+}

--- a/dialect/sql/schema/sqlite.go
+++ b/dialect/sql/schema/sqlite.go
@@ -449,3 +449,10 @@ func (d *SQLite) atIndex(idx1 *Index, t2 *schema.Table, idx2 *schema.Index) erro
 	}
 	return nil
 }
+
+func (SQLite) atTypeRangeSQL(ts ...string) string {
+	for i := range ts {
+		ts[i] = fmt.Sprintf("('%s')", ts[i])
+	}
+	return fmt.Sprintf("INSERT INTO `%s` (`type`) VALUES %s", TypeTable, strings.Join(ts, ", "))
+}

--- a/doc/md/migrate.md
+++ b/doc/md/migrate.md
@@ -81,9 +81,11 @@ To enable the Universal-IDs support for your project, pass the `WithGlobalUnique
 
 :::note
 Be aware, that `WithGlobalUniqueID` and [versioned migration](versioned-migrations.md) files are not working together.
-After understanding the 
-[risks](https://github.com/ent/ent/blob/8eeb23ce56bcb6ac4ee0354a6c847558586c9a46/dialect/sql/schema/atlas.go#L276-L283), 
-you can use `WithDeterministicGlobalUniqueID` instead.
+When using `WithGlobalUniqueID`, the allocated ranges are computed dynamically when creating the diff between a deployed 
+database and the current schema. In cases where multiple deployments exist, the allocated ranges for the same type might 
+be different from each other, depending on when the deployment took part. If you only have one deployment or all 
+deployments have the exact same data in the `ent_types` table, you can use `WithUniversalID` instead. This will enable a
+file based type range store instead of a database-table as source of truth.
 :::
 
 ```go

--- a/doc/md/migrate.md
+++ b/doc/md/migrate.md
@@ -79,6 +79,13 @@ the object ID to be unique.
 
 To enable the Universal-IDs support for your project, pass the `WithGlobalUniqueID` option to the migration.
 
+:::note
+Be aware, that `WithGlobalUniqueID` and [versioned migration](versioned-migrations.md) files are not working together.
+After understanding the 
+[risks](https://github.com/ent/ent/blob/8eeb23ce56bcb6ac4ee0354a6c847558586c9a46/dialect/sql/schema/atlas.go#L276-L283), 
+you can use `WithDeterministicGlobalUniqueID` instead.
+:::
+
 ```go
 package main
 

--- a/entc/integration/migrate/migrate_test.go
+++ b/entc/integration/migrate/migrate_test.go
@@ -228,11 +228,11 @@ func Versioned(t *testing.T, drv sql.ExecQuerier, client *versioned.Client) {
 		template.Must(template.New("name").Parse(`{{ range .Changes }}{{ printf "%s;\n" .Cmd }}{{ end }}`)),
 	)
 	require.NoError(t, err)
-	opts := []schema.MigrateOption{schema.WithDir(dir), schema.WithGlobalUniqueID(true), schema.WithFormatter(format)}
+	opts := []schema.MigrateOption{schema.WithDir(dir), schema.WithDeterministicGlobalUniqueID(), schema.WithFormatter(format)}
 
 	// Compared to empty database.
 	require.NoError(t, client.Schema.NamedDiff(ctx, "first", opts...))
-	require.Equal(t, 1, countFiles(t, dir))
+	require.Equal(t, 2, countFiles(t, dir))
 
 	// Apply the migrations.
 	fs, err := dir.Files()
@@ -249,7 +249,7 @@ func Versioned(t *testing.T, drv sql.ExecQuerier, client *versioned.Client) {
 
 	// Diff again - there should not be a new file.
 	require.NoError(t, client.Schema.NamedDiff(ctx, "second", opts...))
-	require.Equal(t, 1, countFiles(t, dir))
+	require.Equal(t, 2, countFiles(t, dir))
 }
 
 func V1ToV2(t *testing.T, dialect string, clientv1 *entv1.Client, clientv2 *entv2.Client) {

--- a/entc/integration/migrate/migrate_test.go
+++ b/entc/integration/migrate/migrate_test.go
@@ -233,7 +233,7 @@ func Versioned(t *testing.T, drv sql.ExecQuerier, client *versioned.Client) {
 	require.NoError(t, err)
 	opts := []schema.MigrateOption{
 		schema.WithDir(dir),
-		schema.WithDeterministicGlobalUniqueID(),
+		schema.WithUniversalID(),
 		schema.WithFormatter(format),
 	}
 

--- a/entc/integration/migrate/versioned/group.go
+++ b/entc/integration/migrate/versioned/group.go
@@ -74,11 +74,11 @@ func (gr *Group) Update() *GroupUpdateOne {
 // Unwrap unwraps the Group entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
 func (gr *Group) Unwrap() *Group {
-	tx, ok := gr.config.driver.(*txDriver)
+	_tx, ok := gr.config.driver.(*txDriver)
 	if !ok {
 		panic("versioned: Group is not a transactional entity")
 	}
-	gr.config.driver = tx.drv
+	gr.config.driver = _tx.drv
 	return gr
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module entgo.io/ent
 go 1.17
 
 require (
-	ariga.io/atlas v0.4.2-0.20220601084524-93e29909973c
+	ariga.io/atlas v0.4.3-0.20220610112612-85980c775013
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/go-openapi/inflect v0.19.0
 	github.com/go-sql-driver/mysql v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module entgo.io/ent
 go 1.17
 
 require (
-	ariga.io/atlas v0.4.3-0.20220610112612-85980c775013
+	ariga.io/atlas v0.4.3-0.20220615084302-e90a7f969cbd
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/go-openapi/inflect v0.19.0
 	github.com/go-sql-driver/mysql v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ ariga.io/atlas v0.4.2-0.20220524161107-b5b3f75b1034 h1:cjqJPtwk6LhJdYaFgLHI0OuZy
 ariga.io/atlas v0.4.2-0.20220524161107-b5b3f75b1034/go.mod h1:CKqqlJeTdRfEmnHaCcNPHg8DD6GPx1TxNPZ1NFknKHU=
 ariga.io/atlas v0.4.2-0.20220601084524-93e29909973c h1:xCquXJslTtTyp4bG9sH5XHAauvE5lgluRdeo65IRduo=
 ariga.io/atlas v0.4.2-0.20220601084524-93e29909973c/go.mod h1:CKqqlJeTdRfEmnHaCcNPHg8DD6GPx1TxNPZ1NFknKHU=
+ariga.io/atlas v0.4.3-0.20220610112612-85980c775013 h1:LBT0bq4tu/btdF/x2V0aoV421yPnXm2rSorJdt4vlYE=
+ariga.io/atlas v0.4.3-0.20220610112612-85980c775013/go.mod h1:0eSMrFg/pqF2qZ+bjM3yRvlzKROYaLbKbSVaU0RKr5g=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ ariga.io/atlas v0.4.2-0.20220601084524-93e29909973c h1:xCquXJslTtTyp4bG9sH5XHAau
 ariga.io/atlas v0.4.2-0.20220601084524-93e29909973c/go.mod h1:CKqqlJeTdRfEmnHaCcNPHg8DD6GPx1TxNPZ1NFknKHU=
 ariga.io/atlas v0.4.3-0.20220610112612-85980c775013 h1:LBT0bq4tu/btdF/x2V0aoV421yPnXm2rSorJdt4vlYE=
 ariga.io/atlas v0.4.3-0.20220610112612-85980c775013/go.mod h1:0eSMrFg/pqF2qZ+bjM3yRvlzKROYaLbKbSVaU0RKr5g=
+ariga.io/atlas v0.4.3-0.20220615084302-e90a7f969cbd h1:S/RPkFUkVqIH3abJWE5tP3QyqPjat/bAzXSdT7lZokU=
+ariga.io/atlas v0.4.3-0.20220615084302-e90a7f969cbd/go.mod h1:10hc2LWRcvk2SFtdakSD6YKm5wp9DmzcOb6aepwYiG4=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=


### PR DESCRIPTION
This PR adds support for a file based type storage when using versioned migrations. The file called `.ent_types` is written to the migration directory alongside the migration files and will be kept in sync for every migration file generation run.

In order to not break existing code, where the type storage might differ for different deployment, global unique ID mut be enabled by using a new option. This will also be raised as an error to the user when attempting to use versioned migrations and global unique ID.

Documentation will be added to this PR once feedback on the code is gathered.

Fixes #2587 

----- 

I have discussed with Ariel already, that we will move the configuration for allocated pk ranges to the schema level. We haven't yet figured out, how to do this best, but it will come.