### PR TITLE
Do not increment idx for interceptors when a policy is present

### DIFF
--- a/entc/gen/template/runtime.tmpl
+++ b/entc/gen/template/runtime.tmpl
@@ -140,9 +140,6 @@ func init() {
 			{{ print $pkg "Inters" }} := {{ $schema }}.{{ $n.Name }}{}.Interceptors()
 		{{- end }}
 		{{- range $i, $p := $inters }}
-			{{- if $n.NumPolicy }}
-				{{ $i = add $i 1 }}
-			{{- end }}
 			{{- if $p.MixedIn }}
 				{{ print $pkg ".Interceptors" }}[{{ $i }}] =  {{ print $pkg "MixinInters" $p.MixinIndex }}[{{ $p.Index }}]
 			{{- else }}


### PR DESCRIPTION
**Issue**
I have a mixin that includes both a policy and an interceptor. After running `go generate ./...`, `runtime.go` is invalid and includes a number of errors, namely `invalid argument: index 1 out of bounds [0:1]`. 

As discussed on [discord](https://discord.com/channels/885059418646003782/885059419107360779/1060990994243391528), this change fixes the above issue and ensures that interceptors are indexed starting at 0.