### PR TITLE
doc/md: fix broken link to Field Collection tutorial

### DIFF
--- a/doc/md/graphql.md
+++ b/doc/md/graphql.md
@@ -8,7 +8,7 @@ provides various integrations, such as:
 1. Generating a GraphQL schema for nodes and edges defined in an Ent schema.
 2. Auto-generated `Query` and `Mutation` resolvers and provide seamless integration with the [Relay framework](https://relay.dev/).
 3. Filtering, pagination (including nested) and compliant support with the [Relay Cursor Connections Spec](https://relay.dev/graphql/connections.htm).
-4. Efficient [field collection](tutorial-todo-gql-field-collection) to overcome the N+1 problem without requiring data
+4. Efficient [field collection](tutorial-todo-gql-field-collection.md) to overcome the N+1 problem without requiring data
    loaders.
 5. [Transactional mutations](tutorial-todo-gql-tx-mutation.md) to ensure consistency in case of failures. 
 


### PR DESCRIPTION
Hey,
a minor issue I noticed while browsing.