### PR TITLE
entc/gen: fix immutable fields updating during bulk upsert

### DIFF
--- a/entc/gen/template/dialect/sql/feature/upsert.tmpl
+++ b/entc/gen/template/dialect/sql/feature/upsert.tmpl
@@ -338,7 +338,6 @@ func (u *{{ $upsertBulk }}) UpdateNewValues() *{{ $upsertBulk }} {
 				{{- if $udfID }}
 					if _, exists := b.mutation.ID(); exists {
 						s.SetIgnore({{ $.Package }}.{{ $.ID.Constant }})
-						return
 					}
 				{{- end }}
 				{{- range $f := $.ImmutableFields }}

--- a/entc/integration/customid/ent/account_create.go
+++ b/entc/integration/customid/ent/account_create.go
@@ -524,7 +524,6 @@ func (u *AccountUpsertBulk) UpdateNewValues() *AccountUpsertBulk {
 		for _, b := range u.create.builders {
 			if _, exists := b.mutation.ID(); exists {
 				s.SetIgnore(account.FieldID)
-				return
 			}
 		}
 	}))

--- a/entc/integration/customid/ent/blob_create.go
+++ b/entc/integration/customid/ent/blob_create.go
@@ -641,7 +641,6 @@ func (u *BlobUpsertBulk) UpdateNewValues() *BlobUpsertBulk {
 		for _, b := range u.create.builders {
 			if _, exists := b.mutation.ID(); exists {
 				s.SetIgnore(blob.FieldID)
-				return
 			}
 		}
 	}))

--- a/entc/integration/customid/ent/car_create.go
+++ b/entc/integration/customid/ent/car_create.go
@@ -663,7 +663,6 @@ func (u *CarUpsertBulk) UpdateNewValues() *CarUpsertBulk {
 		for _, b := range u.create.builders {
 			if _, exists := b.mutation.ID(); exists {
 				s.SetIgnore(car.FieldID)
-				return
 			}
 		}
 	}))

--- a/entc/integration/customid/ent/device_create.go
+++ b/entc/integration/customid/ent/device_create.go
@@ -509,7 +509,6 @@ func (u *DeviceUpsertBulk) UpdateNewValues() *DeviceUpsertBulk {
 		for _, b := range u.create.builders {
 			if _, exists := b.mutation.ID(); exists {
 				s.SetIgnore(device.FieldID)
-				return
 			}
 		}
 	}))

--- a/entc/integration/customid/ent/doc_create.go
+++ b/entc/integration/customid/ent/doc_create.go
@@ -614,7 +614,6 @@ func (u *DocUpsertBulk) UpdateNewValues() *DocUpsertBulk {
 		for _, b := range u.create.builders {
 			if _, exists := b.mutation.ID(); exists {
 				s.SetIgnore(doc.FieldID)
-				return
 			}
 		}
 	}))

--- a/entc/integration/customid/ent/group_create.go
+++ b/entc/integration/customid/ent/group_create.go
@@ -441,7 +441,6 @@ func (u *GroupUpsertBulk) UpdateNewValues() *GroupUpsertBulk {
 		for _, b := range u.create.builders {
 			if _, exists := b.mutation.ID(); exists {
 				s.SetIgnore(group.FieldID)
-				return
 			}
 		}
 	}))

--- a/entc/integration/customid/ent/intsid_create.go
+++ b/entc/integration/customid/ent/intsid_create.go
@@ -484,7 +484,6 @@ func (u *IntSIDUpsertBulk) UpdateNewValues() *IntSIDUpsertBulk {
 		for _, b := range u.create.builders {
 			if _, exists := b.mutation.ID(); exists {
 				s.SetIgnore(intsid.FieldID)
-				return
 			}
 		}
 	}))

--- a/entc/integration/customid/ent/mixinid_create.go
+++ b/entc/integration/customid/ent/mixinid_create.go
@@ -527,7 +527,6 @@ func (u *MixinIDUpsertBulk) UpdateNewValues() *MixinIDUpsertBulk {
 		for _, b := range u.create.builders {
 			if _, exists := b.mutation.ID(); exists {
 				s.SetIgnore(mixinid.FieldID)
-				return
 			}
 		}
 	}))

--- a/entc/integration/customid/ent/note_create.go
+++ b/entc/integration/customid/ent/note_create.go
@@ -580,7 +580,6 @@ func (u *NoteUpsertBulk) UpdateNewValues() *NoteUpsertBulk {
 		for _, b := range u.create.builders {
 			if _, exists := b.mutation.ID(); exists {
 				s.SetIgnore(note.FieldID)
-				return
 			}
 		}
 	}))

