### PR TITLE
doc/tutorial: fix typos in tutorial-todo-crud

### DIFF
--- a/doc/md/tutorial-todo-crud.md
+++ b/doc/md/tutorial-todo-crud.md
@@ -45,7 +45,7 @@ func (Todo) Fields() []ent.Field {
 			).
 			Annotations(
 				entgql.OrderField("STATUS"),
-			),
+			).
 			Default("in_progress"),
 		field.Int("priority").
 			Default(0),


### PR DESCRIPTION
Fixed a typo in the tutorial-todo-crud.