### PR TITLE
entc/gen: add driver as a reserved field word

### DIFF
--- a/entc/gen/type.go
+++ b/entc/gen/type.go
@@ -2003,6 +2003,7 @@ var (
 		"predicates",
 		"typ",
 		"unique",
+		"driver",
 	)
 )
 

--- a/entc/gen/type_test.go
+++ b/entc/gen/type_test.go
@@ -305,6 +305,7 @@ func TestBuilderField(t *testing.T) {
 		{"type", "_type"},
 		{"config", "_config"},
 		{"SSOCert", "_SSOCert"},
+		{"driver", "_driver"},
 	}
 	for _, tt := range tests {
 		require.Equal(t, tt.field, Edge{Name: tt.name}.BuilderField())


### PR DESCRIPTION
This fixes the code generator to make fields in an entity with the name `driver` to get generated as `_driver` to avoid a collision preventing compilation. 

### Steps to Reproduce

1. `go run -mod=mod entgo.io/ent/cmd/ent init Test`
2. Add a field called `driver`

```
// Fields of the Test.
func (Test) Fields() []ent.Field {
	return []ent.Field{
		field.String("driver"),
	}
}
```
3. `go generate`


Code wont compile because `<T>Mutation` expects to access `m.driver` which is originally contained from the embedded struct `<T>.config` 
