### PR TITLE
fix: Remove deprecated call in documentation

### DIFF
--- a/doc/md/tutorial-grpc-server-and-client.md
+++ b/doc/md/tutorial-grpc-server-and-client.md
@@ -99,7 +99,7 @@ func main() {
 	rand.Seed(time.Now().UnixNano())
 
 	// Open a connection to the server.
-	conn, err := grpc.Dial(":5000", grpc.WithInsecure())
+	conn, err := grpc.Dial(":5000", grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatalf("failed connecting to server: %s", err)
 	}


### PR DESCRIPTION
The documentation uses a deprecated function to setup a connection for an insecure gRPC call

Should be fixed with this PR