### PR TITLE
entc/gen: avoid codegen conflict with one letter (n) receivers

### DIFF
--- a/entc/gen/template/builder/delete.tmpl
+++ b/entc/gen/template/builder/delete.tmpl
@@ -41,11 +41,12 @@ func ({{ $receiver }} *{{ $builder }}) Exec(ctx context.Context) (int, error) {
 
 // ExecX is like Exec, but panics if an error occurs.
 func ({{ $receiver }} *{{ $builder }}) ExecX(ctx context.Context) int {
-	n, err := {{ $receiver }}.Exec(ctx)
+	{{- $n := "n" }}{{ if eq $receiver $n }}{{ $n = "_n" }}{{ end }}
+	{{ $n }}, err := {{ $receiver }}.Exec(ctx)
 	if err != nil {
 		panic(err)
 	}
-	return n
+	return {{ $n }}
 }
 
 {{ with extend $ "Builder" $builder }}

--- a/entc/gen/template/dialect/sql/update.tmpl
+++ b/entc/gen/template/dialect/sql/update.tmpl
@@ -22,7 +22,7 @@ in the LICENSE file in the root directory of this source tree.
 {{ $mutation := print $receiver ".mutation" }}
 {{ $one := hasSuffix $builder "One" }}
 {{- $zero := 0 }}{{ if $one }}{{ $zero = "nil" }}{{ end }}
-{{- $ret := "n" }}{{ if $one }}{{ $ret = "_node" }}{{ end }}
+{{- $ret := "n" }}{{ if eq $ret $receiver }}{{ $ret = "_n" }}{{ end }}{{ if $one }}{{ $ret = "_node" }}{{ end }}
 
 {{- /* Allow adding methods to the update-builder by ent extensions or user templates.*/}}
 {{- with $tmpls := matchTemplate "dialect/sql/update/additional/*" }}


### PR DESCRIPTION
Fixed https://github.com/ent/ent/issues/3222. 

The ideal fix is to avoid these dynamic receiver names and use one letter for all: c for create, q for query, etc.