### PR TITLE
doc/md: fix broken "Atlas migration engine" links on dialects.md

### DIFF
--- a/doc/md/dialects.md
+++ b/doc/md/dialects.md
@@ -20,7 +20,7 @@ and it's being tested constantly on the following 5 versions: `10`, `11`, `12`, 
 
 ## CockroachDB **(<ins>preview</ins>)**
 
-CockroachDB support is in preview and requires the [Atlas migration engine](#atlas-integration).  
+CockroachDB support is in preview and requires the [Atlas migration engine](migrate.md#atlas-integration).  
 The integration with CRDB is currently tested on versions `v21.2.11`.
 
 ## SQLite
@@ -35,7 +35,7 @@ Gremlin does not support migration nor indexes, and **<ins>it's considered exper
 
 ## TiDB **(<ins>preview</ins>)**
 
-TiDB support is in preview and requires the [Atlas migration engine](#atlas-integration).  
+TiDB support is in preview and requires the [Atlas migration engine](migrate.md#atlas-integration).  
 TiDB is MySQL compatible and thus any feature that works on MySQL _should_ work on TiDB as well.  
 For a list of known compatibility issues, visit: https://docs.pingcap.com/tidb/stable/mysql-compatibility  
 The integration with TiDB is currently tested on versions `5.4.0`, `6.0.0`.


### PR DESCRIPTION
This PR fixes two links in the [Dialects](https://entgo.io/docs/dialects/) doc page that are not working because they link to `#atlas-integration` in the current page (which doesn't exist), when they should actually link to `migrate.md#atlas-integration`:

![image](https://user-images.githubusercontent.com/75134774/211611637-5e01afd8-803a-41a0-8db6-ca84f2f94afb.png)
![image](https://user-images.githubusercontent.com/75134774/211611684-a78dbdf8-a1af-42fe-930e-a30ca34e9686.png)
