### PR TITLE
Remove unused variable and type redundancy

### DIFF
--- a/entc/gen/template/client.tmpl
+++ b/entc/gen/template/client.tmpl
@@ -258,7 +258,7 @@ func (c *{{ $client }}) Query() *{{ $n.QueryName }} {
 func (c *{{ $client }}) {{ $func }}({{ $arg }} *{{ $n.Name }}) *{{ $builder }} {
 	{{- if $n.HasOneFieldID }}
 		query := &{{ $builder }}{config: c.config}
-		query.path = func(ctx context.Context) (fromV {{ $.Storage.Builder }}, _ error) {
+		query.path = func(context.Context) (fromV {{ $.Storage.Builder }}, _ error) {
 			{{- with extend $n "Receiver" $arg "Edge" $e "Ident" "fromV" }}
 				{{ $tmpl := printf "dialect/%s/query/from" $.Storage }}
 				{{- xtemplate $tmpl . -}}

--- a/entc/gen/template/dialect/sql/query.tmpl
+++ b/entc/gen/template/dialect/sql/query.tmpl
@@ -136,7 +136,7 @@ func ({{ $receiver }} *{{ $builder }}) sqlAll(ctx context.Context, hooks ...quer
 					outValue := {{ with extend $ "Arg" "values[0]" "Field" $.ID "ScanType" $out }}{{ template "dialect/sql/query/eagerloading/m2massign" . }}{{ end }}
 					inValue := {{ with extend $ "Arg" "values[1]" "Field" $e.Type.ID "ScanType" $in }}{{ template "dialect/sql/query/eagerloading/m2massign" . }}{{ end }}
 					if nids[inValue] == nil {
-						nids[inValue] = map[*{{ $.Name }}]struct{}{byID[outValue]: struct{}{}}
+						nids[inValue] = map[*{{ $.Name }}]struct{}{byID[outValue]: {}}
 						return assign(columns[1:], values[1:])
 					}
 					nids[inValue][byID[outValue]] = struct{}{}

--- a/entc/integration/cascadelete/ent/client.go
+++ b/entc/integration/cascadelete/ent/client.go
@@ -229,7 +229,7 @@ func (c *CommentClient) GetX(ctx context.Context, id int) *Comment {
 // QueryPost queries the post edge of a Comment.
 func (c *CommentClient) QueryPost(co *Comment) *PostQuery {
 	query := &PostQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := co.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(comment.Table, comment.FieldID, id),
@@ -335,7 +335,7 @@ func (c *PostClient) GetX(ctx context.Context, id int) *Post {
 // QueryAuthor queries the author edge of a Post.
 func (c *PostClient) QueryAuthor(po *Post) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := po.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(post.Table, post.FieldID, id),
@@ -351,7 +351,7 @@ func (c *PostClient) QueryAuthor(po *Post) *UserQuery {
 // QueryComments queries the comments edge of a Post.
 func (c *PostClient) QueryComments(po *Post) *CommentQuery {
 	query := &CommentQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := po.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(post.Table, post.FieldID, id),
@@ -457,7 +457,7 @@ func (c *UserClient) GetX(ctx context.Context, id int) *User {
 // QueryPosts queries the posts edge of a User.
 func (c *UserClient) QueryPosts(u *User) *PostQuery {
 	query := &PostQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),

--- a/entc/integration/customid/ent/blob_query.go
+++ b/entc/integration/customid/ent/blob_query.go
@@ -548,7 +548,7 @@ func (bq *BlobQuery) loadLinks(ctx context.Context, query *BlobQuery, nodes []*B
 			outValue := *values[0].(*uuid.UUID)
 			inValue := *values[1].(*uuid.UUID)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*Blob]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*Blob]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/entc/integration/customid/ent/client.go
+++ b/entc/integration/customid/ent/client.go
@@ -331,7 +331,7 @@ func (c *AccountClient) GetX(ctx context.Context, id sid.ID) *Account {
 // QueryToken queries the token edge of a Account.
 func (c *AccountClient) QueryToken(a *Account) *TokenQuery {
 	query := &TokenQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := a.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(account.Table, account.FieldID, id),
@@ -437,7 +437,7 @@ func (c *BlobClient) GetX(ctx context.Context, id uuid.UUID) *Blob {
 // QueryParent queries the parent edge of a Blob.
 func (c *BlobClient) QueryParent(b *Blob) *BlobQuery {
 	query := &BlobQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := b.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(blob.Table, blob.FieldID, id),
@@ -453,7 +453,7 @@ func (c *BlobClient) QueryParent(b *Blob) *BlobQuery {
 // QueryLinks queries the links edge of a Blob.
 func (c *BlobClient) QueryLinks(b *Blob) *BlobQuery {
 	query := &BlobQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := b.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(blob.Table, blob.FieldID, id),
@@ -469,7 +469,7 @@ func (c *BlobClient) QueryLinks(b *Blob) *BlobQuery {
 // QueryBlobLinks queries the blob_links edge of a Blob.
 func (c *BlobClient) QueryBlobLinks(b *Blob) *BlobLinkQuery {
 	query := &BlobLinkQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := b.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(blob.Table, blob.FieldID, id),
@@ -648,7 +648,7 @@ func (c *CarClient) GetX(ctx context.Context, id int) *Car {
 // QueryOwner queries the owner edge of a Car.
 func (c *CarClient) QueryOwner(ca *Car) *PetQuery {
 	query := &PetQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := ca.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(car.Table, car.FieldID, id),
@@ -754,7 +754,7 @@ func (c *DeviceClient) GetX(ctx context.Context, id schema.ID) *Device {
 // QueryActiveSession queries the active_session edge of a Device.
 func (c *DeviceClient) QueryActiveSession(d *Device) *SessionQuery {
 	query := &SessionQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := d.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(device.Table, device.FieldID, id),
@@ -770,7 +770,7 @@ func (c *DeviceClient) QueryActiveSession(d *Device) *SessionQuery {
 // QuerySessions queries the sessions edge of a Device.
 func (c *DeviceClient) QuerySessions(d *Device) *SessionQuery {
 	query := &SessionQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := d.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(device.Table, device.FieldID, id),
@@ -876,7 +876,7 @@ func (c *DocClient) GetX(ctx context.Context, id schema.DocID) *Doc {
 // QueryParent queries the parent edge of a Doc.
 func (c *DocClient) QueryParent(d *Doc) *DocQuery {
 	query := &DocQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := d.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(doc.Table, doc.FieldID, id),
@@ -892,7 +892,7 @@ func (c *DocClient) QueryParent(d *Doc) *DocQuery {
 // QueryChildren queries the children edge of a Doc.
 func (c *DocClient) QueryChildren(d *Doc) *DocQuery {
 	query := &DocQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := d.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(doc.Table, doc.FieldID, id),
@@ -908,7 +908,7 @@ func (c *DocClient) QueryChildren(d *Doc) *DocQuery {
 // QueryRelated queries the related edge of a Doc.
 func (c *DocClient) QueryRelated(d *Doc) *DocQuery {
 	query := &DocQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := d.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(doc.Table, doc.FieldID, id),
@@ -1014,7 +1014,7 @@ func (c *GroupClient) GetX(ctx context.Context, id int) *Group {
 // QueryUsers queries the users edge of a Group.
 func (c *GroupClient) QueryUsers(gr *Group) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := gr.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(group.Table, group.FieldID, id),
@@ -1120,7 +1120,7 @@ func (c *IntSIDClient) GetX(ctx context.Context, id sid.ID) *IntSID {
 // QueryParent queries the parent edge of a IntSID.
 func (c *IntSIDClient) QueryParent(is *IntSID) *IntSIDQuery {
 	query := &IntSIDQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := is.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(intsid.Table, intsid.FieldID, id),
@@ -1136,7 +1136,7 @@ func (c *IntSIDClient) QueryParent(is *IntSID) *IntSIDQuery {
 // QueryChildren queries the children edge of a IntSID.
 func (c *IntSIDClient) QueryChildren(is *IntSID) *IntSIDQuery {
 	query := &IntSIDQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := is.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(intsid.Table, intsid.FieldID, id),
@@ -1422,7 +1422,7 @@ func (c *NoteClient) GetX(ctx context.Context, id schema.NoteID) *Note {
 // QueryParent queries the parent edge of a Note.
 func (c *NoteClient) QueryParent(n *Note) *NoteQuery {
 	query := &NoteQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := n.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(note.Table, note.FieldID, id),
@@ -1438,7 +1438,7 @@ func (c *NoteClient) QueryParent(n *Note) *NoteQuery {
 // QueryChildren queries the children edge of a Note.
 func (c *NoteClient) QueryChildren(n *Note) *NoteQuery {
 	query := &NoteQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := n.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(note.Table, note.FieldID, id),
@@ -1634,7 +1634,7 @@ func (c *PetClient) GetX(ctx context.Context, id string) *Pet {
 // QueryOwner queries the owner edge of a Pet.
 func (c *PetClient) QueryOwner(pe *Pet) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := pe.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(pet.Table, pet.FieldID, id),
@@ -1650,7 +1650,7 @@ func (c *PetClient) QueryOwner(pe *Pet) *UserQuery {
 // QueryCars queries the cars edge of a Pet.
 func (c *PetClient) QueryCars(pe *Pet) *CarQuery {
 	query := &CarQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := pe.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(pet.Table, pet.FieldID, id),
@@ -1666,7 +1666,7 @@ func (c *PetClient) QueryCars(pe *Pet) *CarQuery {
 // QueryFriends queries the friends edge of a Pet.
 func (c *PetClient) QueryFriends(pe *Pet) *PetQuery {
 	query := &PetQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := pe.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(pet.Table, pet.FieldID, id),
@@ -1682,7 +1682,7 @@ func (c *PetClient) QueryFriends(pe *Pet) *PetQuery {
 // QueryBestFriend queries the best_friend edge of a Pet.
 func (c *PetClient) QueryBestFriend(pe *Pet) *PetQuery {
 	query := &PetQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := pe.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(pet.Table, pet.FieldID, id),
@@ -1878,7 +1878,7 @@ func (c *SessionClient) GetX(ctx context.Context, id schema.ID) *Session {
 // QueryDevice queries the device edge of a Session.
 func (c *SessionClient) QueryDevice(s *Session) *DeviceQuery {
 	query := &DeviceQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := s.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(session.Table, session.FieldID, id),
@@ -1984,7 +1984,7 @@ func (c *TokenClient) GetX(ctx context.Context, id sid.ID) *Token {
 // QueryAccount queries the account edge of a Token.
 func (c *TokenClient) QueryAccount(t *Token) *AccountQuery {
 	query := &AccountQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := t.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(token.Table, token.FieldID, id),
@@ -2090,7 +2090,7 @@ func (c *UserClient) GetX(ctx context.Context, id int) *User {
 // QueryGroups queries the groups edge of a User.
 func (c *UserClient) QueryGroups(u *User) *GroupQuery {
 	query := &GroupQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -2106,7 +2106,7 @@ func (c *UserClient) QueryGroups(u *User) *GroupQuery {
 // QueryParent queries the parent edge of a User.
 func (c *UserClient) QueryParent(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -2122,7 +2122,7 @@ func (c *UserClient) QueryParent(u *User) *UserQuery {
 // QueryChildren queries the children edge of a User.
 func (c *UserClient) QueryChildren(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -2138,7 +2138,7 @@ func (c *UserClient) QueryChildren(u *User) *UserQuery {
 // QueryPets queries the pets edge of a User.
 func (c *UserClient) QueryPets(u *User) *PetQuery {
 	query := &PetQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),

--- a/entc/integration/customid/ent/doc_query.go
+++ b/entc/integration/customid/ent/doc_query.go
@@ -578,7 +578,7 @@ func (dq *DocQuery) loadRelated(ctx context.Context, query *DocQuery, nodes []*D
 			outValue := *values[0].(*schema.DocID)
 			inValue := *values[1].(*schema.DocID)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*Doc]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*Doc]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/entc/integration/customid/ent/group_query.go
+++ b/entc/integration/customid/ent/group_query.go
@@ -403,7 +403,7 @@ func (gq *GroupQuery) loadUsers(ctx context.Context, query *UserQuery, nodes []*
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*Group]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*Group]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/entc/integration/customid/ent/pet_query.go
+++ b/entc/integration/customid/ent/pet_query.go
@@ -599,7 +599,7 @@ func (pq *PetQuery) loadFriends(ctx context.Context, query *PetQuery, nodes []*P
 			outValue := values[0].(*sql.NullString).String
 			inValue := values[1].(*sql.NullString).String
 			if nids[inValue] == nil {
-				nids[inValue] = map[*Pet]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*Pet]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/entc/integration/customid/ent/user_query.go
+++ b/entc/integration/customid/ent/user_query.go
@@ -540,7 +540,7 @@ func (uq *UserQuery) loadGroups(ctx context.Context, query *GroupQuery, nodes []
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*User]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*User]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/entc/integration/edgefield/ent/client.go
+++ b/entc/integration/edgefield/ent/client.go
@@ -272,7 +272,7 @@ func (c *CarClient) GetX(ctx context.Context, id uuid.UUID) *Car {
 // QueryRentals queries the rentals edge of a Car.
 func (c *CarClient) QueryRentals(ca *Car) *RentalQuery {
 	query := &RentalQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := ca.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(car.Table, car.FieldID, id),
@@ -378,7 +378,7 @@ func (c *CardClient) GetX(ctx context.Context, id int) *Card {
 // QueryOwner queries the owner edge of a Card.
 func (c *CardClient) QueryOwner(ca *Card) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := ca.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(card.Table, card.FieldID, id),
@@ -484,7 +484,7 @@ func (c *InfoClient) GetX(ctx context.Context, id int) *Info {
 // QueryUser queries the user edge of a Info.
 func (c *InfoClient) QueryUser(i *Info) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := i.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(info.Table, info.FieldID, id),
@@ -590,7 +590,7 @@ func (c *MetadataClient) GetX(ctx context.Context, id int) *Metadata {
 // QueryUser queries the user edge of a Metadata.
 func (c *MetadataClient) QueryUser(m *Metadata) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := m.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(metadata.Table, metadata.FieldID, id),
@@ -606,7 +606,7 @@ func (c *MetadataClient) QueryUser(m *Metadata) *UserQuery {
 // QueryChildren queries the children edge of a Metadata.
 func (c *MetadataClient) QueryChildren(m *Metadata) *MetadataQuery {
 	query := &MetadataQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := m.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(metadata.Table, metadata.FieldID, id),
@@ -622,7 +622,7 @@ func (c *MetadataClient) QueryChildren(m *Metadata) *MetadataQuery {
 // QueryParent queries the parent edge of a Metadata.
 func (c *MetadataClient) QueryParent(m *Metadata) *MetadataQuery {
 	query := &MetadataQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := m.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(metadata.Table, metadata.FieldID, id),
@@ -728,7 +728,7 @@ func (c *NodeClient) GetX(ctx context.Context, id int) *Node {
 // QueryPrev queries the prev edge of a Node.
 func (c *NodeClient) QueryPrev(n *Node) *NodeQuery {
 	query := &NodeQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := n.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(node.Table, node.FieldID, id),
@@ -744,7 +744,7 @@ func (c *NodeClient) QueryPrev(n *Node) *NodeQuery {
 // QueryNext queries the next edge of a Node.
 func (c *NodeClient) QueryNext(n *Node) *NodeQuery {
 	query := &NodeQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := n.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(node.Table, node.FieldID, id),
@@ -850,7 +850,7 @@ func (c *PetClient) GetX(ctx context.Context, id int) *Pet {
 // QueryOwner queries the owner edge of a Pet.
 func (c *PetClient) QueryOwner(pe *Pet) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := pe.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(pet.Table, pet.FieldID, id),
@@ -956,7 +956,7 @@ func (c *PostClient) GetX(ctx context.Context, id int) *Post {
 // QueryAuthor queries the author edge of a Post.
 func (c *PostClient) QueryAuthor(po *Post) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := po.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(post.Table, post.FieldID, id),
@@ -1062,7 +1062,7 @@ func (c *RentalClient) GetX(ctx context.Context, id int) *Rental {
 // QueryUser queries the user edge of a Rental.
 func (c *RentalClient) QueryUser(r *Rental) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := r.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(rental.Table, rental.FieldID, id),
@@ -1078,7 +1078,7 @@ func (c *RentalClient) QueryUser(r *Rental) *UserQuery {
 // QueryCar queries the car edge of a Rental.
 func (c *RentalClient) QueryCar(r *Rental) *CarQuery {
 	query := &CarQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := r.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(rental.Table, rental.FieldID, id),
@@ -1184,7 +1184,7 @@ func (c *UserClient) GetX(ctx context.Context, id int) *User {
 // QueryPets queries the pets edge of a User.
 func (c *UserClient) QueryPets(u *User) *PetQuery {
 	query := &PetQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -1200,7 +1200,7 @@ func (c *UserClient) QueryPets(u *User) *PetQuery {
 // QueryParent queries the parent edge of a User.
 func (c *UserClient) QueryParent(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -1216,7 +1216,7 @@ func (c *UserClient) QueryParent(u *User) *UserQuery {
 // QueryChildren queries the children edge of a User.
 func (c *UserClient) QueryChildren(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -1232,7 +1232,7 @@ func (c *UserClient) QueryChildren(u *User) *UserQuery {
 // QuerySpouse queries the spouse edge of a User.
 func (c *UserClient) QuerySpouse(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -1248,7 +1248,7 @@ func (c *UserClient) QuerySpouse(u *User) *UserQuery {
 // QueryCard queries the card edge of a User.
 func (c *UserClient) QueryCard(u *User) *CardQuery {
 	query := &CardQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -1264,7 +1264,7 @@ func (c *UserClient) QueryCard(u *User) *CardQuery {
 // QueryMetadata queries the metadata edge of a User.
 func (c *UserClient) QueryMetadata(u *User) *MetadataQuery {
 	query := &MetadataQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -1280,7 +1280,7 @@ func (c *UserClient) QueryMetadata(u *User) *MetadataQuery {
 // QueryInfo queries the info edge of a User.
 func (c *UserClient) QueryInfo(u *User) *InfoQuery {
 	query := &InfoQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -1296,7 +1296,7 @@ func (c *UserClient) QueryInfo(u *User) *InfoQuery {
 // QueryRentals queries the rentals edge of a User.
 func (c *UserClient) QueryRentals(u *User) *RentalQuery {
 	query := &RentalQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),

--- a/entc/integration/edgeschema/ent/client.go
+++ b/entc/integration/edgeschema/ent/client.go
@@ -300,7 +300,7 @@ func (c *FriendshipClient) GetX(ctx context.Context, id int) *Friendship {
 // QueryUser queries the user edge of a Friendship.
 func (c *FriendshipClient) QueryUser(f *Friendship) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := f.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(friendship.Table, friendship.FieldID, id),
@@ -316,7 +316,7 @@ func (c *FriendshipClient) QueryUser(f *Friendship) *UserQuery {
 // QueryFriend queries the friend edge of a Friendship.
 func (c *FriendshipClient) QueryFriend(f *Friendship) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := f.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(friendship.Table, friendship.FieldID, id),
@@ -422,7 +422,7 @@ func (c *GroupClient) GetX(ctx context.Context, id int) *Group {
 // QueryUsers queries the users edge of a Group.
 func (c *GroupClient) QueryUsers(gr *Group) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := gr.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(group.Table, group.FieldID, id),
@@ -438,7 +438,7 @@ func (c *GroupClient) QueryUsers(gr *Group) *UserQuery {
 // QueryJoinedUsers queries the joined_users edge of a Group.
 func (c *GroupClient) QueryJoinedUsers(gr *Group) *UserGroupQuery {
 	query := &UserGroupQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := gr.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(group.Table, group.FieldID, id),
@@ -714,7 +714,7 @@ func (c *RoleClient) GetX(ctx context.Context, id int) *Role {
 // QueryUser queries the user edge of a Role.
 func (c *RoleClient) QueryUser(r *Role) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := r.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(role.Table, role.FieldID, id),
@@ -730,7 +730,7 @@ func (c *RoleClient) QueryUser(r *Role) *UserQuery {
 // QueryRolesUsers queries the roles_users edge of a Role.
 func (c *RoleClient) QueryRolesUsers(r *Role) *RoleUserQuery {
 	query := &RoleUserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := r.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(role.Table, role.FieldID, id),
@@ -909,7 +909,7 @@ func (c *TagClient) GetX(ctx context.Context, id int) *Tag {
 // QueryTweets queries the tweets edge of a Tag.
 func (c *TagClient) QueryTweets(t *Tag) *TweetQuery {
 	query := &TweetQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := t.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(tag.Table, tag.FieldID, id),
@@ -925,7 +925,7 @@ func (c *TagClient) QueryTweets(t *Tag) *TweetQuery {
 // QueryTweetTags queries the tweet_tags edge of a Tag.
 func (c *TagClient) QueryTweetTags(t *Tag) *TweetTagQuery {
 	query := &TweetTagQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := t.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(tag.Table, tag.FieldID, id),
@@ -1031,7 +1031,7 @@ func (c *TweetClient) GetX(ctx context.Context, id int) *Tweet {
 // QueryLikedUsers queries the liked_users edge of a Tweet.
 func (c *TweetClient) QueryLikedUsers(t *Tweet) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := t.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(tweet.Table, tweet.FieldID, id),
@@ -1047,7 +1047,7 @@ func (c *TweetClient) QueryLikedUsers(t *Tweet) *UserQuery {
 // QueryUser queries the user edge of a Tweet.
 func (c *TweetClient) QueryUser(t *Tweet) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := t.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(tweet.Table, tweet.FieldID, id),
@@ -1063,7 +1063,7 @@ func (c *TweetClient) QueryUser(t *Tweet) *UserQuery {
 // QueryTags queries the tags edge of a Tweet.
 func (c *TweetClient) QueryTags(t *Tweet) *TagQuery {
 	query := &TagQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := t.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(tweet.Table, tweet.FieldID, id),
@@ -1079,7 +1079,7 @@ func (c *TweetClient) QueryTags(t *Tweet) *TagQuery {
 // QueryLikes queries the likes edge of a Tweet.
 func (c *TweetClient) QueryLikes(t *Tweet) *TweetLikeQuery {
 	query := &TweetLikeQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := t.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(tweet.Table, tweet.FieldID, id),
@@ -1095,7 +1095,7 @@ func (c *TweetClient) QueryLikes(t *Tweet) *TweetLikeQuery {
 // QueryTweetUser queries the tweet_user edge of a Tweet.
 func (c *TweetClient) QueryTweetUser(t *Tweet) *UserTweetQuery {
 	query := &UserTweetQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := t.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(tweet.Table, tweet.FieldID, id),
@@ -1111,7 +1111,7 @@ func (c *TweetClient) QueryTweetUser(t *Tweet) *UserTweetQuery {
 // QueryTweetTags queries the tweet_tags edge of a Tweet.
 func (c *TweetClient) QueryTweetTags(t *Tweet) *TweetTagQuery {
 	query := &TweetTagQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := t.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(tweet.Table, tweet.FieldID, id),
@@ -1291,7 +1291,7 @@ func (c *TweetTagClient) GetX(ctx context.Context, id uuid.UUID) *TweetTag {
 // QueryTag queries the tag edge of a TweetTag.
 func (c *TweetTagClient) QueryTag(tt *TweetTag) *TagQuery {
 	query := &TagQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := tt.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(tweettag.Table, tweettag.FieldID, id),
@@ -1307,7 +1307,7 @@ func (c *TweetTagClient) QueryTag(tt *TweetTag) *TagQuery {
 // QueryTweet queries the tweet edge of a TweetTag.
 func (c *TweetTagClient) QueryTweet(tt *TweetTag) *TweetQuery {
 	query := &TweetQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := tt.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(tweettag.Table, tweettag.FieldID, id),
@@ -1413,7 +1413,7 @@ func (c *UserClient) GetX(ctx context.Context, id int) *User {
 // QueryGroups queries the groups edge of a User.
 func (c *UserClient) QueryGroups(u *User) *GroupQuery {
 	query := &GroupQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -1429,7 +1429,7 @@ func (c *UserClient) QueryGroups(u *User) *GroupQuery {
 // QueryFriends queries the friends edge of a User.
 func (c *UserClient) QueryFriends(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -1445,7 +1445,7 @@ func (c *UserClient) QueryFriends(u *User) *UserQuery {
 // QueryRelatives queries the relatives edge of a User.
 func (c *UserClient) QueryRelatives(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -1461,7 +1461,7 @@ func (c *UserClient) QueryRelatives(u *User) *UserQuery {
 // QueryLikedTweets queries the liked_tweets edge of a User.
 func (c *UserClient) QueryLikedTweets(u *User) *TweetQuery {
 	query := &TweetQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -1477,7 +1477,7 @@ func (c *UserClient) QueryLikedTweets(u *User) *TweetQuery {
 // QueryTweets queries the tweets edge of a User.
 func (c *UserClient) QueryTweets(u *User) *TweetQuery {
 	query := &TweetQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -1493,7 +1493,7 @@ func (c *UserClient) QueryTweets(u *User) *TweetQuery {
 // QueryRoles queries the roles edge of a User.
 func (c *UserClient) QueryRoles(u *User) *RoleQuery {
 	query := &RoleQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -1509,7 +1509,7 @@ func (c *UserClient) QueryRoles(u *User) *RoleQuery {
 // QueryJoinedGroups queries the joined_groups edge of a User.
 func (c *UserClient) QueryJoinedGroups(u *User) *UserGroupQuery {
 	query := &UserGroupQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -1525,7 +1525,7 @@ func (c *UserClient) QueryJoinedGroups(u *User) *UserGroupQuery {
 // QueryFriendships queries the friendships edge of a User.
 func (c *UserClient) QueryFriendships(u *User) *FriendshipQuery {
 	query := &FriendshipQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -1541,7 +1541,7 @@ func (c *UserClient) QueryFriendships(u *User) *FriendshipQuery {
 // QueryRelationship queries the relationship edge of a User.
 func (c *UserClient) QueryRelationship(u *User) *RelationshipQuery {
 	query := &RelationshipQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -1557,7 +1557,7 @@ func (c *UserClient) QueryRelationship(u *User) *RelationshipQuery {
 // QueryLikes queries the likes edge of a User.
 func (c *UserClient) QueryLikes(u *User) *TweetLikeQuery {
 	query := &TweetLikeQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -1573,7 +1573,7 @@ func (c *UserClient) QueryLikes(u *User) *TweetLikeQuery {
 // QueryUserTweets queries the user_tweets edge of a User.
 func (c *UserClient) QueryUserTweets(u *User) *UserTweetQuery {
 	query := &UserTweetQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -1589,7 +1589,7 @@ func (c *UserClient) QueryUserTweets(u *User) *UserTweetQuery {
 // QueryRolesUsers queries the roles_users edge of a User.
 func (c *UserClient) QueryRolesUsers(u *User) *RoleUserQuery {
 	query := &RoleUserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -1696,7 +1696,7 @@ func (c *UserGroupClient) GetX(ctx context.Context, id int) *UserGroup {
 // QueryUser queries the user edge of a UserGroup.
 func (c *UserGroupClient) QueryUser(ug *UserGroup) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := ug.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(usergroup.Table, usergroup.FieldID, id),
@@ -1712,7 +1712,7 @@ func (c *UserGroupClient) QueryUser(ug *UserGroup) *UserQuery {
 // QueryGroup queries the group edge of a UserGroup.
 func (c *UserGroupClient) QueryGroup(ug *UserGroup) *GroupQuery {
 	query := &GroupQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := ug.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(usergroup.Table, usergroup.FieldID, id),
@@ -1818,7 +1818,7 @@ func (c *UserTweetClient) GetX(ctx context.Context, id int) *UserTweet {
 // QueryUser queries the user edge of a UserTweet.
 func (c *UserTweetClient) QueryUser(ut *UserTweet) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := ut.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(usertweet.Table, usertweet.FieldID, id),
@@ -1834,7 +1834,7 @@ func (c *UserTweetClient) QueryUser(ut *UserTweet) *UserQuery {
 // QueryTweet queries the tweet edge of a UserTweet.
 func (c *UserTweetClient) QueryTweet(ut *UserTweet) *TweetQuery {
 	query := &TweetQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := ut.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(usertweet.Table, usertweet.FieldID, id),

--- a/entc/integration/edgeschema/ent/group_query.go
+++ b/entc/integration/edgeschema/ent/group_query.go
@@ -469,7 +469,7 @@ func (gq *GroupQuery) loadUsers(ctx context.Context, query *UserQuery, nodes []*
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*Group]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*Group]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/entc/integration/edgeschema/ent/role_query.go
+++ b/entc/integration/edgeschema/ent/role_query.go
@@ -469,7 +469,7 @@ func (rq *RoleQuery) loadUser(ctx context.Context, query *UserQuery, nodes []*Ro
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*Role]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*Role]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/entc/integration/edgeschema/ent/tag_query.go
+++ b/entc/integration/edgeschema/ent/tag_query.go
@@ -469,7 +469,7 @@ func (tq *TagQuery) loadTweets(ctx context.Context, query *TweetQuery, nodes []*
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*Tag]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*Tag]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/entc/integration/edgeschema/ent/tweet_query.go
+++ b/entc/integration/edgeschema/ent/tweet_query.go
@@ -644,7 +644,7 @@ func (tq *TweetQuery) loadLikedUsers(ctx context.Context, query *UserQuery, node
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*Tweet]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*Tweet]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}
@@ -702,7 +702,7 @@ func (tq *TweetQuery) loadUser(ctx context.Context, query *UserQuery, nodes []*T
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*Tweet]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*Tweet]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}
@@ -760,7 +760,7 @@ func (tq *TweetQuery) loadTags(ctx context.Context, query *TagQuery, nodes []*Tw
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*Tweet]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*Tweet]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/entc/integration/edgeschema/ent/user_query.go
+++ b/entc/integration/edgeschema/ent/user_query.go
@@ -913,7 +913,7 @@ func (uq *UserQuery) loadGroups(ctx context.Context, query *GroupQuery, nodes []
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*User]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*User]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}
@@ -971,7 +971,7 @@ func (uq *UserQuery) loadFriends(ctx context.Context, query *UserQuery, nodes []
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*User]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*User]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}
@@ -1029,7 +1029,7 @@ func (uq *UserQuery) loadRelatives(ctx context.Context, query *UserQuery, nodes 
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*User]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*User]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}
@@ -1087,7 +1087,7 @@ func (uq *UserQuery) loadLikedTweets(ctx context.Context, query *TweetQuery, nod
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*User]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*User]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}
@@ -1145,7 +1145,7 @@ func (uq *UserQuery) loadTweets(ctx context.Context, query *TweetQuery, nodes []
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*User]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*User]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}
@@ -1203,7 +1203,7 @@ func (uq *UserQuery) loadRoles(ctx context.Context, query *RoleQuery, nodes []*U
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*User]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*User]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/entc/integration/ent/card_query.go
+++ b/entc/integration/ent/card_query.go
@@ -518,7 +518,7 @@ func (cq *CardQuery) loadSpec(ctx context.Context, query *SpecQuery, nodes []*Ca
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*Card]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*Card]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/entc/integration/ent/client.go
+++ b/entc/integration/ent/client.go
@@ -324,7 +324,7 @@ func (c *CardClient) GetX(ctx context.Context, id int) *Card {
 // QueryOwner queries the owner edge of a Card.
 func (c *CardClient) QueryOwner(ca *Card) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := ca.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(card.Table, card.FieldID, id),
@@ -340,7 +340,7 @@ func (c *CardClient) QueryOwner(ca *Card) *UserQuery {
 // QuerySpec queries the spec edge of a Card.
 func (c *CardClient) QuerySpec(ca *Card) *SpecQuery {
 	query := &SpecQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := ca.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(card.Table, card.FieldID, id),
@@ -626,7 +626,7 @@ func (c *FileClient) GetX(ctx context.Context, id int) *File {
 // QueryOwner queries the owner edge of a File.
 func (c *FileClient) QueryOwner(f *File) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := f.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(file.Table, file.FieldID, id),
@@ -642,7 +642,7 @@ func (c *FileClient) QueryOwner(f *File) *UserQuery {
 // QueryType queries the type edge of a File.
 func (c *FileClient) QueryType(f *File) *FileTypeQuery {
 	query := &FileTypeQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := f.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(file.Table, file.FieldID, id),
@@ -658,7 +658,7 @@ func (c *FileClient) QueryType(f *File) *FileTypeQuery {
 // QueryField queries the field edge of a File.
 func (c *FileClient) QueryField(f *File) *FieldTypeQuery {
 	query := &FieldTypeQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := f.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(file.Table, file.FieldID, id),
@@ -764,7 +764,7 @@ func (c *FileTypeClient) GetX(ctx context.Context, id int) *FileType {
 // QueryFiles queries the files edge of a FileType.
 func (c *FileTypeClient) QueryFiles(ft *FileType) *FileQuery {
 	query := &FileQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := ft.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(filetype.Table, filetype.FieldID, id),
@@ -960,7 +960,7 @@ func (c *GroupClient) GetX(ctx context.Context, id int) *Group {
 // QueryFiles queries the files edge of a Group.
 func (c *GroupClient) QueryFiles(gr *Group) *FileQuery {
 	query := &FileQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := gr.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(group.Table, group.FieldID, id),
@@ -976,7 +976,7 @@ func (c *GroupClient) QueryFiles(gr *Group) *FileQuery {
 // QueryBlocked queries the blocked edge of a Group.
 func (c *GroupClient) QueryBlocked(gr *Group) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := gr.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(group.Table, group.FieldID, id),
@@ -992,7 +992,7 @@ func (c *GroupClient) QueryBlocked(gr *Group) *UserQuery {
 // QueryUsers queries the users edge of a Group.
 func (c *GroupClient) QueryUsers(gr *Group) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := gr.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(group.Table, group.FieldID, id),
@@ -1008,7 +1008,7 @@ func (c *GroupClient) QueryUsers(gr *Group) *UserQuery {
 // QueryInfo queries the info edge of a Group.
 func (c *GroupClient) QueryInfo(gr *Group) *GroupInfoQuery {
 	query := &GroupInfoQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := gr.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(group.Table, group.FieldID, id),
@@ -1114,7 +1114,7 @@ func (c *GroupInfoClient) GetX(ctx context.Context, id int) *GroupInfo {
 // QueryGroups queries the groups edge of a GroupInfo.
 func (c *GroupInfoClient) QueryGroups(gi *GroupInfo) *GroupQuery {
 	query := &GroupQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := gi.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(groupinfo.Table, groupinfo.FieldID, id),
@@ -1400,7 +1400,7 @@ func (c *NodeClient) GetX(ctx context.Context, id int) *Node {
 // QueryPrev queries the prev edge of a Node.
 func (c *NodeClient) QueryPrev(n *Node) *NodeQuery {
 	query := &NodeQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := n.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(node.Table, node.FieldID, id),
@@ -1416,7 +1416,7 @@ func (c *NodeClient) QueryPrev(n *Node) *NodeQuery {
 // QueryNext queries the next edge of a Node.
 func (c *NodeClient) QueryNext(n *Node) *NodeQuery {
 	query := &NodeQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := n.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(node.Table, node.FieldID, id),
@@ -1522,7 +1522,7 @@ func (c *PetClient) GetX(ctx context.Context, id int) *Pet {
 // QueryTeam queries the team edge of a Pet.
 func (c *PetClient) QueryTeam(pe *Pet) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := pe.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(pet.Table, pet.FieldID, id),
@@ -1538,7 +1538,7 @@ func (c *PetClient) QueryTeam(pe *Pet) *UserQuery {
 // QueryOwner queries the owner edge of a Pet.
 func (c *PetClient) QueryOwner(pe *Pet) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := pe.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(pet.Table, pet.FieldID, id),
@@ -1644,7 +1644,7 @@ func (c *SpecClient) GetX(ctx context.Context, id int) *Spec {
 // QueryCard queries the card edge of a Spec.
 func (c *SpecClient) QueryCard(s *Spec) *CardQuery {
 	query := &CardQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := s.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(spec.Table, spec.FieldID, id),
@@ -1840,7 +1840,7 @@ func (c *UserClient) GetX(ctx context.Context, id int) *User {
 // QueryCard queries the card edge of a User.
 func (c *UserClient) QueryCard(u *User) *CardQuery {
 	query := &CardQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -1856,7 +1856,7 @@ func (c *UserClient) QueryCard(u *User) *CardQuery {
 // QueryPets queries the pets edge of a User.
 func (c *UserClient) QueryPets(u *User) *PetQuery {
 	query := &PetQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -1872,7 +1872,7 @@ func (c *UserClient) QueryPets(u *User) *PetQuery {
 // QueryFiles queries the files edge of a User.
 func (c *UserClient) QueryFiles(u *User) *FileQuery {
 	query := &FileQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -1888,7 +1888,7 @@ func (c *UserClient) QueryFiles(u *User) *FileQuery {
 // QueryGroups queries the groups edge of a User.
 func (c *UserClient) QueryGroups(u *User) *GroupQuery {
 	query := &GroupQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -1904,7 +1904,7 @@ func (c *UserClient) QueryGroups(u *User) *GroupQuery {
 // QueryFriends queries the friends edge of a User.
 func (c *UserClient) QueryFriends(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -1920,7 +1920,7 @@ func (c *UserClient) QueryFriends(u *User) *UserQuery {
 // QueryFollowers queries the followers edge of a User.
 func (c *UserClient) QueryFollowers(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -1936,7 +1936,7 @@ func (c *UserClient) QueryFollowers(u *User) *UserQuery {
 // QueryFollowing queries the following edge of a User.
 func (c *UserClient) QueryFollowing(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -1952,7 +1952,7 @@ func (c *UserClient) QueryFollowing(u *User) *UserQuery {
 // QueryTeam queries the team edge of a User.
 func (c *UserClient) QueryTeam(u *User) *PetQuery {
 	query := &PetQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -1968,7 +1968,7 @@ func (c *UserClient) QueryTeam(u *User) *PetQuery {
 // QuerySpouse queries the spouse edge of a User.
 func (c *UserClient) QuerySpouse(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -1984,7 +1984,7 @@ func (c *UserClient) QuerySpouse(u *User) *UserQuery {
 // QueryChildren queries the children edge of a User.
 func (c *UserClient) QueryChildren(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -2000,7 +2000,7 @@ func (c *UserClient) QueryChildren(u *User) *UserQuery {
 // QueryParent queries the parent edge of a User.
 func (c *UserClient) QueryParent(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),

--- a/entc/integration/ent/group_query.go
+++ b/entc/integration/ent/group_query.go
@@ -654,7 +654,7 @@ func (gq *GroupQuery) loadUsers(ctx context.Context, query *UserQuery, nodes []*
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*Group]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*Group]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/entc/integration/ent/spec_query.go
+++ b/entc/integration/ent/spec_query.go
@@ -416,7 +416,7 @@ func (sq *SpecQuery) loadCard(ctx context.Context, query *CardQuery, nodes []*Sp
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*Spec]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*Spec]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/entc/integration/ent/user_query.go
+++ b/entc/integration/ent/user_query.go
@@ -1013,7 +1013,7 @@ func (uq *UserQuery) loadGroups(ctx context.Context, query *GroupQuery, nodes []
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*User]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*User]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}
@@ -1071,7 +1071,7 @@ func (uq *UserQuery) loadFriends(ctx context.Context, query *UserQuery, nodes []
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*User]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*User]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}
@@ -1129,7 +1129,7 @@ func (uq *UserQuery) loadFollowers(ctx context.Context, query *UserQuery, nodes 
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*User]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*User]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}
@@ -1187,7 +1187,7 @@ func (uq *UserQuery) loadFollowing(ctx context.Context, query *UserQuery, nodes 
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*User]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*User]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/entc/integration/gremlin/ent/client.go
+++ b/entc/integration/gremlin/ent/client.go
@@ -296,7 +296,7 @@ func (c *CardClient) GetX(ctx context.Context, id string) *Card {
 // QueryOwner queries the owner edge of a Card.
 func (c *CardClient) QueryOwner(ca *Card) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *dsl.Traversal, _ error) {
+	query.path = func(context.Context) (fromV *dsl.Traversal, _ error) {
 
 		fromV = g.V(ca.ID).InE(user.CardLabel).OutV()
 		return fromV, nil
@@ -307,7 +307,7 @@ func (c *CardClient) QueryOwner(ca *Card) *UserQuery {
 // QuerySpec queries the spec edge of a Card.
 func (c *CardClient) QuerySpec(ca *Card) *SpecQuery {
 	query := &SpecQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *dsl.Traversal, _ error) {
+	query.path = func(context.Context) (fromV *dsl.Traversal, _ error) {
 
 		fromV = g.V(ca.ID).InE(spec.CardLabel).OutV()
 		return fromV, nil
@@ -588,7 +588,7 @@ func (c *FileClient) GetX(ctx context.Context, id string) *File {
 // QueryOwner queries the owner edge of a File.
 func (c *FileClient) QueryOwner(f *File) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *dsl.Traversal, _ error) {
+	query.path = func(context.Context) (fromV *dsl.Traversal, _ error) {
 
 		fromV = g.V(f.ID).InE(user.FilesLabel).OutV()
 		return fromV, nil
@@ -599,7 +599,7 @@ func (c *FileClient) QueryOwner(f *File) *UserQuery {
 // QueryType queries the type edge of a File.
 func (c *FileClient) QueryType(f *File) *FileTypeQuery {
 	query := &FileTypeQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *dsl.Traversal, _ error) {
+	query.path = func(context.Context) (fromV *dsl.Traversal, _ error) {
 
 		fromV = g.V(f.ID).InE(filetype.FilesLabel).OutV()
 		return fromV, nil
@@ -610,7 +610,7 @@ func (c *FileClient) QueryType(f *File) *FileTypeQuery {
 // QueryField queries the field edge of a File.
 func (c *FileClient) QueryField(f *File) *FieldTypeQuery {
 	query := &FieldTypeQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *dsl.Traversal, _ error) {
+	query.path = func(context.Context) (fromV *dsl.Traversal, _ error) {
 
 		fromV = g.V(f.ID).OutE(file.FieldLabel).InV()
 		return fromV, nil
@@ -711,7 +711,7 @@ func (c *FileTypeClient) GetX(ctx context.Context, id string) *FileType {
 // QueryFiles queries the files edge of a FileType.
 func (c *FileTypeClient) QueryFiles(ft *FileType) *FileQuery {
 	query := &FileQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *dsl.Traversal, _ error) {
+	query.path = func(context.Context) (fromV *dsl.Traversal, _ error) {
 
 		fromV = g.V(ft.ID).OutE(filetype.FilesLabel).InV()
 		return fromV, nil
@@ -902,7 +902,7 @@ func (c *GroupClient) GetX(ctx context.Context, id string) *Group {
 // QueryFiles queries the files edge of a Group.
 func (c *GroupClient) QueryFiles(gr *Group) *FileQuery {
 	query := &FileQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *dsl.Traversal, _ error) {
+	query.path = func(context.Context) (fromV *dsl.Traversal, _ error) {
 
 		fromV = g.V(gr.ID).OutE(group.FilesLabel).InV()
 		return fromV, nil
@@ -913,7 +913,7 @@ func (c *GroupClient) QueryFiles(gr *Group) *FileQuery {
 // QueryBlocked queries the blocked edge of a Group.
 func (c *GroupClient) QueryBlocked(gr *Group) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *dsl.Traversal, _ error) {
+	query.path = func(context.Context) (fromV *dsl.Traversal, _ error) {
 
 		fromV = g.V(gr.ID).OutE(group.BlockedLabel).InV()
 		return fromV, nil
@@ -924,7 +924,7 @@ func (c *GroupClient) QueryBlocked(gr *Group) *UserQuery {
 // QueryUsers queries the users edge of a Group.
 func (c *GroupClient) QueryUsers(gr *Group) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *dsl.Traversal, _ error) {
+	query.path = func(context.Context) (fromV *dsl.Traversal, _ error) {
 
 		fromV = g.V(gr.ID).InE(user.GroupsLabel).OutV()
 		return fromV, nil
@@ -935,7 +935,7 @@ func (c *GroupClient) QueryUsers(gr *Group) *UserQuery {
 // QueryInfo queries the info edge of a Group.
 func (c *GroupClient) QueryInfo(gr *Group) *GroupInfoQuery {
 	query := &GroupInfoQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *dsl.Traversal, _ error) {
+	query.path = func(context.Context) (fromV *dsl.Traversal, _ error) {
 
 		fromV = g.V(gr.ID).OutE(group.InfoLabel).InV()
 		return fromV, nil
@@ -1036,7 +1036,7 @@ func (c *GroupInfoClient) GetX(ctx context.Context, id string) *GroupInfo {
 // QueryGroups queries the groups edge of a GroupInfo.
 func (c *GroupInfoClient) QueryGroups(gi *GroupInfo) *GroupQuery {
 	query := &GroupQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *dsl.Traversal, _ error) {
+	query.path = func(context.Context) (fromV *dsl.Traversal, _ error) {
 
 		fromV = g.V(gi.ID).InE(group.InfoLabel).OutV()
 		return fromV, nil
@@ -1317,7 +1317,7 @@ func (c *NodeClient) GetX(ctx context.Context, id string) *Node {
 // QueryPrev queries the prev edge of a Node.
 func (c *NodeClient) QueryPrev(n *Node) *NodeQuery {
 	query := &NodeQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *dsl.Traversal, _ error) {
+	query.path = func(context.Context) (fromV *dsl.Traversal, _ error) {
 
 		fromV = g.V(n.ID).InE(node.NextLabel).OutV()
 		return fromV, nil
@@ -1328,7 +1328,7 @@ func (c *NodeClient) QueryPrev(n *Node) *NodeQuery {
 // QueryNext queries the next edge of a Node.
 func (c *NodeClient) QueryNext(n *Node) *NodeQuery {
 	query := &NodeQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *dsl.Traversal, _ error) {
+	query.path = func(context.Context) (fromV *dsl.Traversal, _ error) {
 
 		fromV = g.V(n.ID).OutE(node.NextLabel).InV()
 		return fromV, nil
@@ -1429,7 +1429,7 @@ func (c *PetClient) GetX(ctx context.Context, id string) *Pet {
 // QueryTeam queries the team edge of a Pet.
 func (c *PetClient) QueryTeam(pe *Pet) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *dsl.Traversal, _ error) {
+	query.path = func(context.Context) (fromV *dsl.Traversal, _ error) {
 
 		fromV = g.V(pe.ID).InE(user.TeamLabel).OutV()
 		return fromV, nil
@@ -1440,7 +1440,7 @@ func (c *PetClient) QueryTeam(pe *Pet) *UserQuery {
 // QueryOwner queries the owner edge of a Pet.
 func (c *PetClient) QueryOwner(pe *Pet) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *dsl.Traversal, _ error) {
+	query.path = func(context.Context) (fromV *dsl.Traversal, _ error) {
 
 		fromV = g.V(pe.ID).InE(user.PetsLabel).OutV()
 		return fromV, nil
@@ -1541,7 +1541,7 @@ func (c *SpecClient) GetX(ctx context.Context, id string) *Spec {
 // QueryCard queries the card edge of a Spec.
 func (c *SpecClient) QueryCard(s *Spec) *CardQuery {
 	query := &CardQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *dsl.Traversal, _ error) {
+	query.path = func(context.Context) (fromV *dsl.Traversal, _ error) {
 
 		fromV = g.V(s.ID).OutE(spec.CardLabel).InV()
 		return fromV, nil
@@ -1732,7 +1732,7 @@ func (c *UserClient) GetX(ctx context.Context, id string) *User {
 // QueryCard queries the card edge of a User.
 func (c *UserClient) QueryCard(u *User) *CardQuery {
 	query := &CardQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *dsl.Traversal, _ error) {
+	query.path = func(context.Context) (fromV *dsl.Traversal, _ error) {
 
 		fromV = g.V(u.ID).OutE(user.CardLabel).InV()
 		return fromV, nil
@@ -1743,7 +1743,7 @@ func (c *UserClient) QueryCard(u *User) *CardQuery {
 // QueryPets queries the pets edge of a User.
 func (c *UserClient) QueryPets(u *User) *PetQuery {
 	query := &PetQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *dsl.Traversal, _ error) {
+	query.path = func(context.Context) (fromV *dsl.Traversal, _ error) {
 
 		fromV = g.V(u.ID).OutE(user.PetsLabel).InV()
 		return fromV, nil
@@ -1754,7 +1754,7 @@ func (c *UserClient) QueryPets(u *User) *PetQuery {
 // QueryFiles queries the files edge of a User.
 func (c *UserClient) QueryFiles(u *User) *FileQuery {
 	query := &FileQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *dsl.Traversal, _ error) {
+	query.path = func(context.Context) (fromV *dsl.Traversal, _ error) {
 
 		fromV = g.V(u.ID).OutE(user.FilesLabel).InV()
 		return fromV, nil
@@ -1765,7 +1765,7 @@ func (c *UserClient) QueryFiles(u *User) *FileQuery {
 // QueryGroups queries the groups edge of a User.
 func (c *UserClient) QueryGroups(u *User) *GroupQuery {
 	query := &GroupQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *dsl.Traversal, _ error) {
+	query.path = func(context.Context) (fromV *dsl.Traversal, _ error) {
 
 		fromV = g.V(u.ID).OutE(user.GroupsLabel).InV()
 		return fromV, nil
@@ -1776,7 +1776,7 @@ func (c *UserClient) QueryGroups(u *User) *GroupQuery {
 // QueryFriends queries the friends edge of a User.
 func (c *UserClient) QueryFriends(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *dsl.Traversal, _ error) {
+	query.path = func(context.Context) (fromV *dsl.Traversal, _ error) {
 
 		fromV = g.V(u.ID).Both(user.FriendsLabel)
 		return fromV, nil
@@ -1787,7 +1787,7 @@ func (c *UserClient) QueryFriends(u *User) *UserQuery {
 // QueryFollowers queries the followers edge of a User.
 func (c *UserClient) QueryFollowers(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *dsl.Traversal, _ error) {
+	query.path = func(context.Context) (fromV *dsl.Traversal, _ error) {
 
 		fromV = g.V(u.ID).InE(user.FollowingLabel).OutV()
 		return fromV, nil
@@ -1798,7 +1798,7 @@ func (c *UserClient) QueryFollowers(u *User) *UserQuery {
 // QueryFollowing queries the following edge of a User.
 func (c *UserClient) QueryFollowing(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *dsl.Traversal, _ error) {
+	query.path = func(context.Context) (fromV *dsl.Traversal, _ error) {
 
 		fromV = g.V(u.ID).OutE(user.FollowingLabel).InV()
 		return fromV, nil
@@ -1809,7 +1809,7 @@ func (c *UserClient) QueryFollowing(u *User) *UserQuery {
 // QueryTeam queries the team edge of a User.
 func (c *UserClient) QueryTeam(u *User) *PetQuery {
 	query := &PetQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *dsl.Traversal, _ error) {
+	query.path = func(context.Context) (fromV *dsl.Traversal, _ error) {
 
 		fromV = g.V(u.ID).OutE(user.TeamLabel).InV()
 		return fromV, nil
@@ -1820,7 +1820,7 @@ func (c *UserClient) QueryTeam(u *User) *PetQuery {
 // QuerySpouse queries the spouse edge of a User.
 func (c *UserClient) QuerySpouse(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *dsl.Traversal, _ error) {
+	query.path = func(context.Context) (fromV *dsl.Traversal, _ error) {
 
 		fromV = g.V(u.ID).Both(user.SpouseLabel)
 		return fromV, nil
@@ -1831,7 +1831,7 @@ func (c *UserClient) QuerySpouse(u *User) *UserQuery {
 // QueryChildren queries the children edge of a User.
 func (c *UserClient) QueryChildren(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *dsl.Traversal, _ error) {
+	query.path = func(context.Context) (fromV *dsl.Traversal, _ error) {
 
 		fromV = g.V(u.ID).InE(user.ParentLabel).OutV()
 		return fromV, nil
@@ -1842,7 +1842,7 @@ func (c *UserClient) QueryChildren(u *User) *UserQuery {
 // QueryParent queries the parent edge of a User.
 func (c *UserClient) QueryParent(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *dsl.Traversal, _ error) {
+	query.path = func(context.Context) (fromV *dsl.Traversal, _ error) {
 
 		fromV = g.V(u.ID).OutE(user.ParentLabel).InV()
 		return fromV, nil

--- a/entc/integration/hooks/ent/client.go
+++ b/entc/integration/hooks/ent/client.go
@@ -222,7 +222,7 @@ func (c *CardClient) GetX(ctx context.Context, id int) *Card {
 // QueryOwner queries the owner edge of a Card.
 func (c *CardClient) QueryOwner(ca *Card) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := ca.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(card.Table, card.FieldID, id),
@@ -329,7 +329,7 @@ func (c *UserClient) GetX(ctx context.Context, id int) *User {
 // QueryCards queries the cards edge of a User.
 func (c *UserClient) QueryCards(u *User) *CardQuery {
 	query := &CardQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -345,7 +345,7 @@ func (c *UserClient) QueryCards(u *User) *CardQuery {
 // QueryFriends queries the friends edge of a User.
 func (c *UserClient) QueryFriends(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -361,7 +361,7 @@ func (c *UserClient) QueryFriends(u *User) *UserQuery {
 // QueryBestFriend queries the best_friend edge of a User.
 func (c *UserClient) QueryBestFriend(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),

--- a/entc/integration/hooks/ent/user_query.go
+++ b/entc/integration/hooks/ent/user_query.go
@@ -549,7 +549,7 @@ func (uq *UserQuery) loadFriends(ctx context.Context, query *UserQuery, nodes []
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*User]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*User]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/entc/integration/idtype/ent/client.go
+++ b/entc/integration/idtype/ent/client.go
@@ -215,7 +215,7 @@ func (c *UserClient) GetX(ctx context.Context, id uint64) *User {
 // QuerySpouse queries the spouse edge of a User.
 func (c *UserClient) QuerySpouse(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -231,7 +231,7 @@ func (c *UserClient) QuerySpouse(u *User) *UserQuery {
 // QueryFollowers queries the followers edge of a User.
 func (c *UserClient) QueryFollowers(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -247,7 +247,7 @@ func (c *UserClient) QueryFollowers(u *User) *UserQuery {
 // QueryFollowing queries the following edge of a User.
 func (c *UserClient) QueryFollowing(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),

--- a/entc/integration/idtype/ent/user_query.go
+++ b/entc/integration/idtype/ent/user_query.go
@@ -546,7 +546,7 @@ func (uq *UserQuery) loadFollowers(ctx context.Context, query *UserQuery, nodes 
 			outValue := uint64(values[0].(*sql.NullInt64).Int64)
 			inValue := uint64(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*User]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*User]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}
@@ -604,7 +604,7 @@ func (uq *UserQuery) loadFollowing(ctx context.Context, query *UserQuery, nodes 
 			outValue := uint64(values[0].(*sql.NullInt64).Int64)
 			inValue := uint64(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*User]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*User]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/entc/integration/migrate/entv1/client.go
+++ b/entc/integration/migrate/entv1/client.go
@@ -236,7 +236,7 @@ func (c *CarClient) GetX(ctx context.Context, id int) *Car {
 // QueryOwner queries the owner edge of a Car.
 func (c *CarClient) QueryOwner(ca *Car) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := ca.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(car.Table, car.FieldID, id),
@@ -522,7 +522,7 @@ func (c *UserClient) GetX(ctx context.Context, id int) *User {
 // QueryParent queries the parent edge of a User.
 func (c *UserClient) QueryParent(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -538,7 +538,7 @@ func (c *UserClient) QueryParent(u *User) *UserQuery {
 // QueryChildren queries the children edge of a User.
 func (c *UserClient) QueryChildren(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -554,7 +554,7 @@ func (c *UserClient) QueryChildren(u *User) *UserQuery {
 // QuerySpouse queries the spouse edge of a User.
 func (c *UserClient) QuerySpouse(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -570,7 +570,7 @@ func (c *UserClient) QuerySpouse(u *User) *UserQuery {
 // QueryCar queries the car edge of a User.
 func (c *UserClient) QueryCar(u *User) *CarQuery {
 	query := &CarQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),

--- a/entc/integration/migrate/entv2/client.go
+++ b/entc/integration/migrate/entv2/client.go
@@ -264,7 +264,7 @@ func (c *BlogClient) GetX(ctx context.Context, id int) *Blog {
 // QueryAdmins queries the admins edge of a Blog.
 func (c *BlogClient) QueryAdmins(b *Blog) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := b.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(blog.Table, blog.FieldID, id),
@@ -370,7 +370,7 @@ func (c *CarClient) GetX(ctx context.Context, id int) *Car {
 // QueryOwner queries the owner edge of a Car.
 func (c *CarClient) QueryOwner(ca *Car) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := ca.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(car.Table, car.FieldID, id),
@@ -836,7 +836,7 @@ func (c *PetClient) GetX(ctx context.Context, id int) *Pet {
 // QueryOwner queries the owner edge of a Pet.
 func (c *PetClient) QueryOwner(pe *Pet) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := pe.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(pet.Table, pet.FieldID, id),
@@ -942,7 +942,7 @@ func (c *UserClient) GetX(ctx context.Context, id int) *User {
 // QueryCar queries the car edge of a User.
 func (c *UserClient) QueryCar(u *User) *CarQuery {
 	query := &CarQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -958,7 +958,7 @@ func (c *UserClient) QueryCar(u *User) *CarQuery {
 // QueryPets queries the pets edge of a User.
 func (c *UserClient) QueryPets(u *User) *PetQuery {
 	query := &PetQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -974,7 +974,7 @@ func (c *UserClient) QueryPets(u *User) *PetQuery {
 // QueryFriends queries the friends edge of a User.
 func (c *UserClient) QueryFriends(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),

--- a/entc/integration/migrate/entv2/user_query.go
+++ b/entc/integration/migrate/entv2/user_query.go
@@ -575,7 +575,7 @@ func (uq *UserQuery) loadFriends(ctx context.Context, query *UserQuery, nodes []
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*User]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*User]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/entc/integration/multischema/ent/client.go
+++ b/entc/integration/multischema/ent/client.go
@@ -229,7 +229,7 @@ func (c *GroupClient) GetX(ctx context.Context, id int) *Group {
 // QueryUsers queries the users edge of a Group.
 func (c *GroupClient) QueryUsers(gr *Group) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := gr.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(group.Table, group.FieldID, id),
@@ -338,7 +338,7 @@ func (c *PetClient) GetX(ctx context.Context, id int) *Pet {
 // QueryOwner queries the owner edge of a Pet.
 func (c *PetClient) QueryOwner(pe *Pet) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := pe.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(pet.Table, pet.FieldID, id),
@@ -447,7 +447,7 @@ func (c *UserClient) GetX(ctx context.Context, id int) *User {
 // QueryPets queries the pets edge of a User.
 func (c *UserClient) QueryPets(u *User) *PetQuery {
 	query := &PetQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -466,7 +466,7 @@ func (c *UserClient) QueryPets(u *User) *PetQuery {
 // QueryGroups queries the groups edge of a User.
 func (c *UserClient) QueryGroups(u *User) *GroupQuery {
 	query := &GroupQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),

--- a/entc/integration/multischema/ent/group_query.go
+++ b/entc/integration/multischema/ent/group_query.go
@@ -435,7 +435,7 @@ func (gq *GroupQuery) loadUsers(ctx context.Context, query *UserQuery, nodes []*
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*Group]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*Group]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/entc/integration/multischema/ent/user_query.go
+++ b/entc/integration/multischema/ent/user_query.go
@@ -509,7 +509,7 @@ func (uq *UserQuery) loadGroups(ctx context.Context, query *GroupQuery, nodes []
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*User]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*User]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/entc/integration/privacy/ent/client.go
+++ b/entc/integration/privacy/ent/client.go
@@ -229,7 +229,7 @@ func (c *TaskClient) GetX(ctx context.Context, id int) *Task {
 // QueryTeams queries the teams edge of a Task.
 func (c *TaskClient) QueryTeams(t *Task) *TeamQuery {
 	query := &TeamQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := t.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(task.Table, task.FieldID, id),
@@ -245,7 +245,7 @@ func (c *TaskClient) QueryTeams(t *Task) *TeamQuery {
 // QueryOwner queries the owner edge of a Task.
 func (c *TaskClient) QueryOwner(t *Task) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := t.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(task.Table, task.FieldID, id),
@@ -352,7 +352,7 @@ func (c *TeamClient) GetX(ctx context.Context, id int) *Team {
 // QueryTasks queries the tasks edge of a Team.
 func (c *TeamClient) QueryTasks(t *Team) *TaskQuery {
 	query := &TaskQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := t.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(team.Table, team.FieldID, id),
@@ -368,7 +368,7 @@ func (c *TeamClient) QueryTasks(t *Team) *TaskQuery {
 // QueryUsers queries the users edge of a Team.
 func (c *TeamClient) QueryUsers(t *Team) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := t.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(team.Table, team.FieldID, id),
@@ -475,7 +475,7 @@ func (c *UserClient) GetX(ctx context.Context, id int) *User {
 // QueryTeams queries the teams edge of a User.
 func (c *UserClient) QueryTeams(u *User) *TeamQuery {
 	query := &TeamQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -491,7 +491,7 @@ func (c *UserClient) QueryTeams(u *User) *TeamQuery {
 // QueryTasks queries the tasks edge of a User.
 func (c *UserClient) QueryTasks(u *User) *TaskQuery {
 	query := &TaskQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),

--- a/entc/integration/privacy/ent/task_query.go
+++ b/entc/integration/privacy/ent/task_query.go
@@ -483,7 +483,7 @@ func (tq *TaskQuery) loadTeams(ctx context.Context, query *TeamQuery, nodes []*T
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*Task]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*Task]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/entc/integration/privacy/ent/team_query.go
+++ b/entc/integration/privacy/ent/team_query.go
@@ -476,7 +476,7 @@ func (tq *TeamQuery) loadTasks(ctx context.Context, query *TaskQuery, nodes []*T
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*Team]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*Team]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}
@@ -534,7 +534,7 @@ func (tq *TeamQuery) loadUsers(ctx context.Context, query *UserQuery, nodes []*T
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*Team]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*Team]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/entc/integration/privacy/ent/user_query.go
+++ b/entc/integration/privacy/ent/user_query.go
@@ -476,7 +476,7 @@ func (uq *UserQuery) loadTeams(ctx context.Context, query *TeamQuery, nodes []*U
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*User]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*User]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/entc/integration/template/ent/client.go
+++ b/entc/integration/template/ent/client.go
@@ -330,7 +330,7 @@ func (c *PetClient) GetX(ctx context.Context, id int) *Pet {
 // QueryOwner queries the owner edge of a Pet.
 func (c *PetClient) QueryOwner(pe *Pet) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := pe.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(pet.Table, pet.FieldID, id),
@@ -437,7 +437,7 @@ func (c *UserClient) GetX(ctx context.Context, id int) *User {
 // QueryPets queries the pets edge of a User.
 func (c *UserClient) QueryPets(u *User) *PetQuery {
 	query := &PetQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -453,7 +453,7 @@ func (c *UserClient) QueryPets(u *User) *PetQuery {
 // QueryFriends queries the friends edge of a User.
 func (c *UserClient) QueryFriends(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),

--- a/entc/integration/template/ent/user_query.go
+++ b/entc/integration/template/ent/user_query.go
@@ -505,7 +505,7 @@ func (uq *UserQuery) loadFriends(ctx context.Context, query *UserQuery, nodes []
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*User]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*User]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/examples/edgeindex/ent/client.go
+++ b/examples/edgeindex/ent/client.go
@@ -222,7 +222,7 @@ func (c *CityClient) GetX(ctx context.Context, id int) *City {
 // QueryStreets queries the streets edge of a City.
 func (c *CityClient) QueryStreets(ci *City) *StreetQuery {
 	query := &StreetQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := ci.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(city.Table, city.FieldID, id),
@@ -328,7 +328,7 @@ func (c *StreetClient) GetX(ctx context.Context, id int) *Street {
 // QueryCity queries the city edge of a Street.
 func (c *StreetClient) QueryCity(s *Street) *CityQuery {
 	query := &CityQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := s.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(street.Table, street.FieldID, id),

--- a/examples/fs/ent/client.go
+++ b/examples/fs/ent/client.go
@@ -215,7 +215,7 @@ func (c *FileClient) GetX(ctx context.Context, id int) *File {
 // QueryParent queries the parent edge of a File.
 func (c *FileClient) QueryParent(f *File) *FileQuery {
 	query := &FileQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := f.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(file.Table, file.FieldID, id),
@@ -231,7 +231,7 @@ func (c *FileClient) QueryParent(f *File) *FileQuery {
 // QueryChildren queries the children edge of a File.
 func (c *FileClient) QueryChildren(f *File) *FileQuery {
 	query := &FileQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := f.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(file.Table, file.FieldID, id),

--- a/examples/m2m2types/ent/client.go
+++ b/examples/m2m2types/ent/client.go
@@ -222,7 +222,7 @@ func (c *GroupClient) GetX(ctx context.Context, id int) *Group {
 // QueryUsers queries the users edge of a Group.
 func (c *GroupClient) QueryUsers(gr *Group) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := gr.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(group.Table, group.FieldID, id),
@@ -328,7 +328,7 @@ func (c *UserClient) GetX(ctx context.Context, id int) *User {
 // QueryGroups queries the groups edge of a User.
 func (c *UserClient) QueryGroups(u *User) *GroupQuery {
 	query := &GroupQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),

--- a/examples/m2m2types/ent/group_query.go
+++ b/examples/m2m2types/ent/group_query.go
@@ -425,7 +425,7 @@ func (gq *GroupQuery) loadUsers(ctx context.Context, query *UserQuery, nodes []*
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*Group]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*Group]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/examples/m2m2types/ent/user_query.go
+++ b/examples/m2m2types/ent/user_query.go
@@ -425,7 +425,7 @@ func (uq *UserQuery) loadGroups(ctx context.Context, query *GroupQuery, nodes []
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*User]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*User]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/examples/m2mbidi/ent/client.go
+++ b/examples/m2mbidi/ent/client.go
@@ -215,7 +215,7 @@ func (c *UserClient) GetX(ctx context.Context, id int) *User {
 // QueryFriends queries the friends edge of a User.
 func (c *UserClient) QueryFriends(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),

--- a/examples/m2mbidi/ent/user_query.go
+++ b/examples/m2mbidi/ent/user_query.go
@@ -424,7 +424,7 @@ func (uq *UserQuery) loadFriends(ctx context.Context, query *UserQuery, nodes []
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*User]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*User]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/examples/m2mrecur/ent/client.go
+++ b/examples/m2mrecur/ent/client.go
@@ -215,7 +215,7 @@ func (c *UserClient) GetX(ctx context.Context, id int) *User {
 // QueryFollowers queries the followers edge of a User.
 func (c *UserClient) QueryFollowers(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -231,7 +231,7 @@ func (c *UserClient) QueryFollowers(u *User) *UserQuery {
 // QueryFollowing queries the following edge of a User.
 func (c *UserClient) QueryFollowing(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),

--- a/examples/m2mrecur/ent/user_query.go
+++ b/examples/m2mrecur/ent/user_query.go
@@ -467,7 +467,7 @@ func (uq *UserQuery) loadFollowers(ctx context.Context, query *UserQuery, nodes 
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*User]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*User]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}
@@ -525,7 +525,7 @@ func (uq *UserQuery) loadFollowing(ctx context.Context, query *UserQuery, nodes 
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*User]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*User]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/examples/o2m2types/ent/client.go
+++ b/examples/o2m2types/ent/client.go
@@ -222,7 +222,7 @@ func (c *PetClient) GetX(ctx context.Context, id int) *Pet {
 // QueryOwner queries the owner edge of a Pet.
 func (c *PetClient) QueryOwner(pe *Pet) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := pe.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(pet.Table, pet.FieldID, id),
@@ -328,7 +328,7 @@ func (c *UserClient) GetX(ctx context.Context, id int) *User {
 // QueryPets queries the pets edge of a User.
 func (c *UserClient) QueryPets(u *User) *PetQuery {
 	query := &PetQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),

--- a/examples/o2mrecur/ent/client.go
+++ b/examples/o2mrecur/ent/client.go
@@ -215,7 +215,7 @@ func (c *NodeClient) GetX(ctx context.Context, id int) *Node {
 // QueryParent queries the parent edge of a Node.
 func (c *NodeClient) QueryParent(n *Node) *NodeQuery {
 	query := &NodeQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := n.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(node.Table, node.FieldID, id),
@@ -231,7 +231,7 @@ func (c *NodeClient) QueryParent(n *Node) *NodeQuery {
 // QueryChildren queries the children edge of a Node.
 func (c *NodeClient) QueryChildren(n *Node) *NodeQuery {
 	query := &NodeQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := n.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(node.Table, node.FieldID, id),

--- a/examples/o2o2types/ent/client.go
+++ b/examples/o2o2types/ent/client.go
@@ -222,7 +222,7 @@ func (c *CardClient) GetX(ctx context.Context, id int) *Card {
 // QueryOwner queries the owner edge of a Card.
 func (c *CardClient) QueryOwner(ca *Card) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := ca.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(card.Table, card.FieldID, id),
@@ -328,7 +328,7 @@ func (c *UserClient) GetX(ctx context.Context, id int) *User {
 // QueryCard queries the card edge of a User.
 func (c *UserClient) QueryCard(u *User) *CardQuery {
 	query := &CardQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),

--- a/examples/o2obidi/ent/client.go
+++ b/examples/o2obidi/ent/client.go
@@ -215,7 +215,7 @@ func (c *UserClient) GetX(ctx context.Context, id int) *User {
 // QuerySpouse queries the spouse edge of a User.
 func (c *UserClient) QuerySpouse(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),

--- a/examples/o2orecur/ent/client.go
+++ b/examples/o2orecur/ent/client.go
@@ -215,7 +215,7 @@ func (c *NodeClient) GetX(ctx context.Context, id int) *Node {
 // QueryPrev queries the prev edge of a Node.
 func (c *NodeClient) QueryPrev(n *Node) *NodeQuery {
 	query := &NodeQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := n.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(node.Table, node.FieldID, id),
@@ -231,7 +231,7 @@ func (c *NodeClient) QueryPrev(n *Node) *NodeQuery {
 // QueryNext queries the next edge of a Node.
 func (c *NodeClient) QueryNext(n *Node) *NodeQuery {
 	query := &NodeQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := n.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(node.Table, node.FieldID, id),

--- a/examples/privacytenant/ent/client.go
+++ b/examples/privacytenant/ent/client.go
@@ -229,7 +229,7 @@ func (c *GroupClient) GetX(ctx context.Context, id int) *Group {
 // QueryTenant queries the tenant edge of a Group.
 func (c *GroupClient) QueryTenant(gr *Group) *TenantQuery {
 	query := &TenantQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := gr.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(group.Table, group.FieldID, id),
@@ -245,7 +245,7 @@ func (c *GroupClient) QueryTenant(gr *Group) *TenantQuery {
 // QueryUsers queries the users edge of a Group.
 func (c *GroupClient) QueryUsers(gr *Group) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := gr.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(group.Table, group.FieldID, id),
@@ -443,7 +443,7 @@ func (c *UserClient) GetX(ctx context.Context, id int) *User {
 // QueryTenant queries the tenant edge of a User.
 func (c *UserClient) QueryTenant(u *User) *TenantQuery {
 	query := &TenantQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -459,7 +459,7 @@ func (c *UserClient) QueryTenant(u *User) *TenantQuery {
 // QueryGroups queries the groups edge of a User.
 func (c *UserClient) QueryGroups(u *User) *GroupQuery {
 	query := &GroupQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),

--- a/examples/privacytenant/ent/group_query.go
+++ b/examples/privacytenant/ent/group_query.go
@@ -501,7 +501,7 @@ func (gq *GroupQuery) loadUsers(ctx context.Context, query *UserQuery, nodes []*
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*Group]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*Group]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/examples/privacytenant/ent/user_query.go
+++ b/examples/privacytenant/ent/user_query.go
@@ -501,7 +501,7 @@ func (uq *UserQuery) loadGroups(ctx context.Context, query *GroupQuery, nodes []
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*User]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*User]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/examples/start/ent/client.go
+++ b/examples/start/ent/client.go
@@ -229,7 +229,7 @@ func (c *CarClient) GetX(ctx context.Context, id int) *Car {
 // QueryOwner queries the owner edge of a Car.
 func (c *CarClient) QueryOwner(ca *Car) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := ca.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(car.Table, car.FieldID, id),
@@ -335,7 +335,7 @@ func (c *GroupClient) GetX(ctx context.Context, id int) *Group {
 // QueryUsers queries the users edge of a Group.
 func (c *GroupClient) QueryUsers(gr *Group) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := gr.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(group.Table, group.FieldID, id),
@@ -441,7 +441,7 @@ func (c *UserClient) GetX(ctx context.Context, id int) *User {
 // QueryCars queries the cars edge of a User.
 func (c *UserClient) QueryCars(u *User) *CarQuery {
 	query := &CarQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -457,7 +457,7 @@ func (c *UserClient) QueryCars(u *User) *CarQuery {
 // QueryGroups queries the groups edge of a User.
 func (c *UserClient) QueryGroups(u *User) *GroupQuery {
 	query := &GroupQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),

--- a/examples/start/ent/group_query.go
+++ b/examples/start/ent/group_query.go
@@ -425,7 +425,7 @@ func (gq *GroupQuery) loadUsers(ctx context.Context, query *UserQuery, nodes []*
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*Group]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*Group]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/examples/start/ent/user_query.go
+++ b/examples/start/ent/user_query.go
@@ -500,7 +500,7 @@ func (uq *UserQuery) loadGroups(ctx context.Context, query *GroupQuery, nodes []
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*User]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*User]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/examples/traversal/ent/client.go
+++ b/examples/traversal/ent/client.go
@@ -229,7 +229,7 @@ func (c *GroupClient) GetX(ctx context.Context, id int) *Group {
 // QueryUsers queries the users edge of a Group.
 func (c *GroupClient) QueryUsers(gr *Group) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := gr.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(group.Table, group.FieldID, id),
@@ -245,7 +245,7 @@ func (c *GroupClient) QueryUsers(gr *Group) *UserQuery {
 // QueryAdmin queries the admin edge of a Group.
 func (c *GroupClient) QueryAdmin(gr *Group) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := gr.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(group.Table, group.FieldID, id),
@@ -351,7 +351,7 @@ func (c *PetClient) GetX(ctx context.Context, id int) *Pet {
 // QueryFriends queries the friends edge of a Pet.
 func (c *PetClient) QueryFriends(pe *Pet) *PetQuery {
 	query := &PetQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := pe.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(pet.Table, pet.FieldID, id),
@@ -367,7 +367,7 @@ func (c *PetClient) QueryFriends(pe *Pet) *PetQuery {
 // QueryOwner queries the owner edge of a Pet.
 func (c *PetClient) QueryOwner(pe *Pet) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := pe.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(pet.Table, pet.FieldID, id),
@@ -473,7 +473,7 @@ func (c *UserClient) GetX(ctx context.Context, id int) *User {
 // QueryPets queries the pets edge of a User.
 func (c *UserClient) QueryPets(u *User) *PetQuery {
 	query := &PetQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -489,7 +489,7 @@ func (c *UserClient) QueryPets(u *User) *PetQuery {
 // QueryFriends queries the friends edge of a User.
 func (c *UserClient) QueryFriends(u *User) *UserQuery {
 	query := &UserQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -505,7 +505,7 @@ func (c *UserClient) QueryFriends(u *User) *UserQuery {
 // QueryGroups queries the groups edge of a User.
 func (c *UserClient) QueryGroups(u *User) *GroupQuery {
 	query := &GroupQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),
@@ -521,7 +521,7 @@ func (c *UserClient) QueryGroups(u *User) *GroupQuery {
 // QueryManage queries the manage edge of a User.
 func (c *UserClient) QueryManage(u *User) *GroupQuery {
 	query := &GroupQuery{config: c.config}
-	query.path = func(ctx context.Context) (fromV *sql.Selector, _ error) {
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := u.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(user.Table, user.FieldID, id),

--- a/examples/traversal/ent/group_query.go
+++ b/examples/traversal/ent/group_query.go
@@ -475,7 +475,7 @@ func (gq *GroupQuery) loadUsers(ctx context.Context, query *UserQuery, nodes []*
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*Group]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*Group]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/examples/traversal/ent/pet_query.go
+++ b/examples/traversal/ent/pet_query.go
@@ -475,7 +475,7 @@ func (pq *PetQuery) loadFriends(ctx context.Context, query *PetQuery, nodes []*P
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*Pet]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*Pet]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/examples/traversal/ent/user_query.go
+++ b/examples/traversal/ent/user_query.go
@@ -586,7 +586,7 @@ func (uq *UserQuery) loadFriends(ctx context.Context, query *UserQuery, nodes []
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*User]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*User]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}
@@ -644,7 +644,7 @@ func (uq *UserQuery) loadGroups(ctx context.Context, query *GroupQuery, nodes []
 			outValue := int(values[0].(*sql.NullInt64).Int64)
 			inValue := int(values[1].(*sql.NullInt64).Int64)
 			if nids[inValue] == nil {
-				nids[inValue] = map[*User]struct{}{byID[outValue]: struct{}{}}
+				nids[inValue] = map[*User]struct{}{byID[outValue]: {}}
 				return assign(columns[1:], values[1:])
 			}
 			nids[inValue][byID[outValue]] = struct{}{}

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,3 @@
-ariga.io/atlas v0.6.2-0.20220819114704-2060066abac7 h1:qhVEfrV5Z9XZyQJxgogBq6c2pjWUxGLU7bvFeEDY0DA=
-ariga.io/atlas v0.6.2-0.20220819114704-2060066abac7/go.mod h1:ft47uSh5hWGDCmQC9DsztZg6Xk+KagM5Ts/mZYKb9JE=
-ariga.io/atlas v0.6.5-0.20220907173155-3332f3c1b8c9 h1:hb7cCS3+idkvWRxKIiH0pBiyO9tJ9gRiecY+ohA//VY=
-ariga.io/atlas v0.6.5-0.20220907173155-3332f3c1b8c9/go.mod h1:ft47uSh5hWGDCmQC9DsztZg6Xk+KagM5Ts/mZYKb9JE=
-ariga.io/atlas v0.7.2-0.20220927063044-1d12e0ad4813 h1:KdsIBtO4ZpBAAWdg2fEpXuV5YKGpxBTWO7A9V5MM+/Y=
-ariga.io/atlas v0.7.2-0.20220927063044-1d12e0ad4813/go.mod h1:ft47uSh5hWGDCmQC9DsztZg6Xk+KagM5Ts/mZYKb9JE=
 ariga.io/atlas v0.7.2-0.20220927111110-867ee0cca56a h1:6/nt4DODfgxzHTTg3tYy7YkVzruGQGZ/kRvXpA45KUo=
 ariga.io/atlas v0.7.2-0.20220927111110-867ee0cca56a/go.mod h1:ft47uSh5hWGDCmQC9DsztZg6Xk+KagM5Ts/mZYKb9JE=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=


### PR DESCRIPTION
Hi, this is a small PR that does two things:
1. Removes the `ctx` variable from the query.path function since it is being unused.
2. Changes `struct{}{}` to `{}` in map assignment. 

Mainly to make my linter happy and since this is a generated file, I can't put ignore-comments on top of those lines. 