### PR TITLE
dialect/sql/builder: make sql.NotIn() with empty args fallback to NOT FALSE

### DIFF
--- a/dialect/sql/builder.go
+++ b/dialect/sql/builder.go
@@ -1587,10 +1587,10 @@ func NotIn(col string, args ...interface{}) *Predicate {
 
 // NotIn appends the `Not IN` predicate.
 func (p *Predicate) NotIn(col string, args ...interface{}) *Predicate {
-	// If no arguments were provided, append the FALSE constant, since
-	// we cannot apply "NOT IN ()". This will make this predicate falsy.
+	// If no arguments were provided, append the NOT FALSE constant, since
+	// we cannot apply "NOT IN ()". This will make this predicate truthy.
 	if len(args) == 0 {
-		return p.False()
+		return Not(p.False())
 	}
 	return p.Append(func(b *Builder) {
 		b.Ident(col).WriteOp(OpNotIn)

--- a/dialect/sql/builder.go
+++ b/dialect/sql/builder.go
@@ -1587,8 +1587,10 @@ func NotIn(col string, args ...interface{}) *Predicate {
 
 // NotIn appends the `Not IN` predicate.
 func (p *Predicate) NotIn(col string, args ...interface{}) *Predicate {
+	// If no arguments were provided, append the FALSE constant, since
+	// we cannot apply "NOT IN ()". This will make this predicate falsy.
 	if len(args) == 0 {
-		return p
+		return p.False()
 	}
 	return p.Append(func(b *Builder) {
 		b.Ident(col).WriteOp(OpNotIn)

--- a/dialect/sql/builder_test.go
+++ b/dialect/sql/builder_test.go
@@ -637,6 +637,16 @@ func TestBuilder(t *testing.T) {
 		},
 		{
 			input: Delete("users").
+				Where(And(IsNull("parent_id"), In("name"))),
+			wantQuery: "DELETE FROM `users` WHERE `parent_id` IS NULL AND FALSE",
+		},
+		{
+			input: Delete("users").
+				Where(And(IsNull("parent_id"), NotIn("name"))),
+			wantQuery: "DELETE FROM `users` WHERE `parent_id` IS NULL AND FALSE",
+		},
+		{
+			input: Delete("users").
 				Where(And(False(), False())),
 			wantQuery: "DELETE FROM `users` WHERE FALSE AND FALSE",
 		},

--- a/dialect/sql/builder_test.go
+++ b/dialect/sql/builder_test.go
@@ -643,7 +643,7 @@ func TestBuilder(t *testing.T) {
 		{
 			input: Delete("users").
 				Where(And(IsNull("parent_id"), NotIn("name"))),
-			wantQuery: "DELETE FROM `users` WHERE `parent_id` IS NULL AND FALSE",
+			wantQuery: "DELETE FROM `users` WHERE `parent_id` IS NULL AND (NOT (FALSE))",
 		},
 		{
 			input: Delete("users").

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,3 @@
-ariga.io/atlas v0.4.3-0.20220708180314-c4867b18d9f8 h1:8C5iwh5F9AKxtUvMKFIgEoctAHFhow1vvjHoM0FNdts=
-ariga.io/atlas v0.4.3-0.20220708180314-c4867b18d9f8/go.mod h1:ofVetkJqlaWle3mvYmaS2uyFGFcc7dSq436tmxa/Mzk=
-ariga.io/atlas v0.4.3-0.20220711120113-a190b01c6ef9 h1:fCGaHuxbtYaE+OjQGl1hYTq4nwy659FLPVOCySF8MiQ=
-ariga.io/atlas v0.4.3-0.20220711120113-a190b01c6ef9/go.mod h1:ofVetkJqlaWle3mvYmaS2uyFGFcc7dSq436tmxa/Mzk=
-ariga.io/atlas v0.4.3-0.20220713162925-e2eac411c1ee h1:XbEXtwylf0ohKAJcrdVKJs6/fyLrdZItjl10DkFozbw=
-ariga.io/atlas v0.4.3-0.20220713162925-e2eac411c1ee/go.mod h1:ofVetkJqlaWle3mvYmaS2uyFGFcc7dSq436tmxa/Mzk=
-ariga.io/atlas v0.4.3-0.20220713221217-4bf3afd44b23 h1:x13CFp2IZgOzhLIHaY7DetDb7hg0k97BEg79B7ljNsY=
-ariga.io/atlas v0.4.3-0.20220713221217-4bf3afd44b23/go.mod h1:ofVetkJqlaWle3mvYmaS2uyFGFcc7dSq436tmxa/Mzk=
-ariga.io/atlas v0.5.0 h1:9HZclkGI/xsW7IqKZLIMfnUJ0Nkgm1X1nysq4SMkKsg=
-ariga.io/atlas v0.5.0/go.mod h1:ofVetkJqlaWle3mvYmaS2uyFGFcc7dSq436tmxa/Mzk=
 ariga.io/atlas v0.5.1-0.20220714132857-e4805efc4604 h1:HHNqzvInBec35ZfAYlTXUK5xBGGobCBT84SCX7ZO0DU=
 ariga.io/atlas v0.5.1-0.20220714132857-e4805efc4604/go.mod h1:ofVetkJqlaWle3mvYmaS2uyFGFcc7dSq436tmxa/Mzk=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,13 @@
+ariga.io/atlas v0.4.3-0.20220708180314-c4867b18d9f8 h1:8C5iwh5F9AKxtUvMKFIgEoctAHFhow1vvjHoM0FNdts=
+ariga.io/atlas v0.4.3-0.20220708180314-c4867b18d9f8/go.mod h1:ofVetkJqlaWle3mvYmaS2uyFGFcc7dSq436tmxa/Mzk=
+ariga.io/atlas v0.4.3-0.20220711120113-a190b01c6ef9 h1:fCGaHuxbtYaE+OjQGl1hYTq4nwy659FLPVOCySF8MiQ=
+ariga.io/atlas v0.4.3-0.20220711120113-a190b01c6ef9/go.mod h1:ofVetkJqlaWle3mvYmaS2uyFGFcc7dSq436tmxa/Mzk=
+ariga.io/atlas v0.4.3-0.20220713162925-e2eac411c1ee h1:XbEXtwylf0ohKAJcrdVKJs6/fyLrdZItjl10DkFozbw=
+ariga.io/atlas v0.4.3-0.20220713162925-e2eac411c1ee/go.mod h1:ofVetkJqlaWle3mvYmaS2uyFGFcc7dSq436tmxa/Mzk=
+ariga.io/atlas v0.4.3-0.20220713221217-4bf3afd44b23 h1:x13CFp2IZgOzhLIHaY7DetDb7hg0k97BEg79B7ljNsY=
+ariga.io/atlas v0.4.3-0.20220713221217-4bf3afd44b23/go.mod h1:ofVetkJqlaWle3mvYmaS2uyFGFcc7dSq436tmxa/Mzk=
+ariga.io/atlas v0.5.0 h1:9HZclkGI/xsW7IqKZLIMfnUJ0Nkgm1X1nysq4SMkKsg=
+ariga.io/atlas v0.5.0/go.mod h1:ofVetkJqlaWle3mvYmaS2uyFGFcc7dSq436tmxa/Mzk=
 ariga.io/atlas v0.5.1-0.20220714132857-e4805efc4604 h1:HHNqzvInBec35ZfAYlTXUK5xBGGobCBT84SCX7ZO0DU=
 ariga.io/atlas v0.5.1-0.20220714132857-e4805efc4604/go.mod h1:ofVetkJqlaWle3mvYmaS2uyFGFcc7dSq436tmxa/Mzk=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=


### PR DESCRIPTION

This is basically the identical change to #2735, but for NotIn(). Also added tests for both cases.

This bug currently prevents anyone using NotIn() from upgrading from v0.10.x to v0.11.x.