### PR TITLE
entc/gen: skip enum identifier checks in case it has custom Go type

### DIFF
--- a/entc/gen/type.go
+++ b/entc/gen/type.go
@@ -1503,7 +1503,7 @@ func (f Field) enums(lf *load.Field) ([]Enum, error) {
 			return nil, fmt.Errorf("%q field value cannot be empty", f.Name)
 		case values[value]:
 			return nil, fmt.Errorf("duplicate values %q for enum field %q", value, f.Name)
-		case !token.IsIdentifier(name):
+		case !token.IsIdentifier(name) && !f.HasGoType():
 			return nil, fmt.Errorf("enum %q does not have a valid Go identifier (%q)", value, name)
 		default:
 			values[value] = true

--- a/entc/integration/ent/fieldtype/fieldtype.go
+++ b/entc/integration/ent/fieldtype/fieldtype.go
@@ -316,7 +316,7 @@ const DefaultRole role.Role = "READ"
 // RoleValidator is a validator for the "role" field enum values. It is called by the builders before save.
 func RoleValidator(r role.Role) error {
 	switch r {
-	case "ADMIN", "OWNER", "USER", "READ", "WRITE":
+	case "ADMIN", "OWNER", "USER", "READ", "WRITE", "READ+WRITE":
 		return nil
 	default:
 		return fmt.Errorf("fieldtype: invalid enum value for role field: %q", r)

--- a/entc/integration/ent/migrate/schema.go
+++ b/entc/integration/ent/migrate/schema.go
@@ -126,7 +126,7 @@ var (
 		{Name: "schema_float", Type: field.TypeFloat64, Nullable: true},
 		{Name: "schema_float32", Type: field.TypeFloat32, Nullable: true},
 		{Name: "null_float", Type: field.TypeFloat64, Nullable: true},
-		{Name: "role", Type: field.TypeEnum, Enums: []string{"ADMIN", "OWNER", "USER", "READ", "WRITE"}, Default: "READ"},
+		{Name: "role", Type: field.TypeEnum, Enums: []string{"ADMIN", "OWNER", "USER", "READ", "WRITE", "READ+WRITE"}, Default: "READ"},
 		{Name: "priority", Type: field.TypeEnum, Nullable: true, Enums: []string{"UNKNOWN", "LOW", "HIGH"}},
 		{Name: "optional_uuid", Type: field.TypeUUID, Nullable: true},
 		{Name: "nillable_uuid", Type: field.TypeUUID, Nullable: true},

--- a/entc/integration/ent/role/role.go
+++ b/entc/integration/ent/role/role.go
@@ -11,15 +11,16 @@ import (
 type Role string
 
 const (
-	Admin Role = "ADMIN"
-	Owner Role = "OWNER"
-	User  Role = "USER"
-	Read  Role = "READ"
-	Write Role = "WRITE"
+	Admin     Role = "ADMIN"
+	Owner     Role = "OWNER"
+	User      Role = "USER"
+	Read      Role = "READ"
+	Write     Role = "WRITE"
+	ReadWrite Role = "READ+WRITE"
 )
 
 func (Role) Values() (roles []string) {
-	for _, r := range []Role{Admin, Owner, User, Read, Write} {
+	for _, r := range []Role{Admin, Owner, User, Read, Write, ReadWrite} {
 		roles = append(roles, string(r))
 	}
 	return

--- a/entc/integration/gremlin/ent/fieldtype/fieldtype.go
+++ b/entc/integration/gremlin/ent/fieldtype/fieldtype.go
@@ -223,7 +223,7 @@ const DefaultRole role.Role = "READ"
 // RoleValidator is a validator for the "role" field enum values. It is called by the builders before save.
 func RoleValidator(r role.Role) error {
 	switch r {
-	case "ADMIN", "OWNER", "USER", "READ", "WRITE":
+	case "ADMIN", "OWNER", "USER", "READ", "WRITE", "READ+WRITE":
 		return nil
 	default:
 		return fmt.Errorf("fieldtype: invalid enum value for role field: %q", r)


### PR DESCRIPTION
Fixes https://github.com/ent/ent/issues/2756