### PR TITLE
doc/md: broken link to "GraphQL example"

### DIFF
--- a/doc/md/tutorial-todo-gql-field-collection.md
+++ b/doc/md/tutorial-todo-gql-field-collection.md
@@ -4,7 +4,7 @@ title: GraphQL Field Collection
 sidebar_label: Field Collection
 ---
 
-In this section, we continue our [GraphQL example](tutorial-todo-gql.md) by explaining how Ent implements
+In this section, we continue our [GraphQL example](tutorial-todo-gql.mdx) by explaining how Ent implements
 [GraphQL Field Collection](https://spec.graphql.org/June2018/#sec-Field-Collection) for our GraphQL schema and solves the
 "N+1 Problem" in our resolvers.
 

--- a/doc/md/tutorial-todo-gql-filter-input.md
+++ b/doc/md/tutorial-todo-gql-filter-input.md
@@ -4,7 +4,7 @@ title: Filter Inputs
 sidebar_label: Filter Inputs
 ---
 
-In this section, we continue the [GraphQL example](tutorial-todo-gql.md) by explaining how to generate
+In this section, we continue the [GraphQL example](tutorial-todo-gql.mdx) by explaining how to generate
 type-safe GraphQL filters (i.e. `Where` predicates) from our `ent/schema`, and allow users to seamlessly
 map GraphQL queries to Ent queries. For example, the following GraphQL query, maps to the Ent query below:
 

--- a/doc/md/tutorial-todo-gql-mutation-input.md
+++ b/doc/md/tutorial-todo-gql-mutation-input.md
@@ -4,7 +4,7 @@ title: Mutation Inputs
 sidebar_label: Mutation Inputs
 ---
 
-In this section, we continue the [GraphQL example](tutorial-todo-gql.md) by explaining how to extend the Ent code
+In this section, we continue the [GraphQL example](tutorial-todo-gql.mdx) by explaining how to extend the Ent code
 generator using Go templates and generate [input type](https://graphql.org/graphql-js/mutations-and-input-types/)
 objects for our GraphQL mutations that can be applied directly on Ent mutations.
 

--- a/doc/md/tutorial-todo-gql-node.md
+++ b/doc/md/tutorial-todo-gql-node.md
@@ -4,7 +4,7 @@ title: Relay Node Interface
 sidebar_label: Relay Node Interface
 ---
 
-In this section, we continue the [GraphQL example](tutorial-todo-gql.md) by explaining how to implement the 
+In this section, we continue the [GraphQL example](tutorial-todo-gql.mdx) by explaining how to implement the
 [Relay Node Interface](https://relay.dev/graphql/objectidentification.htm). If you're not familiar with the
 Node interface, read the following paragraphs that were taken from [relay.dev](https://relay.dev/graphql/objectidentification.htm#sel-DABDDBAADLA0Cl0c):
 

--- a/doc/md/tutorial-todo-gql-paginate.md
+++ b/doc/md/tutorial-todo-gql-paginate.md
@@ -4,7 +4,7 @@ title: Relay Cursor Connections (Pagination)
 sidebar_label: Relay Cursor Connections
 ---
 
-In this section, we continue the [GraphQL example](tutorial-todo-gql.md) by explaining how to implement the 
+In this section, we continue the [GraphQL example](tutorial-todo-gql.mdx) by explaining how to implement the
 [Relay Cursor Connections Spec](https://relay.dev/graphql/connections.htm). If you're not familiar with the
 Cursor Connections interface, read the following paragraphs that were taken from [relay.dev](https://relay.dev/graphql/connections.htm#sel-DABDDDAADFA0E3kM):
 

--- a/doc/md/tutorial-todo-gql-schema-generator.md
+++ b/doc/md/tutorial-todo-gql-schema-generator.md
@@ -4,7 +4,7 @@ title: Schema Generator
 sidebar_label: Schema Generator
 ---
 
-In this section, we will continue the [GraphQL example](tutorial-todo-gql.md) by explaining how to generate a
+In this section, we will continue the [GraphQL example](tutorial-todo-gql.mdx) by explaining how to generate a
 type-safe GraphQL schema from our `ent/schema`.
 
 ### Configure Ent

--- a/doc/md/tutorial-todo-gql-tx-mutation.md
+++ b/doc/md/tutorial-todo-gql-tx-mutation.md
@@ -4,7 +4,7 @@ title: Transactional Mutations
 sidebar_label: Transactional Mutations
 ---
 
-In this section, we continue the [GraphQL example](tutorial-todo-gql.md) by explaining how to set our GraphQL mutations
+In this section, we continue the [GraphQL example](tutorial-todo-gql.mdx) by explaining how to set our GraphQL mutations
 to be transactional. That means, to automatically wrap our GraphQL mutations with a database transaction and either
 commit at the end, or rollback the transaction in case of a GraphQL error.
 


### PR DESCRIPTION
one of the examples.

https://entgo.io/docs/tutorial-todo-gql-field-collection
link to "GraphQL example".