### PR TITLE
dialect/sql: avoid setting the primary key when no primary key is present

### DIFF
--- a/dialect/sql/schema/atlas.go
+++ b/dialect/sql/schema/atlas.go
@@ -979,7 +979,9 @@ func (a *Atlas) aIndexes(et *Table, at *schema.Table) error {
 		}
 		pk = append(pk, c2)
 	}
-	at.SetPrimaryKey(schema.NewPrimaryKey(pk...))
+	if len(pk) > 0 {
+		at.SetPrimaryKey(schema.NewPrimaryKey(pk...))
+	}
 	// Rest of indexes.
 	for _, idx1 := range et.Indexes {
 		idx2 := schema.NewIndex(idx1.Name).

--- a/dialect/sql/schema/atlas.go
+++ b/dialect/sql/schema/atlas.go
@@ -979,6 +979,7 @@ func (a *Atlas) aIndexes(et *Table, at *schema.Table) error {
 		}
 		pk = append(pk, c2)
 	}
+	// CreateFunc might clear the primary keys.
 	if len(pk) > 0 {
 		at.SetPrimaryKey(schema.NewPrimaryKey(pk...))
 	}

--- a/dialect/sql/schema/migrate_test.go
+++ b/dialect/sql/schema/migrate_test.go
@@ -246,7 +246,7 @@ func TestMigrate_Diff(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, m.Diff(ctx, &Table{Name: "users"}))
 	v := time.Now().UTC().Format("20060102150405")
-	requireFileEqual(t, filepath.Join(p, v+"_changes.up.sql"), "-- create \"users\" table\nCREATE TABLE `users` (, PRIMARY KEY ());\n")
+	requireFileEqual(t, filepath.Join(p, v+"_changes.up.sql"), "-- create \"users\" table\nCREATE TABLE `users` ();\n")
 	requireFileEqual(t, filepath.Join(p, v+"_changes.down.sql"), "-- reverse: create \"users\" table\nDROP TABLE `users`;\n")
 	require.FileExists(t, filepath.Join(p, migrate.HashFileName))
 
@@ -257,7 +257,7 @@ func TestMigrate_Diff(t *testing.T) {
 	m, err = NewMigrate(db, WithDir(d))
 	require.NoError(t, err)
 	require.NoError(t, m.Diff(ctx, &Table{Name: "users"}))
-	requireFileEqual(t, filepath.Join(p, v+"_changes.up.sql"), "-- create \"users\" table\nCREATE TABLE `users` (, PRIMARY KEY ());\n")
+	requireFileEqual(t, filepath.Join(p, v+"_changes.up.sql"), "-- create \"users\" table\nCREATE TABLE `users` ();\n")
 	requireFileEqual(t, filepath.Join(p, v+"_changes.down.sql"), "-- reverse: create \"users\" table\nDROP TABLE `users`;\n")
 	require.FileExists(t, filepath.Join(p, migrate.HashFileName))
 	require.NoError(t, d.WriteFile("tmp.sql", nil))


### PR DESCRIPTION
I'm playing with [Timescale](https://www.timescale.com/), Timescale is a PostgreSQL extension that adds/improves support for time series data.

Timescale works by converting a normal table into a `hypertable`, it's not possible to use Timescale with Ent right now because the primary key of the ID field cause problems.

More info: 
- https://docs.timescale.com/timescaledb/latest/how-to-guides/schema-management/about-constraints/
- https://stackoverflow.com/a/68066535

One solution is avoiding creating the primary key in the first place, to do this on the user side of things a migration hook can be used:

```go
func WithoutPrimaryKey(tableName string) schema.MigrateOption {
	return schema.WithHooks(func(next schema.Creator) schema.Creator {
		return schema.CreateFunc(func(ctx context.Context, tables ...*schema.Table) error {
			for i := range tables {
				if tables[i].Name == tableName {
					tables[i].PrimaryKey = nil
				}
			}
			return next.Create(ctx, tables...)
		})
	})
}
```

But this generates invalid migration code `PRIMARY KEY ()`, this PR solves this problem and allows the use of the migration hook above without problems.

Maybe in the future we could add `WithoutPrimaryKey` as a official option like `WithDropColumn` is today (but I think is better wait to see if there is a need for it, I dont think there is huge user base with tables without primary keys)

It's worth noting that another solution would be to allow more control of the primary key on Ent schema, but based on [this comment](https://github.com/ent/ent/issues/2594#issuecomment-1145056254), seems like there is other's considerations that should be analyzed first and this PR at least solves the problem in a easy way.