### PR TITLE
doc/md: fix package name breaking generate

### DIFF
--- a/doc/md/tutorial-todo-gql.mdx
+++ b/doc/md/tutorial-todo-gql.mdx
@@ -99,7 +99,7 @@ file.
 contents. In next steps, `gqlgen` commands will be added to this file as well.
 
 ```go title="generate.go"
-package ent
+package todo
 
 //go:generate go run -mod=mod ./ent/entc.go
 ```
@@ -215,7 +215,7 @@ func main() {
 4\. Add the `gqlgen` generate command to the `generate.go` file:
 
 ```go title="generate.go"
-package ent
+package todo
 
 //go:generate go run -mod=mod ./ent/entc.go
 //highlight-next-line


### PR DESCRIPTION
I was getting the error below following gql tutorial, had to update package name from ent -> todo


```
validation failed: packages.Load: -: found packages todo (ent.resolvers.go) and ent (generate.go) in /home/broody/development/go_tutorial/ent-graphql-example
/home/broody/development/go_tutorial/ent-graphql-example/generate.go:1:1: package ent; expected todo

exit status 1
generate.go:4: running "go": exit status 1
```