### PR TITLE
entc: Return errors from both packages

### DIFF
--- a/entc/load/load.go
+++ b/entc/load/load.go
@@ -120,6 +120,9 @@ func (c *Config) load() (*SchemaSpec, error) {
 	if len(pkg.Errors) != 0 {
 		return nil, pkg.Errors[0]
 	}
+	if len(entPkg.Errors) != 0 {
+		return nil, entPkg.Errors[0]
+	}
 	if pkgs[0].PkgPath != entInterface.PkgPath() {
 		entPkg, pkg = pkgs[1], pkgs[0]
 	}


### PR DESCRIPTION
This returns errors from both packages after Load() -> issues loading that can crop up by having a `go.work` file present are surfaced more clearly with this in place which improves user experience.