### PR TITLE
entc/gen: ignore edge-fields order in edge-schema with composite identifiers 

### DIFF
--- a/dialect/sql/schema/schema.go
+++ b/dialect/sql/schema/schema.go
@@ -69,8 +69,23 @@ func (t *Table) AddColumn(c *Column) *Table {
 
 // HasColumn reports if the table contains a column with the given name.
 func (t *Table) HasColumn(name string) bool {
-	_, ok := t.columns[name]
+	_, ok := t.Column(name)
 	return ok
+}
+
+// Column returns the column with the given name. If exists.
+func (t *Table) Column(name string) (*Column, bool) {
+	if c, ok := t.columns[name]; ok {
+		return c, true
+	}
+	// In case the column was added
+	// directly to the Columns field.
+	for _, c := range t.Columns {
+		if c.Name == name {
+			return c, true
+		}
+	}
+	return nil, false
 }
 
 // SetAnnotation the entsql.Annotation on the table.

--- a/entc/integration/edgeschema/ent/client.go
+++ b/entc/integration/edgeschema/ent/client.go
@@ -868,18 +868,18 @@ func (c *TweetLikeClient) Query() *TweetLikeQuery {
 	}
 }
 
-// QueryUser queries the user edge of a TweetLike.
-func (c *TweetLikeClient) QueryUser(tl *TweetLike) *UserQuery {
-	return c.Query().
-		Where(tweetlike.UserID(tl.UserID), tweetlike.TweetID(tl.TweetID)).
-		QueryUser()
-}
-
 // QueryTweet queries the tweet edge of a TweetLike.
 func (c *TweetLikeClient) QueryTweet(tl *TweetLike) *TweetQuery {
 	return c.Query().
 		Where(tweetlike.UserID(tl.UserID), tweetlike.TweetID(tl.TweetID)).
 		QueryTweet()
+}
+
+// QueryUser queries the user edge of a TweetLike.
+func (c *TweetLikeClient) QueryUser(tl *TweetLike) *UserQuery {
+	return c.Query().
+		Where(tweetlike.UserID(tl.UserID), tweetlike.TweetID(tl.TweetID)).
+		QueryUser()
 }
 
 // Hooks returns the client hooks.

