### PR TITLE
entc/gen: copies interceptors on Clone

### DIFF
--- a/entc/gen/template/builder/query.tmpl
+++ b/entc/gen/template/builder/query.tmpl
@@ -292,6 +292,7 @@ func ({{ $receiver }} *{{ $builder }}) Clone() *{{ $builder }} {
 		limit: 		{{ $receiver }}.limit,
 		offset: 	{{ $receiver }}.offset,
 		order: 		append([]OrderFunc{}, {{ $receiver }}.order...),
+		inters: 	append([]Interceptor{}, {{ $receiver }}.inters...),
 		predicates: append([]predicate.{{ $.Name }}{}, {{ $receiver }}.predicates...),
 		{{- range $e := $.Edges }}
 			{{ $e.EagerLoadField }}: {{ $receiver }}.{{ $e.EagerLoadField }}.Clone(),

--- a/entc/integration/cascadelete/ent/comment_query.go
+++ b/entc/integration/cascadelete/ent/comment_query.go
@@ -277,6 +277,7 @@ func (cq *CommentQuery) Clone() *CommentQuery {
 		limit:      cq.limit,
 		offset:     cq.offset,
 		order:      append([]OrderFunc{}, cq.order...),
+		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Comment{}, cq.predicates...),
 		withPost:   cq.withPost.Clone(),
 		// clone intermediate query.

--- a/entc/integration/cascadelete/ent/post_query.go
+++ b/entc/integration/cascadelete/ent/post_query.go
@@ -302,6 +302,7 @@ func (pq *PostQuery) Clone() *PostQuery {
 		limit:        pq.limit,
 		offset:       pq.offset,
 		order:        append([]OrderFunc{}, pq.order...),
+		inters:       append([]Interceptor{}, pq.inters...),
 		predicates:   append([]predicate.Post{}, pq.predicates...),
 		withAuthor:   pq.withAuthor.Clone(),
 		withComments: pq.withComments.Clone(),

--- a/entc/integration/cascadelete/ent/user_query.go
+++ b/entc/integration/cascadelete/ent/user_query.go
@@ -278,6 +278,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 		limit:      uq.limit,
 		offset:     uq.offset,
 		order:      append([]OrderFunc{}, uq.order...),
+		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		withPosts:  uq.withPosts.Clone(),
 		// clone intermediate query.

--- a/entc/integration/config/ent/user_query.go
+++ b/entc/integration/config/ent/user_query.go
@@ -253,6 +253,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 		limit:      uq.limit,
 		offset:     uq.offset,
 		order:      append([]OrderFunc{}, uq.order...),
+		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		// clone intermediate query.
 		sql:    uq.sql.Clone(),

--- a/entc/integration/customid/ent/account_query.go
+++ b/entc/integration/customid/ent/account_query.go
@@ -279,6 +279,7 @@ func (aq *AccountQuery) Clone() *AccountQuery {
 		limit:      aq.limit,
 		offset:     aq.offset,
 		order:      append([]OrderFunc{}, aq.order...),
+		inters:     append([]Interceptor{}, aq.inters...),
 		predicates: append([]predicate.Account{}, aq.predicates...),
 		withToken:  aq.withToken.Clone(),
 		// clone intermediate query.

--- a/entc/integration/customid/ent/blob_query.go
+++ b/entc/integration/customid/ent/blob_query.go
@@ -326,6 +326,7 @@ func (bq *BlobQuery) Clone() *BlobQuery {
 		limit:         bq.limit,
 		offset:        bq.offset,
 		order:         append([]OrderFunc{}, bq.order...),
+		inters:        append([]Interceptor{}, bq.inters...),
 		predicates:    append([]predicate.Blob{}, bq.predicates...),
 		withParent:    bq.withParent.Clone(),
 		withLinks:     bq.withLinks.Clone(),

--- a/entc/integration/customid/ent/bloblink_query.go
+++ b/entc/integration/customid/ent/bloblink_query.go
@@ -230,6 +230,7 @@ func (blq *BlobLinkQuery) Clone() *BlobLinkQuery {
 		limit:      blq.limit,
 		offset:     blq.offset,
 		order:      append([]OrderFunc{}, blq.order...),
+		inters:     append([]Interceptor{}, blq.inters...),
 		predicates: append([]predicate.BlobLink{}, blq.predicates...),
 		withBlob:   blq.withBlob.Clone(),
 		withLink:   blq.withLink.Clone(),

--- a/entc/integration/customid/ent/car_query.go
+++ b/entc/integration/customid/ent/car_query.go
@@ -278,6 +278,7 @@ func (cq *CarQuery) Clone() *CarQuery {
 		limit:      cq.limit,
 		offset:     cq.offset,
 		order:      append([]OrderFunc{}, cq.order...),
+		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Car{}, cq.predicates...),
 		withOwner:  cq.withOwner.Clone(),
 		// clone intermediate query.

--- a/entc/integration/customid/ent/device_query.go
+++ b/entc/integration/customid/ent/device_query.go
@@ -303,6 +303,7 @@ func (dq *DeviceQuery) Clone() *DeviceQuery {
 		limit:             dq.limit,
 		offset:            dq.offset,
 		order:             append([]OrderFunc{}, dq.order...),
+		inters:            append([]Interceptor{}, dq.inters...),
 		predicates:        append([]predicate.Device{}, dq.predicates...),
 		withActiveSession: dq.withActiveSession.Clone(),
 		withSessions:      dq.withSessions.Clone(),

--- a/entc/integration/customid/ent/doc_query.go
+++ b/entc/integration/customid/ent/doc_query.go
@@ -325,6 +325,7 @@ func (dq *DocQuery) Clone() *DocQuery {
 		limit:        dq.limit,
 		offset:       dq.offset,
 		order:        append([]OrderFunc{}, dq.order...),
+		inters:       append([]Interceptor{}, dq.inters...),
 		predicates:   append([]predicate.Doc{}, dq.predicates...),
 		withParent:   dq.withParent.Clone(),
 		withChildren: dq.withChildren.Clone(),

--- a/entc/integration/customid/ent/group_query.go
+++ b/entc/integration/customid/ent/group_query.go
@@ -278,6 +278,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 		limit:      gq.limit,
 		offset:     gq.offset,
 		order:      append([]OrderFunc{}, gq.order...),
+		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Group{}, gq.predicates...),
 		withUsers:  gq.withUsers.Clone(),
 		// clone intermediate query.

--- a/entc/integration/customid/ent/intsid_query.go
+++ b/entc/integration/customid/ent/intsid_query.go
@@ -302,6 +302,7 @@ func (isq *IntSIDQuery) Clone() *IntSIDQuery {
 		limit:        isq.limit,
 		offset:       isq.offset,
 		order:        append([]OrderFunc{}, isq.order...),
+		inters:       append([]Interceptor{}, isq.inters...),
 		predicates:   append([]predicate.IntSID{}, isq.predicates...),
 		withParent:   isq.withParent.Clone(),
 		withChildren: isq.withChildren.Clone(),

--- a/entc/integration/customid/ent/link_query.go
+++ b/entc/integration/customid/ent/link_query.go
@@ -254,6 +254,7 @@ func (lq *LinkQuery) Clone() *LinkQuery {
 		limit:      lq.limit,
 		offset:     lq.offset,
 		order:      append([]OrderFunc{}, lq.order...),
+		inters:     append([]Interceptor{}, lq.inters...),
 		predicates: append([]predicate.Link{}, lq.predicates...),
 		// clone intermediate query.
 		sql:    lq.sql.Clone(),

--- a/entc/integration/customid/ent/mixinid_query.go
+++ b/entc/integration/customid/ent/mixinid_query.go
@@ -254,6 +254,7 @@ func (miq *MixinIDQuery) Clone() *MixinIDQuery {
 		limit:      miq.limit,
 		offset:     miq.offset,
 		order:      append([]OrderFunc{}, miq.order...),
+		inters:     append([]Interceptor{}, miq.inters...),
 		predicates: append([]predicate.MixinID{}, miq.predicates...),
 		// clone intermediate query.
 		sql:    miq.sql.Clone(),

--- a/entc/integration/customid/ent/note_query.go
+++ b/entc/integration/customid/ent/note_query.go
@@ -302,6 +302,7 @@ func (nq *NoteQuery) Clone() *NoteQuery {
 		limit:        nq.limit,
 		offset:       nq.offset,
 		order:        append([]OrderFunc{}, nq.order...),
+		inters:       append([]Interceptor{}, nq.inters...),
 		predicates:   append([]predicate.Note{}, nq.predicates...),
 		withParent:   nq.withParent.Clone(),
 		withChildren: nq.withChildren.Clone(),

--- a/entc/integration/customid/ent/other_query.go
+++ b/entc/integration/customid/ent/other_query.go
@@ -254,6 +254,7 @@ func (oq *OtherQuery) Clone() *OtherQuery {
 		limit:      oq.limit,
 		offset:     oq.offset,
 		order:      append([]OrderFunc{}, oq.order...),
+		inters:     append([]Interceptor{}, oq.inters...),
 		predicates: append([]predicate.Other{}, oq.predicates...),
 		// clone intermediate query.
 		sql:    oq.sql.Clone(),

--- a/entc/integration/customid/ent/pet_query.go
+++ b/entc/integration/customid/ent/pet_query.go
@@ -349,6 +349,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 		limit:          pq.limit,
 		offset:         pq.offset,
 		order:          append([]OrderFunc{}, pq.order...),
+		inters:         append([]Interceptor{}, pq.inters...),
 		predicates:     append([]predicate.Pet{}, pq.predicates...),
 		withOwner:      pq.withOwner.Clone(),
 		withCars:       pq.withCars.Clone(),

--- a/entc/integration/customid/ent/revision_query.go
+++ b/entc/integration/customid/ent/revision_query.go
@@ -253,6 +253,7 @@ func (rq *RevisionQuery) Clone() *RevisionQuery {
 		limit:      rq.limit,
 		offset:     rq.offset,
 		order:      append([]OrderFunc{}, rq.order...),
+		inters:     append([]Interceptor{}, rq.inters...),
 		predicates: append([]predicate.Revision{}, rq.predicates...),
 		// clone intermediate query.
 		sql:    rq.sql.Clone(),

--- a/entc/integration/customid/ent/session_query.go
+++ b/entc/integration/customid/ent/session_query.go
@@ -279,6 +279,7 @@ func (sq *SessionQuery) Clone() *SessionQuery {
 		limit:      sq.limit,
 		offset:     sq.offset,
 		order:      append([]OrderFunc{}, sq.order...),
+		inters:     append([]Interceptor{}, sq.inters...),
 		predicates: append([]predicate.Session{}, sq.predicates...),
 		withDevice: sq.withDevice.Clone(),
 		// clone intermediate query.

--- a/entc/integration/customid/ent/token_query.go
+++ b/entc/integration/customid/ent/token_query.go
@@ -279,6 +279,7 @@ func (tq *TokenQuery) Clone() *TokenQuery {
 		limit:       tq.limit,
 		offset:      tq.offset,
 		order:       append([]OrderFunc{}, tq.order...),
+		inters:      append([]Interceptor{}, tq.inters...),
 		predicates:  append([]predicate.Token{}, tq.predicates...),
 		withAccount: tq.withAccount.Clone(),
 		// clone intermediate query.

--- a/entc/integration/customid/ent/user_query.go
+++ b/entc/integration/customid/ent/user_query.go
@@ -349,6 +349,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 		limit:        uq.limit,
 		offset:       uq.offset,
 		order:        append([]OrderFunc{}, uq.order...),
+		inters:       append([]Interceptor{}, uq.inters...),
 		predicates:   append([]predicate.User{}, uq.predicates...),
 		withGroups:   uq.withGroups.Clone(),
 		withParent:   uq.withParent.Clone(),

--- a/entc/integration/edgefield/ent/car_query.go
+++ b/entc/integration/edgefield/ent/car_query.go
@@ -279,6 +279,7 @@ func (cq *CarQuery) Clone() *CarQuery {
 		limit:       cq.limit,
 		offset:      cq.offset,
 		order:       append([]OrderFunc{}, cq.order...),
+		inters:      append([]Interceptor{}, cq.inters...),
 		predicates:  append([]predicate.Car{}, cq.predicates...),
 		withRentals: cq.withRentals.Clone(),
 		// clone intermediate query.

--- a/entc/integration/edgefield/ent/card_query.go
+++ b/entc/integration/edgefield/ent/card_query.go
@@ -277,6 +277,7 @@ func (cq *CardQuery) Clone() *CardQuery {
 		limit:      cq.limit,
 		offset:     cq.offset,
 		order:      append([]OrderFunc{}, cq.order...),
+		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Card{}, cq.predicates...),
 		withOwner:  cq.withOwner.Clone(),
 		// clone intermediate query.

--- a/entc/integration/edgefield/ent/info_query.go
+++ b/entc/integration/edgefield/ent/info_query.go
@@ -277,6 +277,7 @@ func (iq *InfoQuery) Clone() *InfoQuery {
 		limit:      iq.limit,
 		offset:     iq.offset,
 		order:      append([]OrderFunc{}, iq.order...),
+		inters:     append([]Interceptor{}, iq.inters...),
 		predicates: append([]predicate.Info{}, iq.predicates...),
 		withUser:   iq.withUser.Clone(),
 		// clone intermediate query.

--- a/entc/integration/edgefield/ent/metadata_query.go
+++ b/entc/integration/edgefield/ent/metadata_query.go
@@ -324,6 +324,7 @@ func (mq *MetadataQuery) Clone() *MetadataQuery {
 		limit:        mq.limit,
 		offset:       mq.offset,
 		order:        append([]OrderFunc{}, mq.order...),
+		inters:       append([]Interceptor{}, mq.inters...),
 		predicates:   append([]predicate.Metadata{}, mq.predicates...),
 		withUser:     mq.withUser.Clone(),
 		withChildren: mq.withChildren.Clone(),

--- a/entc/integration/edgefield/ent/node_query.go
+++ b/entc/integration/edgefield/ent/node_query.go
@@ -300,6 +300,7 @@ func (nq *NodeQuery) Clone() *NodeQuery {
 		limit:      nq.limit,
 		offset:     nq.offset,
 		order:      append([]OrderFunc{}, nq.order...),
+		inters:     append([]Interceptor{}, nq.inters...),
 		predicates: append([]predicate.Node{}, nq.predicates...),
 		withPrev:   nq.withPrev.Clone(),
 		withNext:   nq.withNext.Clone(),

--- a/entc/integration/edgefield/ent/pet_query.go
+++ b/entc/integration/edgefield/ent/pet_query.go
@@ -277,6 +277,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 		limit:      pq.limit,
 		offset:     pq.offset,
 		order:      append([]OrderFunc{}, pq.order...),
+		inters:     append([]Interceptor{}, pq.inters...),
 		predicates: append([]predicate.Pet{}, pq.predicates...),
 		withOwner:  pq.withOwner.Clone(),
 		// clone intermediate query.

--- a/entc/integration/edgefield/ent/post_query.go
+++ b/entc/integration/edgefield/ent/post_query.go
@@ -277,6 +277,7 @@ func (pq *PostQuery) Clone() *PostQuery {
 		limit:      pq.limit,
 		offset:     pq.offset,
 		order:      append([]OrderFunc{}, pq.order...),
+		inters:     append([]Interceptor{}, pq.inters...),
 		predicates: append([]predicate.Post{}, pq.predicates...),
 		withAuthor: pq.withAuthor.Clone(),
 		// clone intermediate query.

--- a/entc/integration/edgefield/ent/rental_query.go
+++ b/entc/integration/edgefield/ent/rental_query.go
@@ -302,6 +302,7 @@ func (rq *RentalQuery) Clone() *RentalQuery {
 		limit:      rq.limit,
 		offset:     rq.offset,
 		order:      append([]OrderFunc{}, rq.order...),
+		inters:     append([]Interceptor{}, rq.inters...),
 		predicates: append([]predicate.Rental{}, rq.predicates...),
 		withUser:   rq.withUser.Clone(),
 		withCar:    rq.withCar.Clone(),

--- a/entc/integration/edgefield/ent/user_query.go
+++ b/entc/integration/edgefield/ent/user_query.go
@@ -443,6 +443,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 		limit:        uq.limit,
 		offset:       uq.offset,
 		order:        append([]OrderFunc{}, uq.order...),
+		inters:       append([]Interceptor{}, uq.inters...),
 		predicates:   append([]predicate.User{}, uq.predicates...),
 		withPets:     uq.withPets.Clone(),
 		withParent:   uq.withParent.Clone(),

--- a/entc/integration/edgeschema/ent/friendship_query.go
+++ b/entc/integration/edgeschema/ent/friendship_query.go
@@ -300,6 +300,7 @@ func (fq *FriendshipQuery) Clone() *FriendshipQuery {
 		limit:      fq.limit,
 		offset:     fq.offset,
 		order:      append([]OrderFunc{}, fq.order...),
+		inters:     append([]Interceptor{}, fq.inters...),
 		predicates: append([]predicate.Friendship{}, fq.predicates...),
 		withUser:   fq.withUser.Clone(),
 		withFriend: fq.withFriend.Clone(),

--- a/entc/integration/edgeschema/ent/group_query.go
+++ b/entc/integration/edgeschema/ent/group_query.go
@@ -350,6 +350,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 		limit:           gq.limit,
 		offset:          gq.offset,
 		order:           append([]OrderFunc{}, gq.order...),
+		inters:          append([]Interceptor{}, gq.inters...),
 		predicates:      append([]predicate.Group{}, gq.predicates...),
 		withUsers:       gq.withUsers.Clone(),
 		withTags:        gq.withTags.Clone(),

--- a/entc/integration/edgeschema/ent/grouptag_query.go
+++ b/entc/integration/edgeschema/ent/grouptag_query.go
@@ -301,6 +301,7 @@ func (gtq *GroupTagQuery) Clone() *GroupTagQuery {
 		limit:      gtq.limit,
 		offset:     gtq.offset,
 		order:      append([]OrderFunc{}, gtq.order...),
+		inters:     append([]Interceptor{}, gtq.inters...),
 		predicates: append([]predicate.GroupTag{}, gtq.predicates...),
 		withTag:    gtq.withTag.Clone(),
 		withGroup:  gtq.withGroup.Clone(),

--- a/entc/integration/edgeschema/ent/relationship_query.go
+++ b/entc/integration/edgeschema/ent/relationship_query.go
@@ -254,6 +254,7 @@ func (rq *RelationshipQuery) Clone() *RelationshipQuery {
 		limit:        rq.limit,
 		offset:       rq.offset,
 		order:        append([]OrderFunc{}, rq.order...),
+		inters:       append([]Interceptor{}, rq.inters...),
 		predicates:   append([]predicate.Relationship{}, rq.predicates...),
 		withUser:     rq.withUser.Clone(),
 		withRelative: rq.withRelative.Clone(),

--- a/entc/integration/edgeschema/ent/relationshipinfo_query.go
+++ b/entc/integration/edgeschema/ent/relationshipinfo_query.go
@@ -253,6 +253,7 @@ func (riq *RelationshipInfoQuery) Clone() *RelationshipInfoQuery {
 		limit:      riq.limit,
 		offset:     riq.offset,
 		order:      append([]OrderFunc{}, riq.order...),
+		inters:     append([]Interceptor{}, riq.inters...),
 		predicates: append([]predicate.RelationshipInfo{}, riq.predicates...),
 		// clone intermediate query.
 		sql:    riq.sql.Clone(),

--- a/entc/integration/edgeschema/ent/role_query.go
+++ b/entc/integration/edgeschema/ent/role_query.go
@@ -302,6 +302,7 @@ func (rq *RoleQuery) Clone() *RoleQuery {
 		limit:          rq.limit,
 		offset:         rq.offset,
 		order:          append([]OrderFunc{}, rq.order...),
+		inters:         append([]Interceptor{}, rq.inters...),
 		predicates:     append([]predicate.Role{}, rq.predicates...),
 		withUser:       rq.withUser.Clone(),
 		withRolesUsers: rq.withRolesUsers.Clone(),

--- a/entc/integration/edgeschema/ent/roleuser_query.go
+++ b/entc/integration/edgeschema/ent/roleuser_query.go
@@ -230,6 +230,7 @@ func (ruq *RoleUserQuery) Clone() *RoleUserQuery {
 		limit:      ruq.limit,
 		offset:     ruq.offset,
 		order:      append([]OrderFunc{}, ruq.order...),
+		inters:     append([]Interceptor{}, ruq.inters...),
 		predicates: append([]predicate.RoleUser{}, ruq.predicates...),
 		withRole:   ruq.withRole.Clone(),
 		withUser:   ruq.withUser.Clone(),

--- a/entc/integration/edgeschema/ent/tag_query.go
+++ b/entc/integration/edgeschema/ent/tag_query.go
@@ -350,6 +350,7 @@ func (tq *TagQuery) Clone() *TagQuery {
 		limit:         tq.limit,
 		offset:        tq.offset,
 		order:         append([]OrderFunc{}, tq.order...),
+		inters:        append([]Interceptor{}, tq.inters...),
 		predicates:    append([]predicate.Tag{}, tq.predicates...),
 		withTweets:    tq.withTweets.Clone(),
 		withGroups:    tq.withGroups.Clone(),

--- a/entc/integration/edgeschema/ent/tweet_query.go
+++ b/entc/integration/edgeschema/ent/tweet_query.go
@@ -397,6 +397,7 @@ func (tq *TweetQuery) Clone() *TweetQuery {
 		limit:          tq.limit,
 		offset:         tq.offset,
 		order:          append([]OrderFunc{}, tq.order...),
+		inters:         append([]Interceptor{}, tq.inters...),
 		predicates:     append([]predicate.Tweet{}, tq.predicates...),
 		withLikedUsers: tq.withLikedUsers.Clone(),
 		withUser:       tq.withUser.Clone(),

--- a/entc/integration/edgeschema/ent/tweetlike_query.go
+++ b/entc/integration/edgeschema/ent/tweetlike_query.go
@@ -231,6 +231,7 @@ func (tlq *TweetLikeQuery) Clone() *TweetLikeQuery {
 		limit:      tlq.limit,
 		offset:     tlq.offset,
 		order:      append([]OrderFunc{}, tlq.order...),
+		inters:     append([]Interceptor{}, tlq.inters...),
 		predicates: append([]predicate.TweetLike{}, tlq.predicates...),
 		withTweet:  tlq.withTweet.Clone(),
 		withUser:   tlq.withUser.Clone(),

--- a/entc/integration/edgeschema/ent/tweettag_query.go
+++ b/entc/integration/edgeschema/ent/tweettag_query.go
@@ -302,6 +302,7 @@ func (ttq *TweetTagQuery) Clone() *TweetTagQuery {
 		limit:      ttq.limit,
 		offset:     ttq.offset,
 		order:      append([]OrderFunc{}, ttq.order...),
+		inters:     append([]Interceptor{}, ttq.inters...),
 		predicates: append([]predicate.TweetTag{}, ttq.predicates...),
 		withTag:    ttq.withTag.Clone(),
 		withTweet:  ttq.withTweet.Clone(),

--- a/entc/integration/edgeschema/ent/user_query.go
+++ b/entc/integration/edgeschema/ent/user_query.go
@@ -540,6 +540,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 		limit:            uq.limit,
 		offset:           uq.offset,
 		order:            append([]OrderFunc{}, uq.order...),
+		inters:           append([]Interceptor{}, uq.inters...),
 		predicates:       append([]predicate.User{}, uq.predicates...),
 		withGroups:       uq.withGroups.Clone(),
 		withFriends:      uq.withFriends.Clone(),

--- a/entc/integration/edgeschema/ent/usergroup_query.go
+++ b/entc/integration/edgeschema/ent/usergroup_query.go
@@ -301,6 +301,7 @@ func (ugq *UserGroupQuery) Clone() *UserGroupQuery {
 		limit:      ugq.limit,
 		offset:     ugq.offset,
 		order:      append([]OrderFunc{}, ugq.order...),
+		inters:     append([]Interceptor{}, ugq.inters...),
 		predicates: append([]predicate.UserGroup{}, ugq.predicates...),
 		withUser:   ugq.withUser.Clone(),
 		withGroup:  ugq.withGroup.Clone(),

--- a/entc/integration/edgeschema/ent/usertweet_query.go
+++ b/entc/integration/edgeschema/ent/usertweet_query.go
@@ -301,6 +301,7 @@ func (utq *UserTweetQuery) Clone() *UserTweetQuery {
 		limit:      utq.limit,
 		offset:     utq.offset,
 		order:      append([]OrderFunc{}, utq.order...),
+		inters:     append([]Interceptor{}, utq.inters...),
 		predicates: append([]predicate.UserTweet{}, utq.predicates...),
 		withUser:   utq.withUser.Clone(),
 		withTweet:  utq.withTweet.Clone(),

--- a/entc/integration/ent/card_query.go
+++ b/entc/integration/ent/card_query.go
@@ -306,6 +306,7 @@ func (cq *CardQuery) Clone() *CardQuery {
 		limit:      cq.limit,
 		offset:     cq.offset,
 		order:      append([]OrderFunc{}, cq.order...),
+		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Card{}, cq.predicates...),
 		withOwner:  cq.withOwner.Clone(),
 		withSpec:   cq.withSpec.Clone(),

--- a/entc/integration/ent/comment_query.go
+++ b/entc/integration/ent/comment_query.go
@@ -255,6 +255,7 @@ func (cq *CommentQuery) Clone() *CommentQuery {
 		limit:      cq.limit,
 		offset:     cq.offset,
 		order:      append([]OrderFunc{}, cq.order...),
+		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Comment{}, cq.predicates...),
 		// clone intermediate query.
 		sql:    cq.sql.Clone(),

--- a/entc/integration/ent/fieldtype_query.go
+++ b/entc/integration/ent/fieldtype_query.go
@@ -256,6 +256,7 @@ func (ftq *FieldTypeQuery) Clone() *FieldTypeQuery {
 		limit:      ftq.limit,
 		offset:     ftq.offset,
 		order:      append([]OrderFunc{}, ftq.order...),
+		inters:     append([]Interceptor{}, ftq.inters...),
 		predicates: append([]predicate.FieldType{}, ftq.predicates...),
 		// clone intermediate query.
 		sql:    ftq.sql.Clone(),

--- a/entc/integration/ent/file_query.go
+++ b/entc/integration/ent/file_query.go
@@ -330,6 +330,7 @@ func (fq *FileQuery) Clone() *FileQuery {
 		limit:      fq.limit,
 		offset:     fq.offset,
 		order:      append([]OrderFunc{}, fq.order...),
+		inters:     append([]Interceptor{}, fq.inters...),
 		predicates: append([]predicate.File{}, fq.predicates...),
 		withOwner:  fq.withOwner.Clone(),
 		withType:   fq.withType.Clone(),

--- a/entc/integration/ent/filetype_query.go
+++ b/entc/integration/ent/filetype_query.go
@@ -281,6 +281,7 @@ func (ftq *FileTypeQuery) Clone() *FileTypeQuery {
 		limit:      ftq.limit,
 		offset:     ftq.offset,
 		order:      append([]OrderFunc{}, ftq.order...),
+		inters:     append([]Interceptor{}, ftq.inters...),
 		predicates: append([]predicate.FileType{}, ftq.predicates...),
 		withFiles:  ftq.withFiles.Clone(),
 		// clone intermediate query.

--- a/entc/integration/ent/goods_query.go
+++ b/entc/integration/ent/goods_query.go
@@ -255,6 +255,7 @@ func (gq *GoodsQuery) Clone() *GoodsQuery {
 		limit:      gq.limit,
 		offset:     gq.offset,
 		order:      append([]OrderFunc{}, gq.order...),
+		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Goods{}, gq.predicates...),
 		// clone intermediate query.
 		sql:    gq.sql.Clone(),

--- a/entc/integration/ent/group_query.go
+++ b/entc/integration/ent/group_query.go
@@ -355,6 +355,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 		limit:       gq.limit,
 		offset:      gq.offset,
 		order:       append([]OrderFunc{}, gq.order...),
+		inters:      append([]Interceptor{}, gq.inters...),
 		predicates:  append([]predicate.Group{}, gq.predicates...),
 		withFiles:   gq.withFiles.Clone(),
 		withBlocked: gq.withBlocked.Clone(),

--- a/entc/integration/ent/groupinfo_query.go
+++ b/entc/integration/ent/groupinfo_query.go
@@ -281,6 +281,7 @@ func (giq *GroupInfoQuery) Clone() *GroupInfoQuery {
 		limit:      giq.limit,
 		offset:     giq.offset,
 		order:      append([]OrderFunc{}, giq.order...),
+		inters:     append([]Interceptor{}, giq.inters...),
 		predicates: append([]predicate.GroupInfo{}, giq.predicates...),
 		withGroups: giq.withGroups.Clone(),
 		// clone intermediate query.

--- a/entc/integration/ent/item_query.go
+++ b/entc/integration/ent/item_query.go
@@ -255,6 +255,7 @@ func (iq *ItemQuery) Clone() *ItemQuery {
 		limit:      iq.limit,
 		offset:     iq.offset,
 		order:      append([]OrderFunc{}, iq.order...),
+		inters:     append([]Interceptor{}, iq.inters...),
 		predicates: append([]predicate.Item{}, iq.predicates...),
 		// clone intermediate query.
 		sql:    iq.sql.Clone(),

--- a/entc/integration/ent/license_query.go
+++ b/entc/integration/ent/license_query.go
@@ -255,6 +255,7 @@ func (lq *LicenseQuery) Clone() *LicenseQuery {
 		limit:      lq.limit,
 		offset:     lq.offset,
 		order:      append([]OrderFunc{}, lq.order...),
+		inters:     append([]Interceptor{}, lq.inters...),
 		predicates: append([]predicate.License{}, lq.predicates...),
 		// clone intermediate query.
 		sql:    lq.sql.Clone(),

--- a/entc/integration/ent/node_query.go
+++ b/entc/integration/ent/node_query.go
@@ -303,6 +303,7 @@ func (nq *NodeQuery) Clone() *NodeQuery {
 		limit:      nq.limit,
 		offset:     nq.offset,
 		order:      append([]OrderFunc{}, nq.order...),
+		inters:     append([]Interceptor{}, nq.inters...),
 		predicates: append([]predicate.Node{}, nq.predicates...),
 		withPrev:   nq.withPrev.Clone(),
 		withNext:   nq.withNext.Clone(),

--- a/entc/integration/ent/pet_query.go
+++ b/entc/integration/ent/pet_query.go
@@ -303,6 +303,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 		limit:      pq.limit,
 		offset:     pq.offset,
 		order:      append([]OrderFunc{}, pq.order...),
+		inters:     append([]Interceptor{}, pq.inters...),
 		predicates: append([]predicate.Pet{}, pq.predicates...),
 		withTeam:   pq.withTeam.Clone(),
 		withOwner:  pq.withOwner.Clone(),

--- a/entc/integration/ent/spec_query.go
+++ b/entc/integration/ent/spec_query.go
@@ -281,6 +281,7 @@ func (sq *SpecQuery) Clone() *SpecQuery {
 		limit:      sq.limit,
 		offset:     sq.offset,
 		order:      append([]OrderFunc{}, sq.order...),
+		inters:     append([]Interceptor{}, sq.inters...),
 		predicates: append([]predicate.Spec{}, sq.predicates...),
 		withCard:   sq.withCard.Clone(),
 		// clone intermediate query.

--- a/entc/integration/ent/task_query.go
+++ b/entc/integration/ent/task_query.go
@@ -256,6 +256,7 @@ func (tq *TaskQuery) Clone() *TaskQuery {
 		limit:      tq.limit,
 		offset:     tq.offset,
 		order:      append([]OrderFunc{}, tq.order...),
+		inters:     append([]Interceptor{}, tq.inters...),
 		predicates: append([]predicate.Task{}, tq.predicates...),
 		// clone intermediate query.
 		sql:    tq.sql.Clone(),

--- a/entc/integration/ent/user_query.go
+++ b/entc/integration/ent/user_query.go
@@ -521,6 +521,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 		limit:         uq.limit,
 		offset:        uq.offset,
 		order:         append([]OrderFunc{}, uq.order...),
+		inters:        append([]Interceptor{}, uq.inters...),
 		predicates:    append([]predicate.User{}, uq.predicates...),
 		withCard:      uq.withCard.Clone(),
 		withPets:      uq.withPets.Clone(),

--- a/entc/integration/gremlin/ent/card_query.go
+++ b/entc/integration/gremlin/ent/card_query.go
@@ -286,6 +286,7 @@ func (cq *CardQuery) Clone() *CardQuery {
 		limit:      cq.limit,
 		offset:     cq.offset,
 		order:      append([]OrderFunc{}, cq.order...),
+		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Card{}, cq.predicates...),
 		withOwner:  cq.withOwner.Clone(),
 		withSpec:   cq.withSpec.Clone(),

--- a/entc/integration/gremlin/ent/comment_query.go
+++ b/entc/integration/gremlin/ent/comment_query.go
@@ -254,6 +254,7 @@ func (cq *CommentQuery) Clone() *CommentQuery {
 		limit:      cq.limit,
 		offset:     cq.offset,
 		order:      append([]OrderFunc{}, cq.order...),
+		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Comment{}, cq.predicates...),
 		// clone intermediate query.
 		gremlin: cq.gremlin.Clone(),

--- a/entc/integration/gremlin/ent/fieldtype_query.go
+++ b/entc/integration/gremlin/ent/fieldtype_query.go
@@ -254,6 +254,7 @@ func (ftq *FieldTypeQuery) Clone() *FieldTypeQuery {
 		limit:      ftq.limit,
 		offset:     ftq.offset,
 		order:      append([]OrderFunc{}, ftq.order...),
+		inters:     append([]Interceptor{}, ftq.inters...),
 		predicates: append([]predicate.FieldType{}, ftq.predicates...),
 		// clone intermediate query.
 		gremlin: ftq.gremlin.Clone(),

--- a/entc/integration/gremlin/ent/file_query.go
+++ b/entc/integration/gremlin/ent/file_query.go
@@ -301,6 +301,7 @@ func (fq *FileQuery) Clone() *FileQuery {
 		limit:      fq.limit,
 		offset:     fq.offset,
 		order:      append([]OrderFunc{}, fq.order...),
+		inters:     append([]Interceptor{}, fq.inters...),
 		predicates: append([]predicate.File{}, fq.predicates...),
 		withOwner:  fq.withOwner.Clone(),
 		withType:   fq.withType.Clone(),

--- a/entc/integration/gremlin/ent/filetype_query.go
+++ b/entc/integration/gremlin/ent/filetype_query.go
@@ -269,6 +269,7 @@ func (ftq *FileTypeQuery) Clone() *FileTypeQuery {
 		limit:      ftq.limit,
 		offset:     ftq.offset,
 		order:      append([]OrderFunc{}, ftq.order...),
+		inters:     append([]Interceptor{}, ftq.inters...),
 		predicates: append([]predicate.FileType{}, ftq.predicates...),
 		withFiles:  ftq.withFiles.Clone(),
 		// clone intermediate query.

--- a/entc/integration/gremlin/ent/goods_query.go
+++ b/entc/integration/gremlin/ent/goods_query.go
@@ -254,6 +254,7 @@ func (gq *GoodsQuery) Clone() *GoodsQuery {
 		limit:      gq.limit,
 		offset:     gq.offset,
 		order:      append([]OrderFunc{}, gq.order...),
+		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Goods{}, gq.predicates...),
 		// clone intermediate query.
 		gremlin: gq.gremlin.Clone(),

--- a/entc/integration/gremlin/ent/group_query.go
+++ b/entc/integration/gremlin/ent/group_query.go
@@ -315,6 +315,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 		limit:       gq.limit,
 		offset:      gq.offset,
 		order:       append([]OrderFunc{}, gq.order...),
+		inters:      append([]Interceptor{}, gq.inters...),
 		predicates:  append([]predicate.Group{}, gq.predicates...),
 		withFiles:   gq.withFiles.Clone(),
 		withBlocked: gq.withBlocked.Clone(),

--- a/entc/integration/gremlin/ent/groupinfo_query.go
+++ b/entc/integration/gremlin/ent/groupinfo_query.go
@@ -270,6 +270,7 @@ func (giq *GroupInfoQuery) Clone() *GroupInfoQuery {
 		limit:      giq.limit,
 		offset:     giq.offset,
 		order:      append([]OrderFunc{}, giq.order...),
+		inters:     append([]Interceptor{}, giq.inters...),
 		predicates: append([]predicate.GroupInfo{}, giq.predicates...),
 		withGroups: giq.withGroups.Clone(),
 		// clone intermediate query.

--- a/entc/integration/gremlin/ent/item_query.go
+++ b/entc/integration/gremlin/ent/item_query.go
@@ -254,6 +254,7 @@ func (iq *ItemQuery) Clone() *ItemQuery {
 		limit:      iq.limit,
 		offset:     iq.offset,
 		order:      append([]OrderFunc{}, iq.order...),
+		inters:     append([]Interceptor{}, iq.inters...),
 		predicates: append([]predicate.Item{}, iq.predicates...),
 		// clone intermediate query.
 		gremlin: iq.gremlin.Clone(),

--- a/entc/integration/gremlin/ent/license_query.go
+++ b/entc/integration/gremlin/ent/license_query.go
@@ -254,6 +254,7 @@ func (lq *LicenseQuery) Clone() *LicenseQuery {
 		limit:      lq.limit,
 		offset:     lq.offset,
 		order:      append([]OrderFunc{}, lq.order...),
+		inters:     append([]Interceptor{}, lq.inters...),
 		predicates: append([]predicate.License{}, lq.predicates...),
 		// clone intermediate query.
 		gremlin: lq.gremlin.Clone(),

--- a/entc/integration/gremlin/ent/node_query.go
+++ b/entc/integration/gremlin/ent/node_query.go
@@ -284,6 +284,7 @@ func (nq *NodeQuery) Clone() *NodeQuery {
 		limit:      nq.limit,
 		offset:     nq.offset,
 		order:      append([]OrderFunc{}, nq.order...),
+		inters:     append([]Interceptor{}, nq.inters...),
 		predicates: append([]predicate.Node{}, nq.predicates...),
 		withPrev:   nq.withPrev.Clone(),
 		withNext:   nq.withNext.Clone(),

--- a/entc/integration/gremlin/ent/pet_query.go
+++ b/entc/integration/gremlin/ent/pet_query.go
@@ -285,6 +285,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 		limit:      pq.limit,
 		offset:     pq.offset,
 		order:      append([]OrderFunc{}, pq.order...),
+		inters:     append([]Interceptor{}, pq.inters...),
 		predicates: append([]predicate.Pet{}, pq.predicates...),
 		withTeam:   pq.withTeam.Clone(),
 		withOwner:  pq.withOwner.Clone(),

--- a/entc/integration/gremlin/ent/spec_query.go
+++ b/entc/integration/gremlin/ent/spec_query.go
@@ -269,6 +269,7 @@ func (sq *SpecQuery) Clone() *SpecQuery {
 		limit:      sq.limit,
 		offset:     sq.offset,
 		order:      append([]OrderFunc{}, sq.order...),
+		inters:     append([]Interceptor{}, sq.inters...),
 		predicates: append([]predicate.Spec{}, sq.predicates...),
 		withCard:   sq.withCard.Clone(),
 		// clone intermediate query.

--- a/entc/integration/gremlin/ent/task_query.go
+++ b/entc/integration/gremlin/ent/task_query.go
@@ -255,6 +255,7 @@ func (tq *TaskQuery) Clone() *TaskQuery {
 		limit:      tq.limit,
 		offset:     tq.offset,
 		order:      append([]OrderFunc{}, tq.order...),
+		inters:     append([]Interceptor{}, tq.inters...),
 		predicates: append([]predicate.Task{}, tq.predicates...),
 		// clone intermediate query.
 		gremlin: tq.gremlin.Clone(),

--- a/entc/integration/gremlin/ent/user_query.go
+++ b/entc/integration/gremlin/ent/user_query.go
@@ -419,6 +419,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 		limit:         uq.limit,
 		offset:        uq.offset,
 		order:         append([]OrderFunc{}, uq.order...),
+		inters:        append([]Interceptor{}, uq.inters...),
 		predicates:    append([]predicate.User{}, uq.predicates...),
 		withCard:      uq.withCard.Clone(),
 		withPets:      uq.withPets.Clone(),

--- a/entc/integration/hooks/ent/card_query.go
+++ b/entc/integration/hooks/ent/card_query.go
@@ -278,6 +278,7 @@ func (cq *CardQuery) Clone() *CardQuery {
 		limit:      cq.limit,
 		offset:     cq.offset,
 		order:      append([]OrderFunc{}, cq.order...),
+		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Card{}, cq.predicates...),
 		withOwner:  cq.withOwner.Clone(),
 		// clone intermediate query.

--- a/entc/integration/hooks/ent/pet_query.go
+++ b/entc/integration/hooks/ent/pet_query.go
@@ -278,6 +278,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 		limit:      pq.limit,
 		offset:     pq.offset,
 		order:      append([]OrderFunc{}, pq.order...),
+		inters:     append([]Interceptor{}, pq.inters...),
 		predicates: append([]predicate.Pet{}, pq.predicates...),
 		withOwner:  pq.withOwner.Clone(),
 		// clone intermediate query.

--- a/entc/integration/hooks/ent/user_query.go
+++ b/entc/integration/hooks/ent/user_query.go
@@ -349,6 +349,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 		limit:          uq.limit,
 		offset:         uq.offset,
 		order:          append([]OrderFunc{}, uq.order...),
+		inters:         append([]Interceptor{}, uq.inters...),
 		predicates:     append([]predicate.User{}, uq.predicates...),
 		withCards:      uq.withCards.Clone(),
 		withPets:       uq.withPets.Clone(),

--- a/entc/integration/idtype/ent/user_query.go
+++ b/entc/integration/idtype/ent/user_query.go
@@ -324,6 +324,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 		limit:         uq.limit,
 		offset:        uq.offset,
 		order:         append([]OrderFunc{}, uq.order...),
+		inters:        append([]Interceptor{}, uq.inters...),
 		predicates:    append([]predicate.User{}, uq.predicates...),
 		withSpouse:    uq.withSpouse.Clone(),
 		withFollowers: uq.withFollowers.Clone(),

--- a/entc/integration/json/ent/user_query.go
+++ b/entc/integration/json/ent/user_query.go
@@ -254,6 +254,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 		limit:      uq.limit,
 		offset:     uq.offset,
 		order:      append([]OrderFunc{}, uq.order...),
+		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		// clone intermediate query.
 		sql:    uq.sql.Clone(),

--- a/entc/integration/migrate/entv1/car_query.go
+++ b/entc/integration/migrate/entv1/car_query.go
@@ -278,6 +278,7 @@ func (cq *CarQuery) Clone() *CarQuery {
 		limit:      cq.limit,
 		offset:     cq.offset,
 		order:      append([]OrderFunc{}, cq.order...),
+		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Car{}, cq.predicates...),
 		withOwner:  cq.withOwner.Clone(),
 		// clone intermediate query.

--- a/entc/integration/migrate/entv1/conversion_query.go
+++ b/entc/integration/migrate/entv1/conversion_query.go
@@ -253,6 +253,7 @@ func (cq *ConversionQuery) Clone() *ConversionQuery {
 		limit:      cq.limit,
 		offset:     cq.offset,
 		order:      append([]OrderFunc{}, cq.order...),
+		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Conversion{}, cq.predicates...),
 		// clone intermediate query.
 		sql:    cq.sql.Clone(),

--- a/entc/integration/migrate/entv1/customtype_query.go
+++ b/entc/integration/migrate/entv1/customtype_query.go
@@ -253,6 +253,7 @@ func (ctq *CustomTypeQuery) Clone() *CustomTypeQuery {
 		limit:      ctq.limit,
 		offset:     ctq.offset,
 		order:      append([]OrderFunc{}, ctq.order...),
+		inters:     append([]Interceptor{}, ctq.inters...),
 		predicates: append([]predicate.CustomType{}, ctq.predicates...),
 		// clone intermediate query.
 		sql:    ctq.sql.Clone(),

--- a/entc/integration/migrate/entv1/user_query.go
+++ b/entc/integration/migrate/entv1/user_query.go
@@ -348,6 +348,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 		limit:        uq.limit,
 		offset:       uq.offset,
 		order:        append([]OrderFunc{}, uq.order...),
+		inters:       append([]Interceptor{}, uq.inters...),
 		predicates:   append([]predicate.User{}, uq.predicates...),
 		withParent:   uq.withParent.Clone(),
 		withChildren: uq.withChildren.Clone(),

--- a/entc/integration/migrate/entv2/blog_query.go
+++ b/entc/integration/migrate/entv2/blog_query.go
@@ -278,6 +278,7 @@ func (bq *BlogQuery) Clone() *BlogQuery {
 		limit:      bq.limit,
 		offset:     bq.offset,
 		order:      append([]OrderFunc{}, bq.order...),
+		inters:     append([]Interceptor{}, bq.inters...),
 		predicates: append([]predicate.Blog{}, bq.predicates...),
 		withAdmins: bq.withAdmins.Clone(),
 		// clone intermediate query.

--- a/entc/integration/migrate/entv2/car_query.go
+++ b/entc/integration/migrate/entv2/car_query.go
@@ -278,6 +278,7 @@ func (cq *CarQuery) Clone() *CarQuery {
 		limit:      cq.limit,
 		offset:     cq.offset,
 		order:      append([]OrderFunc{}, cq.order...),
+		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Car{}, cq.predicates...),
 		withOwner:  cq.withOwner.Clone(),
 		// clone intermediate query.

--- a/entc/integration/migrate/entv2/conversion_query.go
+++ b/entc/integration/migrate/entv2/conversion_query.go
@@ -253,6 +253,7 @@ func (cq *ConversionQuery) Clone() *ConversionQuery {
 		limit:      cq.limit,
 		offset:     cq.offset,
 		order:      append([]OrderFunc{}, cq.order...),
+		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Conversion{}, cq.predicates...),
 		// clone intermediate query.
 		sql:    cq.sql.Clone(),

--- a/entc/integration/migrate/entv2/customtype_query.go
+++ b/entc/integration/migrate/entv2/customtype_query.go
@@ -253,6 +253,7 @@ func (ctq *CustomTypeQuery) Clone() *CustomTypeQuery {
 		limit:      ctq.limit,
 		offset:     ctq.offset,
 		order:      append([]OrderFunc{}, ctq.order...),
+		inters:     append([]Interceptor{}, ctq.inters...),
 		predicates: append([]predicate.CustomType{}, ctq.predicates...),
 		// clone intermediate query.
 		sql:    ctq.sql.Clone(),

--- a/entc/integration/migrate/entv2/group_query.go
+++ b/entc/integration/migrate/entv2/group_query.go
@@ -253,6 +253,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 		limit:      gq.limit,
 		offset:     gq.offset,
 		order:      append([]OrderFunc{}, gq.order...),
+		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Group{}, gq.predicates...),
 		// clone intermediate query.
 		sql:    gq.sql.Clone(),

--- a/entc/integration/migrate/entv2/media_query.go
+++ b/entc/integration/migrate/entv2/media_query.go
@@ -253,6 +253,7 @@ func (mq *MediaQuery) Clone() *MediaQuery {
 		limit:      mq.limit,
 		offset:     mq.offset,
 		order:      append([]OrderFunc{}, mq.order...),
+		inters:     append([]Interceptor{}, mq.inters...),
 		predicates: append([]predicate.Media{}, mq.predicates...),
 		// clone intermediate query.
 		sql:    mq.sql.Clone(),

--- a/entc/integration/migrate/entv2/pet_query.go
+++ b/entc/integration/migrate/entv2/pet_query.go
@@ -278,6 +278,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 		limit:      pq.limit,
 		offset:     pq.offset,
 		order:      append([]OrderFunc{}, pq.order...),
+		inters:     append([]Interceptor{}, pq.inters...),
 		predicates: append([]predicate.Pet{}, pq.predicates...),
 		withOwner:  pq.withOwner.Clone(),
 		// clone intermediate query.

--- a/entc/integration/migrate/entv2/user_query.go
+++ b/entc/integration/migrate/entv2/user_query.go
@@ -326,6 +326,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 		limit:       uq.limit,
 		offset:      uq.offset,
 		order:       append([]OrderFunc{}, uq.order...),
+		inters:      append([]Interceptor{}, uq.inters...),
 		predicates:  append([]predicate.User{}, uq.predicates...),
 		withCar:     uq.withCar.Clone(),
 		withPets:    uq.withPets.Clone(),

--- a/entc/integration/migrate/entv2/zoo_query.go
+++ b/entc/integration/migrate/entv2/zoo_query.go
@@ -253,6 +253,7 @@ func (zq *ZooQuery) Clone() *ZooQuery {
 		limit:      zq.limit,
 		offset:     zq.offset,
 		order:      append([]OrderFunc{}, zq.order...),
+		inters:     append([]Interceptor{}, zq.inters...),
 		predicates: append([]predicate.Zoo{}, zq.predicates...),
 		// clone intermediate query.
 		sql:    zq.sql.Clone(),

--- a/entc/integration/migrate/versioned/group_query.go
+++ b/entc/integration/migrate/versioned/group_query.go
@@ -253,6 +253,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 		limit:      gq.limit,
 		offset:     gq.offset,
 		order:      append([]OrderFunc{}, gq.order...),
+		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Group{}, gq.predicates...),
 		// clone intermediate query.
 		sql:    gq.sql.Clone(),

--- a/entc/integration/migrate/versioned/user_query.go
+++ b/entc/integration/migrate/versioned/user_query.go
@@ -253,6 +253,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 		limit:      uq.limit,
 		offset:     uq.offset,
 		order:      append([]OrderFunc{}, uq.order...),
+		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		// clone intermediate query.
 		sql:    uq.sql.Clone(),

--- a/entc/integration/multischema/ent/friendship_query.go
+++ b/entc/integration/multischema/ent/friendship_query.go
@@ -308,6 +308,7 @@ func (fq *FriendshipQuery) Clone() *FriendshipQuery {
 		limit:      fq.limit,
 		offset:     fq.offset,
 		order:      append([]OrderFunc{}, fq.order...),
+		inters:     append([]Interceptor{}, fq.inters...),
 		predicates: append([]predicate.Friendship{}, fq.predicates...),
 		withUser:   fq.withUser.Clone(),
 		withFriend: fq.withFriend.Clone(),

--- a/entc/integration/multischema/ent/group_query.go
+++ b/entc/integration/multischema/ent/group_query.go
@@ -283,6 +283,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 		limit:      gq.limit,
 		offset:     gq.offset,
 		order:      append([]OrderFunc{}, gq.order...),
+		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Group{}, gq.predicates...),
 		withUsers:  gq.withUsers.Clone(),
 		// clone intermediate query.

--- a/entc/integration/multischema/ent/pet_query.go
+++ b/entc/integration/multischema/ent/pet_query.go
@@ -282,6 +282,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 		limit:      pq.limit,
 		offset:     pq.offset,
 		order:      append([]OrderFunc{}, pq.order...),
+		inters:     append([]Interceptor{}, pq.inters...),
 		predicates: append([]predicate.Pet{}, pq.predicates...),
 		withOwner:  pq.withOwner.Clone(),
 		// clone intermediate query.

--- a/entc/integration/multischema/ent/user_query.go
+++ b/entc/integration/multischema/ent/user_query.go
@@ -363,6 +363,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 		limit:           uq.limit,
 		offset:          uq.offset,
 		order:           append([]OrderFunc{}, uq.order...),
+		inters:          append([]Interceptor{}, uq.inters...),
 		predicates:      append([]predicate.User{}, uq.predicates...),
 		withPets:        uq.withPets.Clone(),
 		withGroups:      uq.withGroups.Clone(),

--- a/entc/integration/privacy/ent/task_query.go
+++ b/entc/integration/privacy/ent/task_query.go
@@ -304,6 +304,7 @@ func (tq *TaskQuery) Clone() *TaskQuery {
 		limit:      tq.limit,
 		offset:     tq.offset,
 		order:      append([]OrderFunc{}, tq.order...),
+		inters:     append([]Interceptor{}, tq.inters...),
 		predicates: append([]predicate.Task{}, tq.predicates...),
 		withTeams:  tq.withTeams.Clone(),
 		withOwner:  tq.withOwner.Clone(),

--- a/entc/integration/privacy/ent/team_query.go
+++ b/entc/integration/privacy/ent/team_query.go
@@ -303,6 +303,7 @@ func (tq *TeamQuery) Clone() *TeamQuery {
 		limit:      tq.limit,
 		offset:     tq.offset,
 		order:      append([]OrderFunc{}, tq.order...),
+		inters:     append([]Interceptor{}, tq.inters...),
 		predicates: append([]predicate.Team{}, tq.predicates...),
 		withTasks:  tq.withTasks.Clone(),
 		withUsers:  tq.withUsers.Clone(),

--- a/entc/integration/privacy/ent/user_query.go
+++ b/entc/integration/privacy/ent/user_query.go
@@ -303,6 +303,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 		limit:      uq.limit,
 		offset:     uq.offset,
 		order:      append([]OrderFunc{}, uq.order...),
+		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		withTeams:  uq.withTeams.Clone(),
 		withTasks:  uq.withTasks.Clone(),

--- a/entc/integration/template/ent/group_query.go
+++ b/entc/integration/template/ent/group_query.go
@@ -256,6 +256,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 		limit:      gq.limit,
 		offset:     gq.offset,
 		order:      append([]OrderFunc{}, gq.order...),
+		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Group{}, gq.predicates...),
 		// clone intermediate query.
 		sql:    gq.sql.Clone(),

--- a/entc/integration/template/ent/pet_query.go
+++ b/entc/integration/template/ent/pet_query.go
@@ -281,6 +281,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 		limit:      pq.limit,
 		offset:     pq.offset,
 		order:      append([]OrderFunc{}, pq.order...),
+		inters:     append([]Interceptor{}, pq.inters...),
 		predicates: append([]predicate.Pet{}, pq.predicates...),
 		withOwner:  pq.withOwner.Clone(),
 		// clone intermediate query.

--- a/entc/integration/template/ent/user_query.go
+++ b/entc/integration/template/ent/user_query.go
@@ -304,6 +304,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 		limit:       uq.limit,
 		offset:      uq.offset,
 		order:       append([]OrderFunc{}, uq.order...),
+		inters:      append([]Interceptor{}, uq.inters...),
 		predicates:  append([]predicate.User{}, uq.predicates...),
 		withPets:    uq.withPets.Clone(),
 		withFriends: uq.withFriends.Clone(),

--- a/examples/edgeindex/ent/city_query.go
+++ b/examples/edgeindex/ent/city_query.go
@@ -278,6 +278,7 @@ func (cq *CityQuery) Clone() *CityQuery {
 		limit:       cq.limit,
 		offset:      cq.offset,
 		order:       append([]OrderFunc{}, cq.order...),
+		inters:      append([]Interceptor{}, cq.inters...),
 		predicates:  append([]predicate.City{}, cq.predicates...),
 		withStreets: cq.withStreets.Clone(),
 		// clone intermediate query.

--- a/examples/edgeindex/ent/street_query.go
+++ b/examples/edgeindex/ent/street_query.go
@@ -278,6 +278,7 @@ func (sq *StreetQuery) Clone() *StreetQuery {
 		limit:      sq.limit,
 		offset:     sq.offset,
 		order:      append([]OrderFunc{}, sq.order...),
+		inters:     append([]Interceptor{}, sq.inters...),
 		predicates: append([]predicate.Street{}, sq.predicates...),
 		withCity:   sq.withCity.Clone(),
 		// clone intermediate query.

--- a/examples/entcpkg/ent/user_query.go
+++ b/examples/entcpkg/ent/user_query.go
@@ -253,6 +253,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 		limit:      uq.limit,
 		offset:     uq.offset,
 		order:      append([]OrderFunc{}, uq.order...),
+		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		// clone intermediate query.
 		sql:    uq.sql.Clone(),

--- a/examples/fs/ent/file_query.go
+++ b/examples/fs/ent/file_query.go
@@ -300,6 +300,7 @@ func (fq *FileQuery) Clone() *FileQuery {
 		limit:        fq.limit,
 		offset:       fq.offset,
 		order:        append([]OrderFunc{}, fq.order...),
+		inters:       append([]Interceptor{}, fq.inters...),
 		predicates:   append([]predicate.File{}, fq.predicates...),
 		withParent:   fq.withParent.Clone(),
 		withChildren: fq.withChildren.Clone(),

--- a/examples/jsonencode/ent/card_query.go
+++ b/examples/jsonencode/ent/card_query.go
@@ -253,6 +253,7 @@ func (cq *CardQuery) Clone() *CardQuery {
 		limit:      cq.limit,
 		offset:     cq.offset,
 		order:      append([]OrderFunc{}, cq.order...),
+		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Card{}, cq.predicates...),
 		// clone intermediate query.
 		sql:    cq.sql.Clone(),

--- a/examples/jsonencode/ent/pet_query.go
+++ b/examples/jsonencode/ent/pet_query.go
@@ -277,6 +277,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 		limit:      pq.limit,
 		offset:     pq.offset,
 		order:      append([]OrderFunc{}, pq.order...),
+		inters:     append([]Interceptor{}, pq.inters...),
 		predicates: append([]predicate.Pet{}, pq.predicates...),
 		withOwner:  pq.withOwner.Clone(),
 		// clone intermediate query.

--- a/examples/jsonencode/ent/user_query.go
+++ b/examples/jsonencode/ent/user_query.go
@@ -278,6 +278,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 		limit:      uq.limit,
 		offset:     uq.offset,
 		order:      append([]OrderFunc{}, uq.order...),
+		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		withPets:   uq.withPets.Clone(),
 		// clone intermediate query.

--- a/examples/m2m2types/ent/group_query.go
+++ b/examples/m2m2types/ent/group_query.go
@@ -278,6 +278,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 		limit:      gq.limit,
 		offset:     gq.offset,
 		order:      append([]OrderFunc{}, gq.order...),
+		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Group{}, gq.predicates...),
 		withUsers:  gq.withUsers.Clone(),
 		// clone intermediate query.

--- a/examples/m2m2types/ent/user_query.go
+++ b/examples/m2m2types/ent/user_query.go
@@ -278,6 +278,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 		limit:      uq.limit,
 		offset:     uq.offset,
 		order:      append([]OrderFunc{}, uq.order...),
+		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		withGroups: uq.withGroups.Clone(),
 		// clone intermediate query.

--- a/examples/m2mbidi/ent/user_query.go
+++ b/examples/m2mbidi/ent/user_query.go
@@ -277,6 +277,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 		limit:       uq.limit,
 		offset:      uq.offset,
 		order:       append([]OrderFunc{}, uq.order...),
+		inters:      append([]Interceptor{}, uq.inters...),
 		predicates:  append([]predicate.User{}, uq.predicates...),
 		withFriends: uq.withFriends.Clone(),
 		// clone intermediate query.

--- a/examples/m2mrecur/ent/user_query.go
+++ b/examples/m2mrecur/ent/user_query.go
@@ -300,6 +300,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 		limit:         uq.limit,
 		offset:        uq.offset,
 		order:         append([]OrderFunc{}, uq.order...),
+		inters:        append([]Interceptor{}, uq.inters...),
 		predicates:    append([]predicate.User{}, uq.predicates...),
 		withFollowers: uq.withFollowers.Clone(),
 		withFollowing: uq.withFollowing.Clone(),

--- a/examples/migration/ent/user_query.go
+++ b/examples/migration/ent/user_query.go
@@ -253,6 +253,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 		limit:      uq.limit,
 		offset:     uq.offset,
 		order:      append([]OrderFunc{}, uq.order...),
+		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		// clone intermediate query.
 		sql:    uq.sql.Clone(),

--- a/examples/o2m2types/ent/pet_query.go
+++ b/examples/o2m2types/ent/pet_query.go
@@ -278,6 +278,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 		limit:      pq.limit,
 		offset:     pq.offset,
 		order:      append([]OrderFunc{}, pq.order...),
+		inters:     append([]Interceptor{}, pq.inters...),
 		predicates: append([]predicate.Pet{}, pq.predicates...),
 		withOwner:  pq.withOwner.Clone(),
 		// clone intermediate query.

--- a/examples/o2m2types/ent/user_query.go
+++ b/examples/o2m2types/ent/user_query.go
@@ -278,6 +278,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 		limit:      uq.limit,
 		offset:     uq.offset,
 		order:      append([]OrderFunc{}, uq.order...),
+		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		withPets:   uq.withPets.Clone(),
 		// clone intermediate query.

--- a/examples/o2mrecur/ent/node_query.go
+++ b/examples/o2mrecur/ent/node_query.go
@@ -301,6 +301,7 @@ func (nq *NodeQuery) Clone() *NodeQuery {
 		limit:        nq.limit,
 		offset:       nq.offset,
 		order:        append([]OrderFunc{}, nq.order...),
+		inters:       append([]Interceptor{}, nq.inters...),
 		predicates:   append([]predicate.Node{}, nq.predicates...),
 		withParent:   nq.withParent.Clone(),
 		withChildren: nq.withChildren.Clone(),

--- a/examples/o2o2types/ent/card_query.go
+++ b/examples/o2o2types/ent/card_query.go
@@ -278,6 +278,7 @@ func (cq *CardQuery) Clone() *CardQuery {
 		limit:      cq.limit,
 		offset:     cq.offset,
 		order:      append([]OrderFunc{}, cq.order...),
+		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Card{}, cq.predicates...),
 		withOwner:  cq.withOwner.Clone(),
 		// clone intermediate query.

--- a/examples/o2o2types/ent/user_query.go
+++ b/examples/o2o2types/ent/user_query.go
@@ -278,6 +278,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 		limit:      uq.limit,
 		offset:     uq.offset,
 		order:      append([]OrderFunc{}, uq.order...),
+		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		withCard:   uq.withCard.Clone(),
 		// clone intermediate query.

--- a/examples/o2obidi/ent/user_query.go
+++ b/examples/o2obidi/ent/user_query.go
@@ -277,6 +277,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 		limit:      uq.limit,
 		offset:     uq.offset,
 		order:      append([]OrderFunc{}, uq.order...),
+		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		withSpouse: uq.withSpouse.Clone(),
 		// clone intermediate query.

--- a/examples/o2orecur/ent/node_query.go
+++ b/examples/o2orecur/ent/node_query.go
@@ -301,6 +301,7 @@ func (nq *NodeQuery) Clone() *NodeQuery {
 		limit:      nq.limit,
 		offset:     nq.offset,
 		order:      append([]OrderFunc{}, nq.order...),
+		inters:     append([]Interceptor{}, nq.inters...),
 		predicates: append([]predicate.Node{}, nq.predicates...),
 		withPrev:   nq.withPrev.Clone(),
 		withNext:   nq.withNext.Clone(),

--- a/examples/privacyadmin/ent/user_query.go
+++ b/examples/privacyadmin/ent/user_query.go
@@ -254,6 +254,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 		limit:      uq.limit,
 		offset:     uq.offset,
 		order:      append([]OrderFunc{}, uq.order...),
+		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		// clone intermediate query.
 		sql:    uq.sql.Clone(),

--- a/examples/privacytenant/ent/group_query.go
+++ b/examples/privacytenant/ent/group_query.go
@@ -303,6 +303,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 		limit:      gq.limit,
 		offset:     gq.offset,
 		order:      append([]OrderFunc{}, gq.order...),
+		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Group{}, gq.predicates...),
 		withTenant: gq.withTenant.Clone(),
 		withUsers:  gq.withUsers.Clone(),

--- a/examples/privacytenant/ent/tenant_query.go
+++ b/examples/privacytenant/ent/tenant_query.go
@@ -254,6 +254,7 @@ func (tq *TenantQuery) Clone() *TenantQuery {
 		limit:      tq.limit,
 		offset:     tq.offset,
 		order:      append([]OrderFunc{}, tq.order...),
+		inters:     append([]Interceptor{}, tq.inters...),
 		predicates: append([]predicate.Tenant{}, tq.predicates...),
 		// clone intermediate query.
 		sql:    tq.sql.Clone(),

--- a/examples/privacytenant/ent/user_query.go
+++ b/examples/privacytenant/ent/user_query.go
@@ -303,6 +303,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 		limit:      uq.limit,
 		offset:     uq.offset,
 		order:      append([]OrderFunc{}, uq.order...),
+		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		withTenant: uq.withTenant.Clone(),
 		withGroups: uq.withGroups.Clone(),

--- a/examples/start/ent/car_query.go
+++ b/examples/start/ent/car_query.go
@@ -278,6 +278,7 @@ func (cq *CarQuery) Clone() *CarQuery {
 		limit:      cq.limit,
 		offset:     cq.offset,
 		order:      append([]OrderFunc{}, cq.order...),
+		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Car{}, cq.predicates...),
 		withOwner:  cq.withOwner.Clone(),
 		// clone intermediate query.

--- a/examples/start/ent/group_query.go
+++ b/examples/start/ent/group_query.go
@@ -278,6 +278,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 		limit:      gq.limit,
 		offset:     gq.offset,
 		order:      append([]OrderFunc{}, gq.order...),
+		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Group{}, gq.predicates...),
 		withUsers:  gq.withUsers.Clone(),
 		// clone intermediate query.

--- a/examples/start/ent/user_query.go
+++ b/examples/start/ent/user_query.go
@@ -302,6 +302,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 		limit:      uq.limit,
 		offset:     uq.offset,
 		order:      append([]OrderFunc{}, uq.order...),
+		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		withCars:   uq.withCars.Clone(),
 		withGroups: uq.withGroups.Clone(),

--- a/examples/traversal/ent/group_query.go
+++ b/examples/traversal/ent/group_query.go
@@ -302,6 +302,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 		limit:      gq.limit,
 		offset:     gq.offset,
 		order:      append([]OrderFunc{}, gq.order...),
+		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Group{}, gq.predicates...),
 		withUsers:  gq.withUsers.Clone(),
 		withAdmin:  gq.withAdmin.Clone(),

--- a/examples/traversal/ent/pet_query.go
+++ b/examples/traversal/ent/pet_query.go
@@ -302,6 +302,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 		limit:       pq.limit,
 		offset:      pq.offset,
 		order:       append([]OrderFunc{}, pq.order...),
+		inters:      append([]Interceptor{}, pq.inters...),
 		predicates:  append([]predicate.Pet{}, pq.predicates...),
 		withFriends: pq.withFriends.Clone(),
 		withOwner:   pq.withOwner.Clone(),

--- a/examples/traversal/ent/user_query.go
+++ b/examples/traversal/ent/user_query.go
@@ -348,6 +348,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 		limit:       uq.limit,
 		offset:      uq.offset,
 		order:       append([]OrderFunc{}, uq.order...),
+		inters:      append([]Interceptor{}, uq.inters...),
 		predicates:  append([]predicate.User{}, uq.predicates...),
 		withPets:    uq.withPets.Clone(),
 		withFriends: uq.withFriends.Clone(),

--- a/examples/version/ent/user_query.go
+++ b/examples/version/ent/user_query.go
@@ -253,6 +253,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 		limit:      uq.limit,
 		offset:     uq.offset,
 		order:      append([]OrderFunc{}, uq.order...),
+		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		// clone intermediate query.
 		sql:    uq.sql.Clone(),


### PR DESCRIPTION
`entgql` uses [`Clone`](https://github.com/ent/contrib/blob/e2b0072613c094af4b0f47f6e62dd2ce88677051/entgql/template/pagination.tmpl#L530) when handling the pagination, the [Soft Delete example](https://entgo.io/docs/interceptors/#soft-delete) will not work in a few cases (like when using `first` or `last`), because the `Clone` does not copy the interceptors.

This PR fix this problem by copying the interceptors on Clone.

This fixes: #3193