### PR TITLE
feat: Add column comment in SQL DDL, using EntSQL annotations

### DIFF
--- a/dialect/entsql/annotation.go
+++ b/dialect/entsql/annotation.go
@@ -89,14 +89,6 @@ type Annotation struct {
 	//
 	Size int64 `json:"size,omitempty"`
 
-	// Comment defines the column comment in the database schema. For example:
-	//
-	//	entsql.Annotation{
-	//		Comment: "comment",
-	//	}
-	//
-	Comment string `json:"comment,omitempty"`
-
 	// WithComments defines whether entity comments should be
 	// stored in the database schema as column comments.
 	// For example:
@@ -106,9 +98,7 @@ type Annotation struct {
 	//		WithComments: &withCommentsEnabled,
 	//	}
 	//
-	// If WithComments is enabled, Comment in annotation is preferred
-	// as database column comment, and if Comment in annotation is ""
-	// then field comment will be used.
+	// If WithComments is enabled, field comment will be used as database column comment.
 	//
 	// By default, this value is nil defaulting to whatever best fits each scenario.
 	//
@@ -231,11 +221,10 @@ func DefaultExprs(exprs map[string]string) *Annotation {
 }
 
 // WithComments defines whether entity comments should be
-// stored in the database schema as well.
+// stored in the database schema as column comments.
 //
-// If WithComments is enabled, Comment in annotation is preferred
-// as database column comment, and if Comment in annotation is ""
-// then field comment will be used.
+// If WithComments is enabled, field comment will be used as
+// database column comment.
 //
 //	func (T) Annotations() []schema.Annotation {
 //		return []schema.Annotation{
@@ -248,24 +237,6 @@ func WithComments(w bool) *Annotation {
 	return &Annotation{
 		WithComments: &w,
 	}
-}
-
-// Comment defines the column comment in the database schema.
-// And WithComments will be enabled, Comment in annotation is preferred
-// as database column comment, and if Comment in annotation is ""
-// then field comment will be used.
-//
-//	field.String("user").
-//		Comment("user field comment").
-//		Annotations(
-//			entsql.Comments("user comment for database"),
-//		)
-func Comment(c string) *Annotation {
-	var a = new(Annotation)
-	a.Comment = c
-	a.WithComments = new(bool)
-	*a.WithComments = true
-	return a
 }
 
 // Merge implements the schema.Merger interface.
@@ -309,9 +280,6 @@ func (a Annotation) Merge(other schema.Annotation) schema.Annotation {
 	}
 	if s := ant.Size; s != 0 {
 		a.Size = s
-	}
-	if c := ant.Comment; c != "" {
-		a.Comment = c
 	}
 	if c := ant.WithComments; c != nil {
 		a.WithComments = c

--- a/dialect/entsql/annotation.go
+++ b/dialect/entsql/annotation.go
@@ -251,7 +251,7 @@ func WithComments(w bool) *Annotation {
 }
 
 // Comment defines the column comment in the database schema.
-// and WithComments will be enabled, Comment in annotation is preferred
+// And WithComments will be enabled, Comment in annotation is preferred
 // as database column comment, and if Comment in annotation is ""
 // then field comment will be used.
 //

--- a/dialect/entsql/annotation.go
+++ b/dialect/entsql/annotation.go
@@ -95,7 +95,7 @@ type Annotation struct {
 	//		Comment: "comment",
 	//	}
 	//
-	Comment string
+	Comment string `json:"comment,omitempty"`
 
 	// WithComments defines whether entity comments should be
 	// stored in the database schema as column comments.

--- a/dialect/sql/schema/atlas.go
+++ b/dialect/sql/schema/atlas.go
@@ -912,6 +912,9 @@ func (a *Atlas) aColumns(et *Table, at *schema.Table) error {
 		if c1.Collation != "" {
 			c2.SetCollation(c1.Collation)
 		}
+		if c1.Comment != "" {
+			c2.SetComment(c1.Comment)
+		}
 		if err := a.sqlDialect.atTypeC(c1, c2); err != nil {
 			return err
 		}

--- a/dialect/sql/schema/schema.go
+++ b/dialect/sql/schema/schema.go
@@ -295,7 +295,7 @@ type Column struct {
 	typ        string            // row column type (used for Rows.Scan).
 	indexes    Indexes           // linked indexes.
 	foreign    *ForeignKey       // linked foreign-key.
-	Comment    string            // column comment
+	Comment    string            // column comment.
 }
 
 // Expr represents a raw expression. It is used to distinguish between

--- a/dialect/sql/schema/schema.go
+++ b/dialect/sql/schema/schema.go
@@ -295,6 +295,7 @@ type Column struct {
 	typ        string            // row column type (used for Rows.Scan).
 	indexes    Indexes           // linked indexes.
 	foreign    *ForeignKey       // linked foreign-key.
+	Comment    string            // column comment
 }
 
 // Expr represents a raw expression. It is used to distinguish between

--- a/entc/gen/graph.go
+++ b/entc/gen/graph.go
@@ -585,15 +585,7 @@ func (g *Graph) Tables() (all []*schema.Table, err error) {
 		table.SetAnnotation(n.EntSQL())
 		for _, f := range n.Fields {
 			if !f.IsEdgeField() {
-				// If schema EntSQL annotation exist, merge it into field EntSQL annotation
-				if n.EntSQL() != nil {
-					if f.EntSQL() != nil {
-						f.Annotations[n.EntSQL().Name()] = n.EntSQL().Merge(f.EntSQL())
-					} else {
-						f.Annotations = make(Annotations)
-						f.Annotations[n.EntSQL().Name()] = n.EntSQL()
-					}
-				}
+				mergeEntSQLAnnotation(n, f)
 				table.AddColumn(f.Column())
 			}
 		}
@@ -703,6 +695,18 @@ func (g *Graph) Tables() (all []*schema.Table, err error) {
 		return nil, err
 	}
 	return
+}
+
+// If node schema EntSQL annotation exist, merge it into field EntSQL annotation
+func mergeEntSQLAnnotation(n *Type, f *Field) {
+	if n.EntSQL() != nil {
+		if f.EntSQL() != nil {
+			f.Annotations[n.EntSQL().Name()] = n.EntSQL().Merge(f.EntSQL())
+		} else {
+			f.Annotations = make(Annotations)
+			f.Annotations[n.EntSQL().Name()] = n.EntSQL()
+		}
+	}
 }
 
 // mayAddColumn adds the given column if it does not already exist in the table.

--- a/entc/gen/graph.go
+++ b/entc/gen/graph.go
@@ -580,6 +580,7 @@ func (g *Graph) Tables() (all []*schema.Table, err error) {
 	for _, n := range g.Nodes {
 		table := schema.NewTable(n.Table())
 		if n.HasOneFieldID() {
+			mergeEntSQLAnnotation(n, n.ID)
 			table.AddPrimary(n.ID.PK())
 		}
 		table.SetAnnotation(n.EntSQL())
@@ -699,14 +700,15 @@ func (g *Graph) Tables() (all []*schema.Table, err error) {
 
 // If node schema EntSQL annotation exist, merge it into field EntSQL annotation
 func mergeEntSQLAnnotation(n *Type, f *Field) {
-	if n.EntSQL() != nil {
-		if f.EntSQL() != nil {
-			f.Annotations[n.EntSQL().Name()] = n.EntSQL().Merge(f.EntSQL())
-		} else {
-			f.Annotations = make(Annotations)
-			f.Annotations[n.EntSQL().Name()] = n.EntSQL()
-		}
+	if n.EntSQL() == nil {
+		return
 	}
+	if f.EntSQL() != nil {
+		f.Annotations[n.EntSQL().Name()] = n.EntSQL().Merge(f.EntSQL())
+		return
+	}
+	f.Annotations = make(Annotations)
+	f.Annotations[n.EntSQL().Name()] = n.EntSQL()
 }
 
 // mayAddColumn adds the given column if it does not already exist in the table.

--- a/entc/gen/graph.go
+++ b/entc/gen/graph.go
@@ -698,7 +698,8 @@ func (g *Graph) Tables() (all []*schema.Table, err error) {
 	return
 }
 
-// If node schema EntSQL annotation exist, merge it into field EntSQL annotation
+// mergeEntSQLAnnotation merge node schema EntSQL annotation into
+// field EntSQL annotation if it exists.
 func mergeEntSQLAnnotation(n *Type, f *Field) {
 	if n.EntSQL() == nil {
 		return

--- a/entc/gen/graph.go
+++ b/entc/gen/graph.go
@@ -585,6 +585,15 @@ func (g *Graph) Tables() (all []*schema.Table, err error) {
 		table.SetAnnotation(n.EntSQL())
 		for _, f := range n.Fields {
 			if !f.IsEdgeField() {
+				// If schema EntSQL annotation exist, merge it into field EntSQL annotation
+				if n.EntSQL() != nil {
+					if f.EntSQL() != nil {
+						f.Annotations[n.EntSQL().Name()] = n.EntSQL().Merge(f.EntSQL())
+					} else {
+						f.Annotations = make(Annotations)
+						f.Annotations[n.EntSQL().Name()] = n.EntSQL()
+					}
+				}
 				table.AddColumn(f.Column())
 			}
 		}

--- a/entc/gen/template/migrate/schema.tmpl
+++ b/entc/gen/template/migrate/schema.tmpl
@@ -36,6 +36,7 @@ var (
 				{{- if $c.Increment }} Increment: true,{{ end }}
 				{{- if $c.Nullable }} Nullable: {{ $c.Nullable }},{{ end }}
 				{{- with $c.Size }} Size: {{ . }},{{ end }}
+				{{- with $c.Comment }} Comment: "{{ $c.Comment }}",{{ end }}
 				{{- with $c.Attr }} Attr: "{{ . }}",{{ end }}
 				{{- with $c.Enums }} Enums: []string{ {{ range $e := . }}"{{ $e }}",{{ end }} },{{ end }}
 				{{- if not (isNil $c.Default) -}}

--- a/entc/gen/type.go
+++ b/entc/gen/type.go
@@ -1359,6 +1359,18 @@ func (f Field) Column() *schema.Column {
 	if f.def != nil {
 		c.SchemaType = f.def.SchemaType
 	}
+	// Override the Comment defined in the
+	// schema if it was provided by an annotation
+	// and WithComments is enabled in annotation.
+	// Comment in annotation is preferred as Comment,
+	// and if Comment in annotation is "" then field comment will be used.
+	if ant := f.EntSQL(); ant != nil && *ant.WithComments == true {
+		if ant.Comment != "" {
+			c.Comment = ant.Comment
+		} else {
+			c.Comment = f.Comment()
+		}
+	}
 	return c
 }
 

--- a/entc/gen/type.go
+++ b/entc/gen/type.go
@@ -1364,7 +1364,7 @@ func (f Field) Column() *schema.Column {
 	// and WithComments is enabled in annotation.
 	// Comment in annotation is preferred as Comment,
 	// and if Comment in annotation is "" then field comment will be used.
-	if ant := f.EntSQL(); ant != nil && *ant.WithComments == true {
+	if ant := f.EntSQL(); ant != nil && ant.WithComments != nil && *ant.WithComments {
 		if ant.Comment != "" {
 			c.Comment = ant.Comment
 		} else {

--- a/entc/gen/type.go
+++ b/entc/gen/type.go
@@ -1429,6 +1429,18 @@ func (f Field) PK() *schema.Column {
 	if f.def != nil {
 		c.SchemaType = f.def.SchemaType
 	}
+	// Override the Comment defined in the
+	// schema if it was provided by an annotation
+	// and WithComments is enabled in annotation.
+	// Comment in annotation is preferred as Comment,
+	// and if Comment in annotation is "" then field comment will be used.
+	if ant := f.EntSQL(); ant != nil && ant.WithComments != nil && *ant.WithComments {
+		if ant.Comment != "" {
+			c.Comment = ant.Comment
+		} else {
+			c.Comment = f.Comment()
+		}
+	}
 	return c
 }
 

--- a/entc/gen/type.go
+++ b/entc/gen/type.go
@@ -1359,17 +1359,11 @@ func (f Field) Column() *schema.Column {
 	if f.def != nil {
 		c.SchemaType = f.def.SchemaType
 	}
-	// Override the Comment defined in the
-	// schema if it was provided by an annotation
-	// and WithComments is enabled in annotation.
-	// Comment in annotation is preferred as Comment,
-	// and if Comment in annotation is "" then field comment will be used.
+	// Override the Comment defined in the schema
+	// if WithComments is enabled in annotation.
+	// Field comment will be used as column comment.
 	if ant := f.EntSQL(); ant != nil && ant.WithComments != nil && *ant.WithComments {
-		if ant.Comment != "" {
-			c.Comment = ant.Comment
-		} else {
-			c.Comment = f.Comment()
-		}
+		c.Comment = f.Comment()
 	}
 	return c
 }
@@ -1429,17 +1423,11 @@ func (f Field) PK() *schema.Column {
 	if f.def != nil {
 		c.SchemaType = f.def.SchemaType
 	}
-	// Override the Comment defined in the
-	// schema if it was provided by an annotation
-	// and WithComments is enabled in annotation.
-	// Comment in annotation is preferred as Comment,
-	// and if Comment in annotation is "" then field comment will be used.
+	// Override the Comment defined in the schema
+	// if WithComments is enabled in annotation.
+	// Field comment will be used as column comment.
 	if ant := f.EntSQL(); ant != nil && ant.WithComments != nil && *ant.WithComments {
-		if ant.Comment != "" {
-			c.Comment = ant.Comment
-		} else {
-			c.Comment = f.Comment()
-		}
+		c.Comment = f.Comment()
 	}
 	return c
 }


### PR DESCRIPTION
Story background: The project uses Ent as the ORM, and the DBA want to view the column comments directly in the database DDL, which will be more convenient.

In order to achieve the goal, add column comment in SQL DDL by using EntSQL annotations. It use field comment as column comment.
All of these are configurable，it will not to trigger migration changes to all users.
