### PR TITLE
dialect/sql/schema: fix issue with WriteDriver when using Postgres with Query

### DIFF
--- a/dialect/sql/schema/writer.go
+++ b/dialect/sql/schema/writer.go
@@ -110,6 +110,7 @@ func (w *WriteDriver) Query(ctx context.Context, query string, args, res any) er
 		if rr, ok := res.(*sql.Rows); ok {
 			*rr = sql.Rows{ColumnScanner: noRows{}}
 		}
+		return nil
 	}
 	switch w.Driver.(type) {
 	case nil, nopDriver:

--- a/dialect/sql/schema/writer_test.go
+++ b/dialect/sql/schema/writer_test.go
@@ -64,6 +64,12 @@ func TestWriteDriver(t *testing.T) {
 	err = w.Exec(ctx, `INSERT INTO "users" (name) VALUES("a8m") RETURNING id`, nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, `INSERT INTO "users" (name) VALUES("a8m") RETURNING id;`+"\n", b.String())
+
+	// batchCreator uses tx.Query when doing an insert
+	b.Reset()
+	err = w.Query(ctx, `INSERT INTO "users" (name) VALUES("a8m") RETURNING id`, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, `INSERT INTO "users" (name) VALUES("a8m") RETURNING id;`+"\n", b.String())
 }
 
 func TestDirWriter(t *testing.T) {


### PR DESCRIPTION
I think a return is missing, since the case for `INSERT/UPDATE`  is delegated to `Exec`, but I'm not 100% sure.
Please review if this makes sense.

I think this fixes #3137, I have tested and the migration is generated as expected.

https://github.com/ent/ent/blob/d7f2f3a098633ae8c6f844ce707a2eb983b1a340/dialect/sql/sqlgraph/graph.go#L1500-L1507

