### PR TITLE
dialect/sql: escape EqualFold on Postgres

### DIFF
--- a/dialect/sql/builder.go
+++ b/dialect/sql/builder.go
@@ -1710,14 +1710,17 @@ func (p *Predicate) EqualFold(col, sub string) *Predicate {
 			// We assume the CHARACTER SET is configured to utf8mb4,
 			// because this how it is defined in dialect/sql/schema.
 			b.Ident(col).WriteString(" COLLATE utf8mb4_general_ci = ")
+			b.Arg(strings.ToLower(sub))
 		case dialect.Postgres:
 			b.Ident(col).WriteString(" ILIKE ")
+			w, _ := escape(sub)
+			b.Arg(strings.ToLower(w))
 		default: // SQLite.
 			f.Lower(col)
 			b.WriteString(f.String())
 			b.WriteOp(OpEQ)
+			b.Arg(strings.ToLower(sub))
 		}
-		b.Arg(strings.ToLower(sub))
 	})
 }
 

--- a/dialect/sql/builder_test.go
+++ b/dialect/sql/builder_test.go
@@ -1010,6 +1010,22 @@ func TestBuilder(t *testing.T) {
 			wantArgs:  []interface{}{"bar", "baz"},
 		},
 		{
+			input: Dialect(dialect.Postgres).
+				Select().
+				From(Table("users")).
+				Where(Or(EqualFold("name", "BAR%"), EqualFold("name", "%BAZ"))),
+			wantQuery: `SELECT * FROM "users" WHERE "name" ILIKE $1 OR "name" ILIKE $2`,
+			wantArgs:  []interface{}{"bar\\%", "\\%baz"},
+		},
+		{
+			input: Dialect(dialect.Postgres).
+				Select().
+				From(Table("users")).
+				Where(Or(EqualFold("name", "BAR\\"), EqualFold("name", "\\BAZ"))),
+			wantQuery: `SELECT * FROM "users" WHERE "name" ILIKE $1 OR "name" ILIKE $2`,
+			wantArgs:  []interface{}{"bar\\\\", "\\\\baz"},
+		},
+		{
 			input: Dialect(dialect.MySQL).
 				Select().
 				From(Table("users")).

--- a/entc/integration/integration_test.go
+++ b/entc/integration/integration_test.go
@@ -291,6 +291,10 @@ func Sanity(t *testing.T, client *ent.Client) {
 		require.True(client.Pet.Query().Where(pet.NameContainsFold("A")).ExistX(ctx))
 		require.False(client.Pet.Query().Where(pet.NameContainsFold("%A")).ExistX(ctx))
 		require.False(client.Pet.Query().Where(pet.NameContainsFold("A%")).ExistX(ctx))
+		require.True(client.Pet.Query().Where(pet.NameEqualFold("A_\\")).ExistX(ctx))
+		require.False(client.Pet.Query().Where(pet.NameEqualFold("%A_\\")).ExistX(ctx))
+		require.False(client.Pet.Query().Where(pet.NameEqualFold("A_\\%")).ExistX(ctx))
+		require.False(client.Pet.Query().Where(pet.NameEqualFold("A%")).ExistX(ctx))
 	})
 }
 


### PR DESCRIPTION
Hello 👋, `EqualFold` currently does not escape the argument, this can lead to problems, like returning multiple results when the first/last character of the argument is `%` and `pq: LIKE pattern must not end with escape character` when the first/last  character of the argument is a escape character.

While at it, I revised the points raised on #1484 (from the Postgres point of view). There seems to be a lot of different information about the use of `ILIKE` vs `LOWER` and I could not reach a conclusion.

I think we just leave as is but we should keep in mind that may exists a faster way available, when we have a user that needs it, we could look at it again.

- https://stackoverflow.com/a/41691993
- https://dba.stackexchange.com/questions/89901/lower-vs-ilike-on-postgresql
- https://til.hashrocket.com/posts/e65bb49204-lower-is-faster-than-ilike