--- a/entc/integration/customid/ent/other_create.go
+++ b/entc/integration/customid/ent/other_create.go
@@ -430,7 +430,6 @@ func (u *OtherUpsertBulk) UpdateNewValues() *OtherUpsertBulk {
 		for _, b := range u.create.builders {
 			if _, exists := b.mutation.ID(); exists {
 				s.SetIgnore(other.FieldID)
-				return
 			}
 		}
 	}))

--- a/entc/integration/customid/ent/pet_create.go
+++ b/entc/integration/customid/ent/pet_create.go
@@ -582,7 +582,6 @@ func (u *PetUpsertBulk) UpdateNewValues() *PetUpsertBulk {
 		for _, b := range u.create.builders {
 			if _, exists := b.mutation.ID(); exists {
 				s.SetIgnore(pet.FieldID)
-				return
 			}
 		}
 	}))

--- a/entc/integration/customid/ent/revision_create.go
+++ b/entc/integration/customid/ent/revision_create.go
@@ -411,7 +411,6 @@ func (u *RevisionUpsertBulk) UpdateNewValues() *RevisionUpsertBulk {
 		for _, b := range u.create.builders {
 			if _, exists := b.mutation.ID(); exists {
 				s.SetIgnore(revision.FieldID)
-				return
 			}
 		}
 	}))

--- a/entc/integration/customid/ent/session_create.go
+++ b/entc/integration/customid/ent/session_create.go
@@ -475,7 +475,6 @@ func (u *SessionUpsertBulk) UpdateNewValues() *SessionUpsertBulk {
 		for _, b := range u.create.builders {
 			if _, exists := b.mutation.ID(); exists {
 				s.SetIgnore(session.FieldID)
-				return
 			}
 		}
 	}))

--- a/entc/integration/customid/ent/token_create.go
+++ b/entc/integration/customid/ent/token_create.go
@@ -524,7 +524,6 @@ func (u *TokenUpsertBulk) UpdateNewValues() *TokenUpsertBulk {
 		for _, b := range u.create.builders {
 			if _, exists := b.mutation.ID(); exists {
 				s.SetIgnore(token.FieldID)
-				return
 			}
 		}
 	}))

--- a/entc/integration/customid/ent/user_create.go
+++ b/entc/integration/customid/ent/user_create.go
@@ -549,7 +549,6 @@ func (u *UserUpsertBulk) UpdateNewValues() *UserUpsertBulk {
 		for _, b := range u.create.builders {
 			if _, exists := b.mutation.ID(); exists {
 				s.SetIgnore(user.FieldID)
-				return
 			}
 		}
 	}))

--- a/entc/integration/edgeschema/ent/tweettag_create.go
+++ b/entc/integration/edgeschema/ent/tweettag_create.go
@@ -625,7 +625,6 @@ func (u *TweetTagUpsertBulk) UpdateNewValues() *TweetTagUpsertBulk {
 		for _, b := range u.create.builders {
 			if _, exists := b.mutation.ID(); exists {
 				s.SetIgnore(tweettag.FieldID)
-				return
 			}
 		}
 	}))

--- a/entc/integration/ent/item_create.go
+++ b/entc/integration/ent/item_create.go
@@ -511,7 +511,6 @@ func (u *ItemUpsertBulk) UpdateNewValues() *ItemUpsertBulk {
 		for _, b := range u.create.builders {
 			if _, exists := b.mutation.ID(); exists {
 				s.SetIgnore(item.FieldID)
-				return
 			}
 		}
 	}))

--- a/entc/integration/ent/license_create.go
+++ b/entc/integration/ent/license_create.go
@@ -406,7 +406,6 @@ func (u *LicenseUpsertBulk) UpdateNewValues() *LicenseUpsertBulk {
 		for _, b := range u.create.builders {
 			if _, exists := b.mutation.ID(); exists {
 				s.SetIgnore(license.FieldID)
-				return
 			}
 		}
 	}))


### PR DESCRIPTION
Fixed https://github.com/ent/ent/issues/2000

After https://github.com/ent/ent/pull/2011 immutable fields are still being ignored in case of bulk upsert. Example of generated code before fix:

```go
func (u *MyEntityUpsertBulk) UpdateNewValues() *MyEntityUpsertBulk {
	u.create.conflict = append(u.create.conflict, sql.ResolveWithNewValues())
	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(s *sql.UpdateSet) {
		for _, b := range u.create.builders {
			if _, exists := b.mutation.ID(); exists {
				s.SetIgnore(myentity.FieldID)
				return // <-- if id exists, we will never call SetIgnore for created_at and created_by
			}
			if _, exists := b.mutation.CreatedAt(); exists {
				s.SetIgnore(myentity.FieldCreatedAt)
			}
			if _, exists := b.mutation.CreatedBy(); exists {
				s.SetIgnore(myentity.FieldCreatedBy)
			}
		}
	}))
	return u
}
```