### PR TITLE
entc: remove space around `continue` for 1.18 compatible 

### DIFF
--- a/entc/gen/template/builder/setter.tmpl
+++ b/entc/gen/template/builder/setter.tmpl
@@ -66,7 +66,7 @@ in the LICENSE file in the root directory of this source tree.
 {{ range $e := $.EdgesWithID }}
 	{{ if and $updater $e.Immutable }}
 		{{/* Skip to the next one as immutable edges cannot be updated. */}}
-		{{ continue }}
+		{{continue}}
 	{{ end }}
 	{{ $op := "add" }}{{ $idsFunc := $e.MutationAdd }}{{ if $e.Unique }}{{ $op = "set" }}{{ $idsFunc = $e.MutationSet }}{{ end }}
 	{{/* Check if this setter was already defined by the field-setters (e.g. edge-field with the same name). */}}

--- a/entc/gen/template/builder/update.tmpl
+++ b/entc/gen/template/builder/update.tmpl
@@ -270,7 +270,7 @@ func ({{ $receiver }} *{{ $onebuilder }}) ExecX(ctx context.Context) {
 {{ range $e := $.EdgesWithID }}
 	{{ if $e.Immutable }}
 		{{/* Skip to the next one as immutable edges cannot be updated. */}}
-		{{ continue }}
+		{{continue}}
 	{{ end }}
 	{{ $func := $e.MutationClear }}
 	// {{ $func }} clears {{ if $e.Unique }}the "{{ $e.Name }}" edge{{ else }}all "{{ $e.Name }}" edges{{ end }} to the {{ $e.Type.Name }} entity.

--- a/entc/gen/template/dialect/sql/update.tmpl
+++ b/entc/gen/template/dialect/sql/update.tmpl
@@ -129,7 +129,7 @@ func ({{ $receiver }} *{{ $builder }}) sqlSave(ctx context.Context) ({{ $ret }} 
 	{{- range $e := $.EdgesWithID }}
 		{{- if $e.Immutable }}
 			{{- /* Skip to the next one as immutable edges cannot be updated. */}}
-			{{- continue }}
+			{{- continue}}
 		{{- end }}
 		if {{ $mutation }}.{{ $e.MutationCleared }}() {
 			{{- with extend $ "Edge" $e }}


### PR DESCRIPTION
Close: https://github.com/ent/ent/issues/2938