### PR TITLE
Add `BuildFlags` to schema loader configuration

### DIFF
--- a/entc/entc.go
+++ b/entc/entc.go
@@ -27,7 +27,7 @@ import (
 // LoadGraph loads the schema package from the given schema path,
 // and constructs a *gen.Graph.
 func LoadGraph(schemaPath string, cfg *gen.Config) (*gen.Graph, error) {
-	spec, err := (&load.Config{Path: schemaPath}).Load()
+	spec, err := (&load.Config{Path: schemaPath, BuildFlags: cfg.BuildFlags}).Load()
 	if err != nil {
 		return nil, err
 	}
@@ -152,6 +152,20 @@ func Annotations(annotations ...Annotation) Option {
 		}
 		return nil
 	}
+}
+
+// BuildFlags appends the given build flags to the codegen config.
+func BuildFlags(flags ...string) Option {
+	return func(cfg *gen.Config) error {
+		cfg.BuildFlags = append(cfg.BuildFlags, flags...)
+		return nil
+	}
+}
+
+// BuildTags appends the given build tags as build flags to the codegen
+// config.
+func BuildTags(tags ...string) Option {
+	return BuildFlags("-tags", strings.Join(tags, ","))
 }
 
 // TemplateFiles parses the named files and associates the resulting templates

--- a/entc/gen/graph.go
+++ b/entc/gen/graph.go
@@ -90,6 +90,10 @@ type (
 		//
 		// Note that the mapping is from the annotation-name (e.g. "GQL") to a JSON decoded object.
 		Annotations Annotations
+
+		// BuildFlags holds a list of custom build flags to use
+		// when loading the schema packages.
+		BuildFlags []string
 	}
 
 	// Graph holds the nodes/entities of the loaded graph schema. Note that, it doesn't

--- a/entc/load/load.go
+++ b/entc/load/load.go
@@ -49,6 +49,9 @@ type (
 		Path string
 		// Names are the schema names to load. Empty means all schemas in the directory.
 		Names []string
+		// BuildFlags are forwarded to the package.Config when
+		// loading the schema package.
+		BuildFlags []string
 	}
 )
 
@@ -104,7 +107,8 @@ var entInterface = reflect.TypeOf(struct{ ent.Interface }{}).Field(0).Type
 // load loads the schemas info.
 func (c *Config) load() (*SchemaSpec, error) {
 	pkgs, err := packages.Load(&packages.Config{
-		Mode: packages.NeedName | packages.NeedTypes | packages.NeedTypesInfo | packages.NeedModule,
+		BuildFlags: c.BuildFlags,
+		Mode:       packages.NeedName | packages.NeedTypes | packages.NeedTypesInfo | packages.NeedModule,
 	}, c.Path, entInterface.PkgPath())
 	if err != nil {
 		return nil, fmt.Errorf("loading package: %w", err)

--- a/entc/load/load_test.go
+++ b/entc/load/load_test.go
@@ -67,3 +67,25 @@ func TestLoadBaseSchema(t *testing.T) {
 	require.Equal(t, "user_field", f2.Name)
 	require.Equal(t, field.TypeString, f2.Info.Type)
 }
+
+func TestLoadTags(t *testing.T) {
+	all, err := (&Config{
+		Path: "./testdata/buildflags",
+	}).Load()
+	require.NoError(t, err)
+
+	require.Len(t, all.Schemas, 2)
+	require.Equal(t, "Group", all.Schemas[0].Name, "ordered alphabetically")
+	require.Equal(t, "User", all.Schemas[1].Name)
+
+	notags, err := (&Config{
+		Path:       "./testdata/buildflags",
+		BuildFlags: []string{"-tags", "hidegroups"},
+	}).Load()
+	require.NoError(t, err)
+
+	require.Len(t, notags.Schemas, 1)
+	require.Equal(t, "User", notags.Schemas[0].Name)
+
+	require.Equal(t, all.Schemas[1], notags.Schemas[0])
+}

--- a/entc/load/testdata/buildflags/group.go
+++ b/entc/load/testdata/buildflags/group.go
@@ -1,0 +1,24 @@
+//go:build !hidegroups
+
+// Copyright 2019-present Facebook Inc. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
+package buildflags
+
+import (
+	"entgo.io/ent"
+	"entgo.io/ent/schema/field"
+)
+
+// Group holds the group schema.
+type Group struct {
+	ent.Schema
+}
+
+func (Group) Fields() []ent.Field {
+	return []ent.Field{
+		field.Time("expired_at"),
+		field.String("organization"),
+	}
+}

--- a/entc/load/testdata/buildflags/user.go
+++ b/entc/load/testdata/buildflags/user.go
@@ -1,0 +1,22 @@
+// Copyright 2019-present Facebook Inc. All rights reserved.
+// This source code is licensed under the Apache 2.0 license found
+// in the LICENSE file in the root directory of this source tree.
+
+package buildflags
+
+import (
+	"entgo.io/ent"
+	"entgo.io/ent/schema/field"
+)
+
+// User holds the user schema.
+type User struct {
+	ent.Schema
+}
+
+func (User) Fields() []ent.Field {
+	return []ent.Field{
+		field.Int("age"),
+		field.String("name"),
+	}
+}


### PR DESCRIPTION
This allows passing arbitrary build flags to the schema package loader,
which in turn can be used to pass build constraints affecting what
schema types and/or methods are visible.

As a particular use case, this should make it easier to implement
two-pass code generation to deal with circular imports in hooks (#892).