### PR TITLE
add note to import correct modules in tutorial

### DIFF
--- a/doc/md/tutorial-todo-crud.md
+++ b/doc/md/tutorial-todo-crud.md
@@ -50,6 +50,16 @@ func (Todo) Fields() []ent.Field {
 }
 ```
 
+Update your imports to look like this:
+```
+import (
+	"time"
+
+	"entgo.io/ent"
+	"entgo.io/ent/schema/field"
+)
+```
+
 After adding these fields, we need to run the code-generation as before:
 
 ```console

--- a/doc/md/tutorial-todo-crud.md
+++ b/doc/md/tutorial-todo-crud.md
@@ -51,7 +51,7 @@ func (Todo) Fields() []ent.Field {
 ```
 
 Update your imports to look like this:
-```
+```go
 import (
 	"time"
 


### PR DESCRIPTION
This adds a note to import the correct modules when adding the fields to the tutorial.

Just had to take a look at the examples to find the right module imports so I thought it would be good to have it in the tutorial.