### PR TITLE
entc/gen: improve assets formatting performance

### DIFF
--- a/entc/gen/graph.go
+++ b/entc/gen/graph.go
@@ -21,6 +21,7 @@ import (
 	"entgo.io/ent/dialect/sql/schema"
 	"entgo.io/ent/entc/load"
 	"entgo.io/ent/schema/field"
+	"golang.org/x/sync/errgroup"
 
 	"golang.org/x/tools/imports"
 )
@@ -1040,16 +1041,21 @@ func (a assets) write() error {
 
 // format runs "goimports" on all assets.
 func (a assets) format() error {
+	var eg errgroup.Group
 	for path, content := range a.files {
-		src, err := imports.Process(path, content, nil)
-		if err != nil {
-			return fmt.Errorf("format file %s: %w", path, err)
-		}
-		if err := os.WriteFile(path, src, 0644); err != nil {
-			return fmt.Errorf("write file %s: %w", path, err)
-		}
+		path, content := path, content
+		eg.Go(func() error {
+			src, err := imports.Process(path, content, nil)
+			if err != nil {
+				return fmt.Errorf("format file %s: %w", path, err)
+			}
+			if err := os.WriteFile(path, src, 0644); err != nil {
+				return fmt.Errorf("write file %s: %w", path, err)
+			}
+			return nil
+		})
 	}
-	return nil
+	return eg.Wait()
 }
 
 // expect panics if the condition is false.


### PR DESCRIPTION
Issue #3235 talks about the performance of generating the code when having a lot of schema files, I have a schema with 53 entities and currently the it takes ~20s, but I'm sure we can improve it.

Looking at a CPU profile of the gen process of my code base, we can see that most of the time is spent on GC and `gen.assets.format`
![image](https://user-images.githubusercontent.com/1251151/212371011-0c4f2e93-a34d-4d59-aea6-9f7ff076a440.png)

This PR tries to solve the problem of the `gen.assets.format`, we can always optimize the allocations and handle GC problems at a later date. Since  `gen.assets.format` only calls `imports.Process`, we can easily use a better concurrency pattern to improve things, the down side is that since `gen.assets.format` only calls `imports.Process`, this is the only optimization that we can do for now.

We use [golang.org/x/sync/errgroup](https://pkg.go.dev/golang.org/x/sync/errgroup) to execute `goimports` concurrently.


Here the benchmarks results:

### `entc/integration/edgeschema`:
**Before**
```shell
❯ time go run entc.go
go run entc.go  4,44s user 0,85s system 287% cpu 1,839 total
```

```shell
❯ go test -bench=. -benchmem                            
goos: linux
goarch: amd64
pkg: entgo.io/ent/entc/integration/edgeschema/bench
cpu: AMD Ryzen 9 5950X 16-Core Processor            
BenchmarkGenerate-32                   1        1528192474 ns/op        449178144 B/op   8497465 allocs/op
PASS
ok      entgo.io/ent/entc/integration/edgeschema/bench  1.540s
```


**After:**
```shell
❯ time go run entc.go       
go run entc.go  4,67s user 0,99s system 518% cpu 1,093 total
```

_This time go test was able to execute 2 iterations._
```shell
❯ go test -bench=. -benchmem
goos: linux
goarch: amd64
pkg: entgo.io/ent/entc/integration/edgeschema/bench
cpu: AMD Ryzen 9 5950X 16-Core Processor            
BenchmarkGenerate-32                   2         806641478 ns/op        448795616 B/op   8475744 allocs/op
PASS
ok      entgo.io/ent/entc/integration/edgeschema/bench  2.430s
```

_Comparing a single iteration._
```shell
❯ go test -bench=. -benchmem -benchtime 1x
goos: linux
goarch: amd64
pkg: entgo.io/ent/entc/integration/edgeschema/bench
cpu: AMD Ryzen 9 5950X 16-Core Processor            
BenchmarkGenerate-32                   1         846288268 ns/op        445141376 B/op   8490399 allocs/op
PASS
ok      entgo.io/ent/entc/integration/edgeschema/bench  0.862s
```

### Results

```shell
❯ benchstat before.txt after.txt 
name         old time/op  new time/op  delta
Generate-32   1.49s ± 5%   0.84s ± 6%  -43.82%  (p=0.008 n=5+5)
```

### My code base:
**Before**
```shell
❯ time go run main.go
go run main.go  53,87s user 2,25s system 310% cpu 18,097 total
```

**After:**
```shell
❯ time go run main.go       
go run main.go  19,31s user 1,35s system 562% cpu 3,672 total
```