--- a/entc/integration/edgeschema/ent/migrate/schema.go
+++ b/entc/integration/edgeschema/ent/migrate/schema.go
@@ -121,25 +121,25 @@ var (
 	// TweetLikesColumns holds the columns for the "tweet_likes" table.
 	TweetLikesColumns = []*schema.Column{
 		{Name: "liked_at", Type: field.TypeTime},
-		{Name: "user_id", Type: field.TypeInt},
 		{Name: "tweet_id", Type: field.TypeInt},
+		{Name: "user_id", Type: field.TypeInt},
 	}
 	// TweetLikesTable holds the schema information for the "tweet_likes" table.
 	TweetLikesTable = &schema.Table{
 		Name:       "tweet_likes",
 		Columns:    TweetLikesColumns,
-		PrimaryKey: []*schema.Column{TweetLikesColumns[1], TweetLikesColumns[2]},
+		PrimaryKey: []*schema.Column{TweetLikesColumns[2], TweetLikesColumns[1]},
 		ForeignKeys: []*schema.ForeignKey{
 			{
-				Symbol:     "tweet_likes_users_user",
+				Symbol:     "tweet_likes_tweets_tweet",
 				Columns:    []*schema.Column{TweetLikesColumns[1]},
-				RefColumns: []*schema.Column{UsersColumns[0]},
+				RefColumns: []*schema.Column{TweetsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
-				Symbol:     "tweet_likes_tweets_tweet",
+				Symbol:     "tweet_likes_users_user",
 				Columns:    []*schema.Column{TweetLikesColumns[2]},
-				RefColumns: []*schema.Column{TweetsColumns[0]},
+				RefColumns: []*schema.Column{UsersColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 		},
@@ -282,8 +282,8 @@ func init() {
 	FriendshipsTable.ForeignKeys[1].RefTable = UsersTable
 	RelationshipsTable.ForeignKeys[0].RefTable = UsersTable
 	RelationshipsTable.ForeignKeys[1].RefTable = UsersTable
-	TweetLikesTable.ForeignKeys[0].RefTable = UsersTable
-	TweetLikesTable.ForeignKeys[1].RefTable = TweetsTable
+	TweetLikesTable.ForeignKeys[0].RefTable = TweetsTable
+	TweetLikesTable.ForeignKeys[1].RefTable = UsersTable
 	TweetTagsTable.ForeignKeys[0].RefTable = TagsTable
 	TweetTagsTable.ForeignKeys[1].RefTable = TweetsTable
 	UserGroupsTable.ForeignKeys[0].RefTable = UsersTable

--- a/entc/integration/edgeschema/ent/mutation.go
+++ b/entc/integration/edgeschema/ent/mutation.go
@@ -2811,10 +2811,10 @@ type TweetLikeMutation struct {
 	typ           string
 	liked_at      *time.Time
 	clearedFields map[string]struct{}
-	user          *int
-	cleareduser   bool
 	tweet         *int
 	clearedtweet  bool
+	user          *int
+	cleareduser   bool
 	done          bool
 	oldValue      func(context.Context) (*TweetLike, error)
 	predicates    []predicate.TweetLike
@@ -2915,32 +2915,6 @@ func (m *TweetLikeMutation) ResetTweetID() {
 	m.tweet = nil
 }
 
-// ClearUser clears the "user" edge to the User entity.
-func (m *TweetLikeMutation) ClearUser() {
-	m.cleareduser = true
-}
-
-// UserCleared reports if the "user" edge to the User entity was cleared.
-func (m *TweetLikeMutation) UserCleared() bool {
-	return m.cleareduser
-}
-
-// UserIDs returns the "user" edge IDs in the mutation.
-// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
-// UserID instead. It exists only for internal usage by the builders.
-func (m *TweetLikeMutation) UserIDs() (ids []int) {
-	if id := m.user; id != nil {
-		ids = append(ids, *id)
-	}
-	return
-}
-
-// ResetUser resets all changes to the "user" edge.
-func (m *TweetLikeMutation) ResetUser() {
-	m.user = nil
-	m.cleareduser = false
-}
-
 // ClearTweet clears the "tweet" edge to the Tweet entity.
 func (m *TweetLikeMutation) ClearTweet() {
 	m.clearedtweet = true
@@ -2965,6 +2939,32 @@ func (m *TweetLikeMutation) TweetIDs() (ids []int) {
 func (m *TweetLikeMutation) ResetTweet() {
 	m.tweet = nil
 	m.clearedtweet = false
+}
+
+// ClearUser clears the "user" edge to the User entity.
+func (m *TweetLikeMutation) ClearUser() {
+	m.cleareduser = true
+}
+
+// UserCleared reports if the "user" edge to the User entity was cleared.
+func (m *TweetLikeMutation) UserCleared() bool {
+	return m.cleareduser
+}
+
+// UserIDs returns the "user" edge IDs in the mutation.
+// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
+// UserID instead. It exists only for internal usage by the builders.
+func (m *TweetLikeMutation) UserIDs() (ids []int) {
+	if id := m.user; id != nil {
+		ids = append(ids, *id)
+	}
+	return
+}
+
+// ResetUser resets all changes to the "user" edge.
+func (m *TweetLikeMutation) ResetUser() {
+	m.user = nil
+	m.cleareduser = false
 }
 
 // Where appends a list predicates to the TweetLikeMutation builder.
@@ -3115,11 +3115,11 @@ func (m *TweetLikeMutation) ResetField(name string) error {
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *TweetLikeMutation) AddedEdges() []string {
 	edges := make([]string, 0, 2)
-	if m.user != nil {
-		edges = append(edges, tweetlike.EdgeUser)
-	}
 	if m.tweet != nil {
 		edges = append(edges, tweetlike.EdgeTweet)
+	}
+	if m.user != nil {
+		edges = append(edges, tweetlike.EdgeUser)
 	}
 	return edges
 }
@@ -3128,12 +3128,12 @@ func (m *TweetLikeMutation) AddedEdges() []string {
 // name in this mutation.
 func (m *TweetLikeMutation) AddedIDs(name string) []ent.Value {
 	switch name {
-	case tweetlike.EdgeUser:
-		if id := m.user; id != nil {
-			return []ent.Value{*id}
-		}
 	case tweetlike.EdgeTweet:
 		if id := m.tweet; id != nil {
+			return []ent.Value{*id}
+		}
+	case tweetlike.EdgeUser:
+		if id := m.user; id != nil {
 			return []ent.Value{*id}
 		}
 	}
@@ -3157,11 +3157,11 @@ func (m *TweetLikeMutation) RemovedIDs(name string) []ent.Value {
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *TweetLikeMutation) ClearedEdges() []string {
 	edges := make([]string, 0, 2)
-	if m.cleareduser {
-		edges = append(edges, tweetlike.EdgeUser)
-	}
 	if m.clearedtweet {
 		edges = append(edges, tweetlike.EdgeTweet)
+	}
+	if m.cleareduser {
+		edges = append(edges, tweetlike.EdgeUser)
 	}
 	return edges
 }
@@ -3170,10 +3170,10 @@ func (m *TweetLikeMutation) ClearedEdges() []string {
 // was cleared in this mutation.
 func (m *TweetLikeMutation) EdgeCleared(name string) bool {
 	switch name {
-	case tweetlike.EdgeUser:
-		return m.cleareduser
 	case tweetlike.EdgeTweet:
 		return m.clearedtweet
+	case tweetlike.EdgeUser:
+		return m.cleareduser
 	}
 	return false
 }
@@ -3182,11 +3182,11 @@ func (m *TweetLikeMutation) EdgeCleared(name string) bool {
 // if that edge is not defined in the schema.
 func (m *TweetLikeMutation) ClearEdge(name string) error {
 	switch name {
-	case tweetlike.EdgeUser:
-		m.ClearUser()
-		return nil
 	case tweetlike.EdgeTweet:
 		m.ClearTweet()
+		return nil
+	case tweetlike.EdgeUser:
+		m.ClearUser()
 		return nil
 	}
 	return fmt.Errorf("unknown TweetLike unique edge %s", name)
@@ -3196,11 +3196,11 @@ func (m *TweetLikeMutation) ClearEdge(name string) error {
 // It returns an error if the edge is not defined in the schema.
 func (m *TweetLikeMutation) ResetEdge(name string) error {
 	switch name {
-	case tweetlike.EdgeUser:
-		m.ResetUser()
-		return nil
 	case tweetlike.EdgeTweet:
 		m.ResetTweet()
+		return nil
+	case tweetlike.EdgeUser:
+		m.ResetUser()
 		return nil
 	}
 	return fmt.Errorf("unknown TweetLike edge %s", name)

--- a/entc/integration/edgeschema/ent/schema/tweetlike.go
+++ b/entc/integration/edgeschema/ent/schema/tweetlike.go
@@ -37,13 +37,13 @@ func (TweetLike) Fields() []ent.Field {
 // Edges of the TweetLike.
 func (TweetLike) Edges() []ent.Edge {
 	return []ent.Edge{
-		edge.To("user", User.Type).
-			Unique().
-			Required().
-			Field("user_id"),
 		edge.To("tweet", Tweet.Type).
 			Unique().
 			Required().
 			Field("tweet_id"),
+		edge.To("user", User.Type).
+			Unique().
+			Required().
+			Field("user_id"),
 	}
 }

--- a/entc/integration/edgeschema/ent/tweetlike.go
+++ b/entc/integration/edgeschema/ent/tweetlike.go
@@ -33,33 +33,19 @@ type TweetLike struct {
 
 // TweetLikeEdges holds the relations/edges for other nodes in the graph.
 type TweetLikeEdges struct {
-	// User holds the value of the user edge.
-	User *User `json:"user,omitempty"`
 	// Tweet holds the value of the tweet edge.
 	Tweet *Tweet `json:"tweet,omitempty"`
+	// User holds the value of the user edge.
+	User *User `json:"user,omitempty"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
 	loadedTypes [2]bool
 }
 
-// UserOrErr returns the User value or an error if the edge
-// was not loaded in eager-loading, or loaded but was not found.
-func (e TweetLikeEdges) UserOrErr() (*User, error) {
-	if e.loadedTypes[0] {
-		if e.User == nil {
-			// The edge user was loaded in eager-loading,
-			// but was not found.
-			return nil, &NotFoundError{label: user.Label}
-		}
-		return e.User, nil
-	}
-	return nil, &NotLoadedError{edge: "user"}
-}
-
 // TweetOrErr returns the Tweet value or an error if the edge
 // was not loaded in eager-loading, or loaded but was not found.
 func (e TweetLikeEdges) TweetOrErr() (*Tweet, error) {
-	if e.loadedTypes[1] {
+	if e.loadedTypes[0] {
 		if e.Tweet == nil {
 			// The edge tweet was loaded in eager-loading,
 			// but was not found.
@@ -68,6 +54,20 @@ func (e TweetLikeEdges) TweetOrErr() (*Tweet, error) {
 		return e.Tweet, nil
 	}
 	return nil, &NotLoadedError{edge: "tweet"}
+}
+
+// UserOrErr returns the User value or an error if the edge
+// was not loaded in eager-loading, or loaded but was not found.
+func (e TweetLikeEdges) UserOrErr() (*User, error) {
+	if e.loadedTypes[1] {
+		if e.User == nil {
+			// The edge user was loaded in eager-loading,
+			// but was not found.
+			return nil, &NotFoundError{label: user.Label}
+		}
+		return e.User, nil
+	}
+	return nil, &NotLoadedError{edge: "user"}
 }
 
 // scanValues returns the types for scanning values from sql.Rows.
@@ -117,14 +117,14 @@ func (tl *TweetLike) assignValues(columns []string, values []interface{}) error 
 	return nil
 }
 
-// QueryUser queries the "user" edge of the TweetLike entity.
-func (tl *TweetLike) QueryUser() *UserQuery {
-	return (&TweetLikeClient{config: tl.config}).QueryUser(tl)
-}
-
 // QueryTweet queries the "tweet" edge of the TweetLike entity.
 func (tl *TweetLike) QueryTweet() *TweetQuery {
 	return (&TweetLikeClient{config: tl.config}).QueryTweet(tl)
+}
+
+// QueryUser queries the "user" edge of the TweetLike entity.
+func (tl *TweetLike) QueryUser() *UserQuery {
+	return (&TweetLikeClient{config: tl.config}).QueryUser(tl)
 }
 
 // Update returns a builder for updating this TweetLike.

--- a/entc/integration/edgeschema/ent/tweetlike/tweetlike.go
+++ b/entc/integration/edgeschema/ent/tweetlike/tweetlike.go
@@ -19,23 +19,16 @@ const (
 	FieldUserID = "user_id"
 	// FieldTweetID holds the string denoting the tweet_id field in the database.
 	FieldTweetID = "tweet_id"
-	// EdgeUser holds the string denoting the user edge name in mutations.
-	EdgeUser = "user"
 	// EdgeTweet holds the string denoting the tweet edge name in mutations.
 	EdgeTweet = "tweet"
-	// UserFieldID holds the string denoting the ID field of the User.
-	UserFieldID = "id"
+	// EdgeUser holds the string denoting the user edge name in mutations.
+	EdgeUser = "user"
 	// TweetFieldID holds the string denoting the ID field of the Tweet.
 	TweetFieldID = "id"
+	// UserFieldID holds the string denoting the ID field of the User.
+	UserFieldID = "id"
 	// Table holds the table name of the tweetlike in the database.
 	Table = "tweet_likes"
-	// UserTable is the table that holds the user relation/edge.
-	UserTable = "tweet_likes"
-	// UserInverseTable is the table name for the User entity.
-	// It exists in this package in order to avoid circular dependency with the "user" package.
-	UserInverseTable = "users"
-	// UserColumn is the table column denoting the user relation/edge.
-	UserColumn = "user_id"
 	// TweetTable is the table that holds the tweet relation/edge.
 	TweetTable = "tweet_likes"
 	// TweetInverseTable is the table name for the Tweet entity.
@@ -43,6 +36,13 @@ const (
 	TweetInverseTable = "tweets"
 	// TweetColumn is the table column denoting the tweet relation/edge.
 	TweetColumn = "tweet_id"
+	// UserTable is the table that holds the user relation/edge.
+	UserTable = "tweet_likes"
+	// UserInverseTable is the table name for the User entity.
+	// It exists in this package in order to avoid circular dependency with the "user" package.
+	UserInverseTable = "users"
+	// UserColumn is the table column denoting the user relation/edge.
+	UserColumn = "user_id"
 )
 
 // Columns holds all SQL columns for tweetlike fields.

--- a/entc/integration/edgeschema/ent/tweetlike/where.go
+++ b/entc/integration/edgeschema/ent/tweetlike/where.go
@@ -207,34 +207,6 @@ func TweetIDNotIn(vs ...int) predicate.TweetLike {
 	})
 }
 
-// HasUser applies the HasEdge predicate on the "user" edge.
-func HasUser() predicate.TweetLike {
-	return predicate.TweetLike(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, UserColumn),
-			sqlgraph.To(UserInverseTable, UserFieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, UserTable, UserColumn),
-		)
-		sqlgraph.HasNeighbors(s, step)
-	})
-}
-
-// HasUserWith applies the HasEdge predicate on the "user" edge with a given conditions (other predicates).
-func HasUserWith(preds ...predicate.User) predicate.TweetLike {
-	return predicate.TweetLike(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, UserColumn),
-			sqlgraph.To(UserInverseTable, UserFieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, UserTable, UserColumn),
-		)
-		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
-			for _, p := range preds {
-				p(s)
-			}
-		})
-	})
-}
-
 // HasTweet applies the HasEdge predicate on the "tweet" edge.
 func HasTweet() predicate.TweetLike {
 	return predicate.TweetLike(func(s *sql.Selector) {
@@ -254,6 +226,34 @@ func HasTweetWith(preds ...predicate.Tweet) predicate.TweetLike {
 			sqlgraph.From(Table, TweetColumn),
 			sqlgraph.To(TweetInverseTable, TweetFieldID),
 			sqlgraph.Edge(sqlgraph.M2O, false, TweetTable, TweetColumn),
+		)
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasUser applies the HasEdge predicate on the "user" edge.
+func HasUser() predicate.TweetLike {
+	return predicate.TweetLike(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, UserColumn),
+			sqlgraph.To(UserInverseTable, UserFieldID),
+			sqlgraph.Edge(sqlgraph.M2O, false, UserTable, UserColumn),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasUserWith applies the HasEdge predicate on the "user" edge with a given conditions (other predicates).
+func HasUserWith(preds ...predicate.User) predicate.TweetLike {
+	return predicate.TweetLike(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, UserColumn),
+			sqlgraph.To(UserInverseTable, UserFieldID),
+			sqlgraph.Edge(sqlgraph.M2O, false, UserTable, UserColumn),
 		)
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {

--- a/entc/integration/edgeschema/ent/tweetlike_create.go
+++ b/entc/integration/edgeschema/ent/tweetlike_create.go
@@ -54,14 +54,14 @@ func (tlc *TweetLikeCreate) SetTweetID(i int) *TweetLikeCreate {
 	return tlc
 }
 
-// SetUser sets the "user" edge to the User entity.
-func (tlc *TweetLikeCreate) SetUser(u *User) *TweetLikeCreate {
-	return tlc.SetUserID(u.ID)
-}
-
 // SetTweet sets the "tweet" edge to the Tweet entity.
 func (tlc *TweetLikeCreate) SetTweet(t *Tweet) *TweetLikeCreate {
 	return tlc.SetTweetID(t.ID)
+}
+
+// SetUser sets the "user" edge to the User entity.
+func (tlc *TweetLikeCreate) SetUser(u *User) *TweetLikeCreate {
+	return tlc.SetUserID(u.ID)
 }
 
 // Mutation returns the TweetLikeMutation object of the builder.
@@ -156,11 +156,11 @@ func (tlc *TweetLikeCreate) check() error {
 	if _, ok := tlc.mutation.TweetID(); !ok {
 		return &ValidationError{Name: "tweet_id", err: errors.New(`ent: missing required field "TweetLike.tweet_id"`)}
 	}
-	if _, ok := tlc.mutation.UserID(); !ok {
-		return &ValidationError{Name: "user", err: errors.New(`ent: missing required edge "TweetLike.user"`)}
-	}
 	if _, ok := tlc.mutation.TweetID(); !ok {
 		return &ValidationError{Name: "tweet", err: errors.New(`ent: missing required edge "TweetLike.tweet"`)}
+	}
+	if _, ok := tlc.mutation.UserID(); !ok {
+		return &ValidationError{Name: "user", err: errors.New(`ent: missing required edge "TweetLike.user"`)}
 	}
 	return nil
 }
@@ -192,26 +192,6 @@ func (tlc *TweetLikeCreate) createSpec() (*TweetLike, *sqlgraph.CreateSpec) {
 		})
 		_node.LikedAt = value
 	}
-	if nodes := tlc.mutation.UserIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
-			Inverse: false,
-			Table:   tweetlike.UserTable,
-			Columns: []string{tweetlike.UserColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: &sqlgraph.FieldSpec{
-					Type:   field.TypeInt,
-					Column: user.FieldID,
-				},
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_node.UserID = nodes[0]
-		_spec.Edges = append(_spec.Edges, edge)
-	}
 	if nodes := tlc.mutation.TweetIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2O,
@@ -230,6 +210,26 @@ func (tlc *TweetLikeCreate) createSpec() (*TweetLike, *sqlgraph.CreateSpec) {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
 		_node.TweetID = nodes[0]
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := tlc.mutation.UserIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: false,
+			Table:   tweetlike.UserTable,
+			Columns: []string{tweetlike.UserColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: &sqlgraph.FieldSpec{
+					Type:   field.TypeInt,
+					Column: user.FieldID,
+				},
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_node.UserID = nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	return _node, _spec

--- a/entc/integration/edgeschema/ent/tweetlike_query.go
+++ b/entc/integration/edgeschema/ent/tweetlike_query.go
@@ -29,8 +29,8 @@ type TweetLikeQuery struct {
 	fields     []string
 	predicates []predicate.TweetLike
 	// eager-loading edges.
-	withUser  *UserQuery
 	withTweet *TweetQuery
+	withUser  *UserQuery
 	// intermediate query (i.e. traversal path).
 	sql  *sql.Selector
 	path func(context.Context) (*sql.Selector, error)
@@ -67,28 +67,6 @@ func (tlq *TweetLikeQuery) Order(o ...OrderFunc) *TweetLikeQuery {
 	return tlq
 }
 
-// QueryUser chains the current query on the "user" edge.
-func (tlq *TweetLikeQuery) QueryUser() *UserQuery {
-	query := &UserQuery{config: tlq.config}
-	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
-		if err := tlq.prepareQuery(ctx); err != nil {
-			return nil, err
-		}
-		selector := tlq.sqlQuery(ctx)
-		if err := selector.Err(); err != nil {
-			return nil, err
-		}
-		step := sqlgraph.NewStep(
-			sqlgraph.From(tweetlike.Table, tweetlike.UserColumn, selector),
-			sqlgraph.To(user.Table, user.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, tweetlike.UserTable, tweetlike.UserColumn),
-		)
-		fromU = sqlgraph.SetNeighbors(tlq.driver.Dialect(), step)
-		return fromU, nil
-	}
-	return query
-}
-
 // QueryTweet chains the current query on the "tweet" edge.
 func (tlq *TweetLikeQuery) QueryTweet() *TweetQuery {
 	query := &TweetQuery{config: tlq.config}
@@ -104,6 +82,28 @@ func (tlq *TweetLikeQuery) QueryTweet() *TweetQuery {
 			sqlgraph.From(tweetlike.Table, tweetlike.TweetColumn, selector),
 			sqlgraph.To(tweet.Table, tweet.FieldID),
 			sqlgraph.Edge(sqlgraph.M2O, false, tweetlike.TweetTable, tweetlike.TweetColumn),
+		)
+		fromU = sqlgraph.SetNeighbors(tlq.driver.Dialect(), step)
+		return fromU, nil
+	}
+	return query
+}
+
+// QueryUser chains the current query on the "user" edge.
+func (tlq *TweetLikeQuery) QueryUser() *UserQuery {
+	query := &UserQuery{config: tlq.config}
+	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
+		if err := tlq.prepareQuery(ctx); err != nil {
+			return nil, err
+		}
+		selector := tlq.sqlQuery(ctx)
+		if err := selector.Err(); err != nil {
+			return nil, err
+		}
+		step := sqlgraph.NewStep(
+			sqlgraph.From(tweetlike.Table, tweetlike.UserColumn, selector),
+			sqlgraph.To(user.Table, user.FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, false, tweetlike.UserTable, tweetlike.UserColumn),
 		)
 		fromU = sqlgraph.SetNeighbors(tlq.driver.Dialect(), step)
 		return fromU, nil
@@ -223,24 +223,13 @@ func (tlq *TweetLikeQuery) Clone() *TweetLikeQuery {
 		offset:     tlq.offset,
 		order:      append([]OrderFunc{}, tlq.order...),
 		predicates: append([]predicate.TweetLike{}, tlq.predicates...),
-		withUser:   tlq.withUser.Clone(),
 		withTweet:  tlq.withTweet.Clone(),
+		withUser:   tlq.withUser.Clone(),
 		// clone intermediate query.
 		sql:    tlq.sql.Clone(),
 		path:   tlq.path,
 		unique: tlq.unique,
 	}
-}
-
-// WithUser tells the query-builder to eager-load the nodes that are connected to
-// the "user" edge. The optional arguments are used to configure the query builder of the edge.
-func (tlq *TweetLikeQuery) WithUser(opts ...func(*UserQuery)) *TweetLikeQuery {
-	query := &UserQuery{config: tlq.config}
-	for _, opt := range opts {
-		opt(query)
-	}
-	tlq.withUser = query
-	return tlq
 }
 
 // WithTweet tells the query-builder to eager-load the nodes that are connected to
@@ -251,6 +240,17 @@ func (tlq *TweetLikeQuery) WithTweet(opts ...func(*TweetQuery)) *TweetLikeQuery 
 		opt(query)
 	}
 	tlq.withTweet = query
+	return tlq
+}
+
+// WithUser tells the query-builder to eager-load the nodes that are connected to
+// the "user" edge. The optional arguments are used to configure the query builder of the edge.
+func (tlq *TweetLikeQuery) WithUser(opts ...func(*UserQuery)) *TweetLikeQuery {
+	query := &UserQuery{config: tlq.config}
+	for _, opt := range opts {
+		opt(query)
+	}
+	tlq.withUser = query
 	return tlq
 }
 
@@ -325,8 +325,8 @@ func (tlq *TweetLikeQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*T
 		nodes       = []*TweetLike{}
 		_spec       = tlq.querySpec()
 		loadedTypes = [2]bool{
-			tlq.withUser != nil,
 			tlq.withTweet != nil,
+			tlq.withUser != nil,
 		}
 	)
 	_spec.ScanValues = func(columns []string) ([]interface{}, error) {
@@ -346,32 +346,6 @@ func (tlq *TweetLikeQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*T
 	}
 	if len(nodes) == 0 {
 		return nodes, nil
-	}
-
-	if query := tlq.withUser; query != nil {
-		ids := make([]int, 0, len(nodes))
-		nodeids := make(map[int][]*TweetLike)
-		for i := range nodes {
-			fk := nodes[i].UserID
-			if _, ok := nodeids[fk]; !ok {
-				ids = append(ids, fk)
-			}
-			nodeids[fk] = append(nodeids[fk], nodes[i])
-		}
-		query.Where(user.IDIn(ids...))
-		neighbors, err := query.All(ctx)
-		if err != nil {
-			return nil, err
-		}
-		for _, n := range neighbors {
-			nodes, ok := nodeids[n.ID]
-			if !ok {
-				return nil, fmt.Errorf(`unexpected foreign-key "user_id" returned %v`, n.ID)
-			}
-			for i := range nodes {
-				nodes[i].Edges.User = n
-			}
-		}
 	}
 
 	if query := tlq.withTweet; query != nil {
@@ -396,6 +370,32 @@ func (tlq *TweetLikeQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*T
 			}
 			for i := range nodes {
 				nodes[i].Edges.Tweet = n
+			}
+		}
+	}
+
+	if query := tlq.withUser; query != nil {
+		ids := make([]int, 0, len(nodes))
+		nodeids := make(map[int][]*TweetLike)
+		for i := range nodes {
+			fk := nodes[i].UserID
+			if _, ok := nodeids[fk]; !ok {
+				ids = append(ids, fk)
+			}
+			nodeids[fk] = append(nodeids[fk], nodes[i])
+		}
+		query.Where(user.IDIn(ids...))
+		neighbors, err := query.All(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range neighbors {
+			nodes, ok := nodeids[n.ID]
+			if !ok {
+				return nil, fmt.Errorf(`unexpected foreign-key "user_id" returned %v`, n.ID)
+			}
+			for i := range nodes {
+				nodes[i].Edges.User = n
 			}
 		}
 	}

--- a/entc/integration/edgeschema/ent/tweetlike_update.go
+++ b/entc/integration/edgeschema/ent/tweetlike_update.go
@@ -60,14 +60,14 @@ func (tlu *TweetLikeUpdate) SetTweetID(i int) *TweetLikeUpdate {
 	return tlu
 }
 
-// SetUser sets the "user" edge to the User entity.
-func (tlu *TweetLikeUpdate) SetUser(u *User) *TweetLikeUpdate {
-	return tlu.SetUserID(u.ID)
-}
-
 // SetTweet sets the "tweet" edge to the Tweet entity.
 func (tlu *TweetLikeUpdate) SetTweet(t *Tweet) *TweetLikeUpdate {
 	return tlu.SetTweetID(t.ID)
+}
+
+// SetUser sets the "user" edge to the User entity.
+func (tlu *TweetLikeUpdate) SetUser(u *User) *TweetLikeUpdate {
+	return tlu.SetUserID(u.ID)
 }
 
 // Mutation returns the TweetLikeMutation object of the builder.
@@ -75,15 +75,15 @@ func (tlu *TweetLikeUpdate) Mutation() *TweetLikeMutation {
 	return tlu.mutation
 }
 
-// ClearUser clears the "user" edge to the User entity.
-func (tlu *TweetLikeUpdate) ClearUser() *TweetLikeUpdate {
-	tlu.mutation.ClearUser()
-	return tlu
-}
-
 // ClearTweet clears the "tweet" edge to the Tweet entity.
 func (tlu *TweetLikeUpdate) ClearTweet() *TweetLikeUpdate {
 	tlu.mutation.ClearTweet()
+	return tlu
+}
+
+// ClearUser clears the "user" edge to the User entity.
+func (tlu *TweetLikeUpdate) ClearUser() *TweetLikeUpdate {
+	tlu.mutation.ClearUser()
 	return tlu
 }
 
@@ -149,11 +149,11 @@ func (tlu *TweetLikeUpdate) ExecX(ctx context.Context) {
 
 // check runs all checks and user-defined validators on the builder.
 func (tlu *TweetLikeUpdate) check() error {
-	if _, ok := tlu.mutation.UserID(); tlu.mutation.UserCleared() && !ok {
-		return errors.New(`ent: clearing a required unique edge "TweetLike.user"`)
-	}
 	if _, ok := tlu.mutation.TweetID(); tlu.mutation.TweetCleared() && !ok {
 		return errors.New(`ent: clearing a required unique edge "TweetLike.tweet"`)
+	}
+	if _, ok := tlu.mutation.UserID(); tlu.mutation.UserCleared() && !ok {
+		return errors.New(`ent: clearing a required unique edge "TweetLike.user"`)
 	}
 	return nil
 }
@@ -178,41 +178,6 @@ func (tlu *TweetLikeUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Value:  value,
 			Column: tweetlike.FieldLikedAt,
 		})
-	}
-	if tlu.mutation.UserCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
-			Inverse: false,
-			Table:   tweetlike.UserTable,
-			Columns: []string{tweetlike.UserColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: &sqlgraph.FieldSpec{
-					Type:   field.TypeInt,
-					Column: user.FieldID,
-				},
-			},
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := tlu.mutation.UserIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
-			Inverse: false,
-			Table:   tweetlike.UserTable,
-			Columns: []string{tweetlike.UserColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: &sqlgraph.FieldSpec{
-					Type:   field.TypeInt,
-					Column: user.FieldID,
-				},
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if tlu.mutation.TweetCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -241,6 +206,41 @@ func (tlu *TweetLikeUpdate) sqlSave(ctx context.Context) (n int, err error) {
 				IDSpec: &sqlgraph.FieldSpec{
 					Type:   field.TypeInt,
 					Column: tweet.FieldID,
+				},
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if tlu.mutation.UserCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: false,
+			Table:   tweetlike.UserTable,
+			Columns: []string{tweetlike.UserColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: &sqlgraph.FieldSpec{
+					Type:   field.TypeInt,
+					Column: user.FieldID,
+				},
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := tlu.mutation.UserIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: false,
+			Table:   tweetlike.UserTable,
+			Columns: []string{tweetlike.UserColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: &sqlgraph.FieldSpec{
+					Type:   field.TypeInt,
+					Column: user.FieldID,
 				},
 			},
 		}
@@ -294,14 +294,14 @@ func (tluo *TweetLikeUpdateOne) SetTweetID(i int) *TweetLikeUpdateOne {
 	return tluo
 }
 
-// SetUser sets the "user" edge to the User entity.
-func (tluo *TweetLikeUpdateOne) SetUser(u *User) *TweetLikeUpdateOne {
-	return tluo.SetUserID(u.ID)
-}
-
 // SetTweet sets the "tweet" edge to the Tweet entity.
 func (tluo *TweetLikeUpdateOne) SetTweet(t *Tweet) *TweetLikeUpdateOne {
 	return tluo.SetTweetID(t.ID)
+}
+
+// SetUser sets the "user" edge to the User entity.
+func (tluo *TweetLikeUpdateOne) SetUser(u *User) *TweetLikeUpdateOne {
+	return tluo.SetUserID(u.ID)
 }
 
 // Mutation returns the TweetLikeMutation object of the builder.
@@ -309,15 +309,15 @@ func (tluo *TweetLikeUpdateOne) Mutation() *TweetLikeMutation {
 	return tluo.mutation
 }
 
-// ClearUser clears the "user" edge to the User entity.
-func (tluo *TweetLikeUpdateOne) ClearUser() *TweetLikeUpdateOne {
-	tluo.mutation.ClearUser()
-	return tluo
-}
-
 // ClearTweet clears the "tweet" edge to the Tweet entity.
 func (tluo *TweetLikeUpdateOne) ClearTweet() *TweetLikeUpdateOne {
 	tluo.mutation.ClearTweet()
+	return tluo
+}
+
+// ClearUser clears the "user" edge to the User entity.
+func (tluo *TweetLikeUpdateOne) ClearUser() *TweetLikeUpdateOne {
+	tluo.mutation.ClearUser()
 	return tluo
 }
 
@@ -396,11 +396,11 @@ func (tluo *TweetLikeUpdateOne) ExecX(ctx context.Context) {
 
 // check runs all checks and user-defined validators on the builder.
 func (tluo *TweetLikeUpdateOne) check() error {
-	if _, ok := tluo.mutation.UserID(); tluo.mutation.UserCleared() && !ok {
-		return errors.New(`ent: clearing a required unique edge "TweetLike.user"`)
-	}
 	if _, ok := tluo.mutation.TweetID(); tluo.mutation.TweetCleared() && !ok {
 		return errors.New(`ent: clearing a required unique edge "TweetLike.tweet"`)
+	}
+	if _, ok := tluo.mutation.UserID(); tluo.mutation.UserCleared() && !ok {
+		return errors.New(`ent: clearing a required unique edge "TweetLike.user"`)
 	}
 	return nil
 }
@@ -435,41 +435,6 @@ func (tluo *TweetLikeUpdateOne) sqlSave(ctx context.Context) (_node *TweetLike, 
 			Column: tweetlike.FieldLikedAt,
 		})
 	}
-	if tluo.mutation.UserCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
-			Inverse: false,
-			Table:   tweetlike.UserTable,
-			Columns: []string{tweetlike.UserColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: &sqlgraph.FieldSpec{
-					Type:   field.TypeInt,
-					Column: user.FieldID,
-				},
-			},
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := tluo.mutation.UserIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
-			Inverse: false,
-			Table:   tweetlike.UserTable,
-			Columns: []string{tweetlike.UserColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: &sqlgraph.FieldSpec{
-					Type:   field.TypeInt,
-					Column: user.FieldID,
-				},
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
-	}
 	if tluo.mutation.TweetCleared() {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2O,
@@ -497,6 +462,41 @@ func (tluo *TweetLikeUpdateOne) sqlSave(ctx context.Context) (_node *TweetLike, 
 				IDSpec: &sqlgraph.FieldSpec{
 					Type:   field.TypeInt,
 					Column: tweet.FieldID,
+				},
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if tluo.mutation.UserCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: false,
+			Table:   tweetlike.UserTable,
+			Columns: []string{tweetlike.UserColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: &sqlgraph.FieldSpec{
+					Type:   field.TypeInt,
+					Column: user.FieldID,
+				},
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := tluo.mutation.UserIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: false,
+			Table:   tweetlike.UserTable,
+			Columns: []string{tweetlike.UserColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: &sqlgraph.FieldSpec{
+					Type:   field.TypeInt,
+					Column: user.FieldID,
 				},
 			},
 		}


### PR DESCRIPTION
This PR allows defining edge schemas with any order of their edges, but still, enforces the ordering of the fields in the ID annotation

cc @Liooo