### PR TITLE
entc/gen: satisfy schema/field.EnumValues with generated enum types

### DIFF
--- a/entc/gen/template/meta.tmpl
+++ b/entc/gen/template/meta.tmpl
@@ -126,6 +126,14 @@ const (
 		func ({{ $receiver }} {{ $enum }}) String() string {
 			return string({{ $receiver }})
 		}
+
+		func ({{ $receiver }} {{ $enum }}) Values() []string {
+			return []string{
+				{{- range $e := $f.Enums }}
+					"{{ $e.Value }}",
+				{{- end }}
+			}
+		}
 	{{ end }}
 
 


### PR DESCRIPTION
This provides a consistent consumer interface for enums using either the underlying type (via `GoType`) or the generated type (via `Values`).

I wasn't certain of the best place to add a test, if desirable.