### PR TITLE
doc/md: fixing enum Status in Add Fields To The Schema

### DIFF
--- a/doc/md/tutorial-todo-crud.md
+++ b/doc/md/tutorial-todo-crud.md
@@ -46,7 +46,7 @@ func (Todo) Fields() []ent.Field {
 			Annotations(
 				entgql.OrderField("STATUS"),
 			).
-			Default("in_progress"),
+			Default("IN_PROGRESS"),
 		field.Int("priority").
 			Default(0),
 	}


### PR DESCRIPTION
When run 'go generate ./ent', got error on [create type Todo: invalid default value for enum field "status"]

Because todo.graphql on tutorial-todo-gql.md says enum Status is "IN_PROGRESS"