### PR TITLE
docs: Correct expression on documentation

### DIFF
--- a/doc/md/predicates.md
+++ b/doc/md/predicates.md
@@ -232,7 +232,7 @@ SELECT `id` FROM `users` WHERE DATE(`last_login_at`) >= ?
 users := client.User.Query().
 	Select(user.FieldID).
 	Where(func(s *sql.Selector) {
-		s.Where(sql.ExprP("DATE(last_login_at >= ?", value))
+		s.Where(sql.ExprP("DATE(last_login_at) >= ?", value))
 	}).
 	AllX(ctx)
 ```


### PR DESCRIPTION
An invalide sql statement is provider in documentation, just a missing `)`