### PR TITLE
entc/gen: explicitly import node packages in generate ent.go file

### DIFF
--- a/entc/gen/template/base.tmpl
+++ b/entc/gen/template/base.tmpl
@@ -13,7 +13,12 @@ in the LICENSE file in the root directory of this source tree.
 
 {{ template "import" $ }}
 
-import "reflect"
+import (
+	"reflect"
+	{{- range $n := $.Nodes }}
+		{{ $n.PackageAlias }} "{{ $n.Config.Package }}/{{ $n.PackageDir }}"
+	{{- end }}
+)
 
 // ent aliases to avoid import conflicts in user's code.
 type (

--- a/entc/integration/ent/ent.go
+++ b/entc/integration/ent/ent.go
@@ -28,6 +28,7 @@ import (
 	"entgo.io/ent/entc/integration/ent/node"
 	"entgo.io/ent/entc/integration/ent/pet"
 	"entgo.io/ent/entc/integration/ent/spec"
+
 	enttask "entgo.io/ent/entc/integration/ent/task"
 	"entgo.io/ent/entc/integration/ent/user"
 )


### PR DESCRIPTION
Fixed https://github.com/ent/ent/issues/3208

Verified this with the following command:

```zsh
repeat 50 { go generate ./... && git --no-pager diff }
```