### PR TITLE
entc/gen: add support for DeleteOne with predicates

### DIFF
--- a/doc/md/crud.mdx
+++ b/doc/md/crud.mdx
@@ -109,7 +109,6 @@ func main() {
 ```
 
 </TabItem>
-
 <TabItem value="gremlin">
 
 ```go
@@ -452,7 +451,7 @@ pedro, err := client.Pet.
 
 ## Delete One 
 
-Delete an entity.
+Delete an entity:
 
 ```go
 err := client.User.
@@ -460,7 +459,7 @@ err := client.User.
 	Exec(ctx)
 ```
 
-Delete by ID.
+Delete by ID:
 
 ```go
 err := client.User.
@@ -468,12 +467,38 @@ err := client.User.
 	Exec(ctx)
 ```
 
-## Delete Many
+#### Delete One With Condition
 
-Delete using predicates.
+In some projects, the "delete many" operation is not allowed and is blocked using hooks. However, there is still a need
+to delete a single entity by its ID while ensuring it meets a specific condition. In this case, you can use the `Where`
+option as follows:
 
 ```go
-_, err := client.File.
+err := client.Todo.
+    DeleteOneID(id).
+    Where(
+        // Allow deleting only expired todos.
+        todo.ExpireLT(time.Now()),
+    ).
+    Exec(ctx)
+switch {
+// If the entity does not meet a specific condition,
+// the operation will return an "ent.NotFoundError".
+case ent.IsNotFound(err):
+    fmt.Println("todo item was not found")
+// Any other error.
+case err != nil:
+    fmt.Println("deletion error:", err)
+}
+```
+
+
+## Delete Many
+
+Delete using predicates:
+
+```go
+affected, err := client.File.
 	Delete().
 	Where(file.UpdatedAtLT(date)).
 	Exec(ctx)

--- a/entc/gen/template/builder/delete.tmpl
+++ b/entc/gen/template/builder/delete.tmpl
@@ -69,6 +69,12 @@ type {{ $onebuilder }} struct {
 	{{ $receiver }} *{{ $builder }}
 }
 
+// Where appends a list predicates to the {{ $builder }} builder.
+func ({{ $oneReceiver }} *{{ $onebuilder }}) Where(ps ...predicate.{{ $.Name }}) *{{ $onebuilder }} {
+	{{ $oneReceiver }}.{{ $mutation }}.Where(ps...)
+	return {{ $oneReceiver }}
+}
+
 // Exec executes the deletion query.
 func ({{ $oneReceiver }} *{{ $onebuilder }}) Exec(ctx context.Context) error {
 	n, err := {{ $oneReceiver }}.{{ $receiver }}.Exec(ctx)
@@ -84,7 +90,9 @@ func ({{ $oneReceiver }} *{{ $onebuilder }}) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func ({{ $oneReceiver }} *{{ $onebuilder }}) ExecX(ctx context.Context) {
-	{{ $oneReceiver }}.{{ $receiver }}.ExecX(ctx)
+	if err := {{ $oneReceiver }}.Exec(ctx); err != nil {
+		panic(err)
+	}
 }
 
 {{ end }}

--- a/entc/integration/cascadelete/ent/comment_delete.go
+++ b/entc/integration/cascadelete/ent/comment_delete.go
@@ -73,6 +73,12 @@ type CommentDeleteOne struct {
 	cd *CommentDelete
 }
 
+// Where appends a list predicates to the CommentDelete builder.
+func (cdo *CommentDeleteOne) Where(ps ...predicate.Comment) *CommentDeleteOne {
+	cdo.cd.mutation.Where(ps...)
+	return cdo
+}
+
 // Exec executes the deletion query.
 func (cdo *CommentDeleteOne) Exec(ctx context.Context) error {
 	n, err := cdo.cd.Exec(ctx)
@@ -88,5 +94,7 @@ func (cdo *CommentDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (cdo *CommentDeleteOne) ExecX(ctx context.Context) {
-	cdo.cd.ExecX(ctx)
+	if err := cdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/cascadelete/ent/post_delete.go
+++ b/entc/integration/cascadelete/ent/post_delete.go
@@ -73,6 +73,12 @@ type PostDeleteOne struct {
 	pd *PostDelete
 }
 
+// Where appends a list predicates to the PostDelete builder.
+func (pdo *PostDeleteOne) Where(ps ...predicate.Post) *PostDeleteOne {
+	pdo.pd.mutation.Where(ps...)
+	return pdo
+}
+
 // Exec executes the deletion query.
 func (pdo *PostDeleteOne) Exec(ctx context.Context) error {
 	n, err := pdo.pd.Exec(ctx)
@@ -88,5 +94,7 @@ func (pdo *PostDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (pdo *PostDeleteOne) ExecX(ctx context.Context) {
-	pdo.pd.ExecX(ctx)
+	if err := pdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/cascadelete/ent/user_delete.go
+++ b/entc/integration/cascadelete/ent/user_delete.go
@@ -73,6 +73,12 @@ type UserDeleteOne struct {
 	ud *UserDelete
 }
 
+// Where appends a list predicates to the UserDelete builder.
+func (udo *UserDeleteOne) Where(ps ...predicate.User) *UserDeleteOne {
+	udo.ud.mutation.Where(ps...)
+	return udo
+}
+
 // Exec executes the deletion query.
 func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 	n, err := udo.ud.Exec(ctx)
@@ -88,5 +94,7 @@ func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (udo *UserDeleteOne) ExecX(ctx context.Context) {
-	udo.ud.ExecX(ctx)
+	if err := udo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/config/ent/user_delete.go
+++ b/entc/integration/config/ent/user_delete.go
@@ -73,6 +73,12 @@ type UserDeleteOne struct {
 	ud *UserDelete
 }
 
+// Where appends a list predicates to the UserDelete builder.
+func (udo *UserDeleteOne) Where(ps ...predicate.User) *UserDeleteOne {
+	udo.ud.mutation.Where(ps...)
+	return udo
+}
+
 // Exec executes the deletion query.
 func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 	n, err := udo.ud.Exec(ctx)
@@ -88,5 +94,7 @@ func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (udo *UserDeleteOne) ExecX(ctx context.Context) {
-	udo.ud.ExecX(ctx)
+	if err := udo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/customid/ent/account_delete.go
+++ b/entc/integration/customid/ent/account_delete.go
@@ -73,6 +73,12 @@ type AccountDeleteOne struct {
 	ad *AccountDelete
 }
 
+// Where appends a list predicates to the AccountDelete builder.
+func (ado *AccountDeleteOne) Where(ps ...predicate.Account) *AccountDeleteOne {
+	ado.ad.mutation.Where(ps...)
+	return ado
+}
+
 // Exec executes the deletion query.
 func (ado *AccountDeleteOne) Exec(ctx context.Context) error {
 	n, err := ado.ad.Exec(ctx)
@@ -88,5 +94,7 @@ func (ado *AccountDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (ado *AccountDeleteOne) ExecX(ctx context.Context) {
-	ado.ad.ExecX(ctx)
+	if err := ado.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/customid/ent/blob_delete.go
+++ b/entc/integration/customid/ent/blob_delete.go
@@ -73,6 +73,12 @@ type BlobDeleteOne struct {
 	bd *BlobDelete
 }
 
+// Where appends a list predicates to the BlobDelete builder.
+func (bdo *BlobDeleteOne) Where(ps ...predicate.Blob) *BlobDeleteOne {
+	bdo.bd.mutation.Where(ps...)
+	return bdo
+}
+
 // Exec executes the deletion query.
 func (bdo *BlobDeleteOne) Exec(ctx context.Context) error {
 	n, err := bdo.bd.Exec(ctx)
@@ -88,5 +94,7 @@ func (bdo *BlobDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (bdo *BlobDeleteOne) ExecX(ctx context.Context) {
-	bdo.bd.ExecX(ctx)
+	if err := bdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/customid/ent/bloblink_delete.go
+++ b/entc/integration/customid/ent/bloblink_delete.go
@@ -68,6 +68,12 @@ type BlobLinkDeleteOne struct {
 	bld *BlobLinkDelete
 }
 
+// Where appends a list predicates to the BlobLinkDelete builder.
+func (bldo *BlobLinkDeleteOne) Where(ps ...predicate.BlobLink) *BlobLinkDeleteOne {
+	bldo.bld.mutation.Where(ps...)
+	return bldo
+}
+
 // Exec executes the deletion query.
 func (bldo *BlobLinkDeleteOne) Exec(ctx context.Context) error {
 	n, err := bldo.bld.Exec(ctx)
@@ -83,5 +89,7 @@ func (bldo *BlobLinkDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (bldo *BlobLinkDeleteOne) ExecX(ctx context.Context) {
-	bldo.bld.ExecX(ctx)
+	if err := bldo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/customid/ent/car_delete.go
+++ b/entc/integration/customid/ent/car_delete.go
@@ -73,6 +73,12 @@ type CarDeleteOne struct {
 	cd *CarDelete
 }
 
+// Where appends a list predicates to the CarDelete builder.
+func (cdo *CarDeleteOne) Where(ps ...predicate.Car) *CarDeleteOne {
+	cdo.cd.mutation.Where(ps...)
+	return cdo
+}
+
 // Exec executes the deletion query.
 func (cdo *CarDeleteOne) Exec(ctx context.Context) error {
 	n, err := cdo.cd.Exec(ctx)
@@ -88,5 +94,7 @@ func (cdo *CarDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (cdo *CarDeleteOne) ExecX(ctx context.Context) {
-	cdo.cd.ExecX(ctx)
+	if err := cdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/customid/ent/device_delete.go
+++ b/entc/integration/customid/ent/device_delete.go
@@ -73,6 +73,12 @@ type DeviceDeleteOne struct {
 	dd *DeviceDelete
 }
 
+// Where appends a list predicates to the DeviceDelete builder.
+func (ddo *DeviceDeleteOne) Where(ps ...predicate.Device) *DeviceDeleteOne {
+	ddo.dd.mutation.Where(ps...)
+	return ddo
+}
+
 // Exec executes the deletion query.
 func (ddo *DeviceDeleteOne) Exec(ctx context.Context) error {
 	n, err := ddo.dd.Exec(ctx)
@@ -88,5 +94,7 @@ func (ddo *DeviceDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (ddo *DeviceDeleteOne) ExecX(ctx context.Context) {
-	ddo.dd.ExecX(ctx)
+	if err := ddo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/customid/ent/doc_delete.go
+++ b/entc/integration/customid/ent/doc_delete.go
@@ -73,6 +73,12 @@ type DocDeleteOne struct {
 	dd *DocDelete
 }
 
+// Where appends a list predicates to the DocDelete builder.
+func (ddo *DocDeleteOne) Where(ps ...predicate.Doc) *DocDeleteOne {
+	ddo.dd.mutation.Where(ps...)
+	return ddo
+}
+
 // Exec executes the deletion query.
 func (ddo *DocDeleteOne) Exec(ctx context.Context) error {
 	n, err := ddo.dd.Exec(ctx)
@@ -88,5 +94,7 @@ func (ddo *DocDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (ddo *DocDeleteOne) ExecX(ctx context.Context) {
-	ddo.dd.ExecX(ctx)
+	if err := ddo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/customid/ent/group_delete.go
+++ b/entc/integration/customid/ent/group_delete.go
@@ -73,6 +73,12 @@ type GroupDeleteOne struct {
 	gd *GroupDelete
 }
 
+// Where appends a list predicates to the GroupDelete builder.
+func (gdo *GroupDeleteOne) Where(ps ...predicate.Group) *GroupDeleteOne {
+	gdo.gd.mutation.Where(ps...)
+	return gdo
+}
+
 // Exec executes the deletion query.
 func (gdo *GroupDeleteOne) Exec(ctx context.Context) error {
 	n, err := gdo.gd.Exec(ctx)
@@ -88,5 +94,7 @@ func (gdo *GroupDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (gdo *GroupDeleteOne) ExecX(ctx context.Context) {
-	gdo.gd.ExecX(ctx)
+	if err := gdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/customid/ent/intsid_delete.go
+++ b/entc/integration/customid/ent/intsid_delete.go
@@ -73,6 +73,12 @@ type IntSIDDeleteOne struct {
 	isd *IntSIDDelete
 }
 
+// Where appends a list predicates to the IntSIDDelete builder.
+func (isdo *IntSIDDeleteOne) Where(ps ...predicate.IntSID) *IntSIDDeleteOne {
+	isdo.isd.mutation.Where(ps...)
+	return isdo
+}
+
 // Exec executes the deletion query.
 func (isdo *IntSIDDeleteOne) Exec(ctx context.Context) error {
 	n, err := isdo.isd.Exec(ctx)
@@ -88,5 +94,7 @@ func (isdo *IntSIDDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (isdo *IntSIDDeleteOne) ExecX(ctx context.Context) {
-	isdo.isd.ExecX(ctx)
+	if err := isdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/customid/ent/link_delete.go
+++ b/entc/integration/customid/ent/link_delete.go
@@ -73,6 +73,12 @@ type LinkDeleteOne struct {
 	ld *LinkDelete
 }
 
+// Where appends a list predicates to the LinkDelete builder.
+func (ldo *LinkDeleteOne) Where(ps ...predicate.Link) *LinkDeleteOne {
+	ldo.ld.mutation.Where(ps...)
+	return ldo
+}
+
 // Exec executes the deletion query.
 func (ldo *LinkDeleteOne) Exec(ctx context.Context) error {
 	n, err := ldo.ld.Exec(ctx)
@@ -88,5 +94,7 @@ func (ldo *LinkDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (ldo *LinkDeleteOne) ExecX(ctx context.Context) {
-	ldo.ld.ExecX(ctx)
+	if err := ldo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/customid/ent/mixinid_delete.go
+++ b/entc/integration/customid/ent/mixinid_delete.go
@@ -73,6 +73,12 @@ type MixinIDDeleteOne struct {
 	mid *MixinIDDelete
 }
 
+// Where appends a list predicates to the MixinIDDelete builder.
+func (mido *MixinIDDeleteOne) Where(ps ...predicate.MixinID) *MixinIDDeleteOne {
+	mido.mid.mutation.Where(ps...)
+	return mido
+}
+
 // Exec executes the deletion query.
 func (mido *MixinIDDeleteOne) Exec(ctx context.Context) error {
 	n, err := mido.mid.Exec(ctx)
@@ -88,5 +94,7 @@ func (mido *MixinIDDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (mido *MixinIDDeleteOne) ExecX(ctx context.Context) {
-	mido.mid.ExecX(ctx)
+	if err := mido.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/customid/ent/note_delete.go
+++ b/entc/integration/customid/ent/note_delete.go
@@ -73,6 +73,12 @@ type NoteDeleteOne struct {
 	nd *NoteDelete
 }
 
+// Where appends a list predicates to the NoteDelete builder.
+func (ndo *NoteDeleteOne) Where(ps ...predicate.Note) *NoteDeleteOne {
+	ndo.nd.mutation.Where(ps...)
+	return ndo
+}
+
 // Exec executes the deletion query.
 func (ndo *NoteDeleteOne) Exec(ctx context.Context) error {
 	n, err := ndo.nd.Exec(ctx)
@@ -88,5 +94,7 @@ func (ndo *NoteDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (ndo *NoteDeleteOne) ExecX(ctx context.Context) {
-	ndo.nd.ExecX(ctx)
+	if err := ndo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/customid/ent/other_delete.go
+++ b/entc/integration/customid/ent/other_delete.go
@@ -73,6 +73,12 @@ type OtherDeleteOne struct {
 	od *OtherDelete
 }
 
+// Where appends a list predicates to the OtherDelete builder.
+func (odo *OtherDeleteOne) Where(ps ...predicate.Other) *OtherDeleteOne {
+	odo.od.mutation.Where(ps...)
+	return odo
+}
+
 // Exec executes the deletion query.
 func (odo *OtherDeleteOne) Exec(ctx context.Context) error {
 	n, err := odo.od.Exec(ctx)
@@ -88,5 +94,7 @@ func (odo *OtherDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (odo *OtherDeleteOne) ExecX(ctx context.Context) {
-	odo.od.ExecX(ctx)
+	if err := odo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/customid/ent/pet_delete.go
+++ b/entc/integration/customid/ent/pet_delete.go
@@ -73,6 +73,12 @@ type PetDeleteOne struct {
 	pd *PetDelete
 }
 
+// Where appends a list predicates to the PetDelete builder.
+func (pdo *PetDeleteOne) Where(ps ...predicate.Pet) *PetDeleteOne {
+	pdo.pd.mutation.Where(ps...)
+	return pdo
+}
+
 // Exec executes the deletion query.
 func (pdo *PetDeleteOne) Exec(ctx context.Context) error {
 	n, err := pdo.pd.Exec(ctx)
@@ -88,5 +94,7 @@ func (pdo *PetDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (pdo *PetDeleteOne) ExecX(ctx context.Context) {
-	pdo.pd.ExecX(ctx)
+	if err := pdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/customid/ent/revision_delete.go
+++ b/entc/integration/customid/ent/revision_delete.go
@@ -73,6 +73,12 @@ type RevisionDeleteOne struct {
 	rd *RevisionDelete
 }
 
+// Where appends a list predicates to the RevisionDelete builder.
+func (rdo *RevisionDeleteOne) Where(ps ...predicate.Revision) *RevisionDeleteOne {
+	rdo.rd.mutation.Where(ps...)
+	return rdo
+}
+
 // Exec executes the deletion query.
 func (rdo *RevisionDeleteOne) Exec(ctx context.Context) error {
 	n, err := rdo.rd.Exec(ctx)
@@ -88,5 +94,7 @@ func (rdo *RevisionDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (rdo *RevisionDeleteOne) ExecX(ctx context.Context) {
-	rdo.rd.ExecX(ctx)
+	if err := rdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/customid/ent/session_delete.go
+++ b/entc/integration/customid/ent/session_delete.go
@@ -73,6 +73,12 @@ type SessionDeleteOne struct {
 	sd *SessionDelete
 }
 
+// Where appends a list predicates to the SessionDelete builder.
+func (sdo *SessionDeleteOne) Where(ps ...predicate.Session) *SessionDeleteOne {
+	sdo.sd.mutation.Where(ps...)
+	return sdo
+}
+
 // Exec executes the deletion query.
 func (sdo *SessionDeleteOne) Exec(ctx context.Context) error {
 	n, err := sdo.sd.Exec(ctx)
@@ -88,5 +94,7 @@ func (sdo *SessionDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (sdo *SessionDeleteOne) ExecX(ctx context.Context) {
-	sdo.sd.ExecX(ctx)
+	if err := sdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/customid/ent/token_delete.go
+++ b/entc/integration/customid/ent/token_delete.go
@@ -73,6 +73,12 @@ type TokenDeleteOne struct {
 	td *TokenDelete
 }
 
+// Where appends a list predicates to the TokenDelete builder.
+func (tdo *TokenDeleteOne) Where(ps ...predicate.Token) *TokenDeleteOne {
+	tdo.td.mutation.Where(ps...)
+	return tdo
+}
+
 // Exec executes the deletion query.
 func (tdo *TokenDeleteOne) Exec(ctx context.Context) error {
 	n, err := tdo.td.Exec(ctx)
@@ -88,5 +94,7 @@ func (tdo *TokenDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (tdo *TokenDeleteOne) ExecX(ctx context.Context) {
-	tdo.td.ExecX(ctx)
+	if err := tdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/customid/ent/user_delete.go
+++ b/entc/integration/customid/ent/user_delete.go
@@ -73,6 +73,12 @@ type UserDeleteOne struct {
 	ud *UserDelete
 }
 
+// Where appends a list predicates to the UserDelete builder.
+func (udo *UserDeleteOne) Where(ps ...predicate.User) *UserDeleteOne {
+	udo.ud.mutation.Where(ps...)
+	return udo
+}
+
 // Exec executes the deletion query.
 func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 	n, err := udo.ud.Exec(ctx)
@@ -88,5 +94,7 @@ func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (udo *UserDeleteOne) ExecX(ctx context.Context) {
-	udo.ud.ExecX(ctx)
+	if err := udo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/edgefield/ent/car_delete.go
+++ b/entc/integration/edgefield/ent/car_delete.go
@@ -73,6 +73,12 @@ type CarDeleteOne struct {
 	cd *CarDelete
 }
 
+// Where appends a list predicates to the CarDelete builder.
+func (cdo *CarDeleteOne) Where(ps ...predicate.Car) *CarDeleteOne {
+	cdo.cd.mutation.Where(ps...)
+	return cdo
+}
+
 // Exec executes the deletion query.
 func (cdo *CarDeleteOne) Exec(ctx context.Context) error {
 	n, err := cdo.cd.Exec(ctx)
@@ -88,5 +94,7 @@ func (cdo *CarDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (cdo *CarDeleteOne) ExecX(ctx context.Context) {
-	cdo.cd.ExecX(ctx)
+	if err := cdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/edgefield/ent/card_delete.go
+++ b/entc/integration/edgefield/ent/card_delete.go
@@ -73,6 +73,12 @@ type CardDeleteOne struct {
 	cd *CardDelete
 }
 
+// Where appends a list predicates to the CardDelete builder.
+func (cdo *CardDeleteOne) Where(ps ...predicate.Card) *CardDeleteOne {
+	cdo.cd.mutation.Where(ps...)
+	return cdo
+}
+
 // Exec executes the deletion query.
 func (cdo *CardDeleteOne) Exec(ctx context.Context) error {
 	n, err := cdo.cd.Exec(ctx)
@@ -88,5 +94,7 @@ func (cdo *CardDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (cdo *CardDeleteOne) ExecX(ctx context.Context) {
-	cdo.cd.ExecX(ctx)
+	if err := cdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/edgefield/ent/info_delete.go
+++ b/entc/integration/edgefield/ent/info_delete.go
@@ -73,6 +73,12 @@ type InfoDeleteOne struct {
 	id *InfoDelete
 }
 
+// Where appends a list predicates to the InfoDelete builder.
+func (ido *InfoDeleteOne) Where(ps ...predicate.Info) *InfoDeleteOne {
+	ido.id.mutation.Where(ps...)
+	return ido
+}
+
 // Exec executes the deletion query.
 func (ido *InfoDeleteOne) Exec(ctx context.Context) error {
 	n, err := ido.id.Exec(ctx)
@@ -88,5 +94,7 @@ func (ido *InfoDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (ido *InfoDeleteOne) ExecX(ctx context.Context) {
-	ido.id.ExecX(ctx)
+	if err := ido.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/edgefield/ent/metadata_delete.go
+++ b/entc/integration/edgefield/ent/metadata_delete.go
@@ -73,6 +73,12 @@ type MetadataDeleteOne struct {
 	md *MetadataDelete
 }
 
+// Where appends a list predicates to the MetadataDelete builder.
+func (mdo *MetadataDeleteOne) Where(ps ...predicate.Metadata) *MetadataDeleteOne {
+	mdo.md.mutation.Where(ps...)
+	return mdo
+}
+
 // Exec executes the deletion query.
 func (mdo *MetadataDeleteOne) Exec(ctx context.Context) error {
 	n, err := mdo.md.Exec(ctx)
@@ -88,5 +94,7 @@ func (mdo *MetadataDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (mdo *MetadataDeleteOne) ExecX(ctx context.Context) {
-	mdo.md.ExecX(ctx)
+	if err := mdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/edgefield/ent/node_delete.go
+++ b/entc/integration/edgefield/ent/node_delete.go
@@ -73,6 +73,12 @@ type NodeDeleteOne struct {
 	nd *NodeDelete
 }
 
+// Where appends a list predicates to the NodeDelete builder.
+func (ndo *NodeDeleteOne) Where(ps ...predicate.Node) *NodeDeleteOne {
+	ndo.nd.mutation.Where(ps...)
+	return ndo
+}
+
 // Exec executes the deletion query.
 func (ndo *NodeDeleteOne) Exec(ctx context.Context) error {
 	n, err := ndo.nd.Exec(ctx)
@@ -88,5 +94,7 @@ func (ndo *NodeDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (ndo *NodeDeleteOne) ExecX(ctx context.Context) {
-	ndo.nd.ExecX(ctx)
+	if err := ndo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/edgefield/ent/pet_delete.go
+++ b/entc/integration/edgefield/ent/pet_delete.go
@@ -73,6 +73,12 @@ type PetDeleteOne struct {
 	pd *PetDelete
 }
 
+// Where appends a list predicates to the PetDelete builder.
+func (pdo *PetDeleteOne) Where(ps ...predicate.Pet) *PetDeleteOne {
+	pdo.pd.mutation.Where(ps...)
+	return pdo
+}
+
 // Exec executes the deletion query.
 func (pdo *PetDeleteOne) Exec(ctx context.Context) error {
 	n, err := pdo.pd.Exec(ctx)
@@ -88,5 +94,7 @@ func (pdo *PetDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (pdo *PetDeleteOne) ExecX(ctx context.Context) {
-	pdo.pd.ExecX(ctx)
+	if err := pdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/edgefield/ent/post_delete.go
+++ b/entc/integration/edgefield/ent/post_delete.go
@@ -73,6 +73,12 @@ type PostDeleteOne struct {
 	pd *PostDelete
 }
 
+// Where appends a list predicates to the PostDelete builder.
+func (pdo *PostDeleteOne) Where(ps ...predicate.Post) *PostDeleteOne {
+	pdo.pd.mutation.Where(ps...)
+	return pdo
+}
+
 // Exec executes the deletion query.
 func (pdo *PostDeleteOne) Exec(ctx context.Context) error {
 	n, err := pdo.pd.Exec(ctx)
@@ -88,5 +94,7 @@ func (pdo *PostDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (pdo *PostDeleteOne) ExecX(ctx context.Context) {
-	pdo.pd.ExecX(ctx)
+	if err := pdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/edgefield/ent/rental_delete.go
+++ b/entc/integration/edgefield/ent/rental_delete.go
@@ -73,6 +73,12 @@ type RentalDeleteOne struct {
 	rd *RentalDelete
 }
 
+// Where appends a list predicates to the RentalDelete builder.
+func (rdo *RentalDeleteOne) Where(ps ...predicate.Rental) *RentalDeleteOne {
+	rdo.rd.mutation.Where(ps...)
+	return rdo
+}
+
 // Exec executes the deletion query.
 func (rdo *RentalDeleteOne) Exec(ctx context.Context) error {
 	n, err := rdo.rd.Exec(ctx)
@@ -88,5 +94,7 @@ func (rdo *RentalDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (rdo *RentalDeleteOne) ExecX(ctx context.Context) {
-	rdo.rd.ExecX(ctx)
+	if err := rdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/edgefield/ent/user_delete.go
+++ b/entc/integration/edgefield/ent/user_delete.go
@@ -73,6 +73,12 @@ type UserDeleteOne struct {
 	ud *UserDelete
 }
 
+// Where appends a list predicates to the UserDelete builder.
+func (udo *UserDeleteOne) Where(ps ...predicate.User) *UserDeleteOne {
+	udo.ud.mutation.Where(ps...)
+	return udo
+}
+
 // Exec executes the deletion query.
 func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 	n, err := udo.ud.Exec(ctx)
@@ -88,5 +94,7 @@ func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (udo *UserDeleteOne) ExecX(ctx context.Context) {
-	udo.ud.ExecX(ctx)
+	if err := udo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/edgeschema/ent/friendship_delete.go
+++ b/entc/integration/edgeschema/ent/friendship_delete.go
@@ -73,6 +73,12 @@ type FriendshipDeleteOne struct {
 	fd *FriendshipDelete
 }
 
+// Where appends a list predicates to the FriendshipDelete builder.
+func (fdo *FriendshipDeleteOne) Where(ps ...predicate.Friendship) *FriendshipDeleteOne {
+	fdo.fd.mutation.Where(ps...)
+	return fdo
+}
+
 // Exec executes the deletion query.
 func (fdo *FriendshipDeleteOne) Exec(ctx context.Context) error {
 	n, err := fdo.fd.Exec(ctx)
@@ -88,5 +94,7 @@ func (fdo *FriendshipDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (fdo *FriendshipDeleteOne) ExecX(ctx context.Context) {
-	fdo.fd.ExecX(ctx)
+	if err := fdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/edgeschema/ent/group_delete.go
+++ b/entc/integration/edgeschema/ent/group_delete.go
@@ -73,6 +73,12 @@ type GroupDeleteOne struct {
 	gd *GroupDelete
 }
 
+// Where appends a list predicates to the GroupDelete builder.
+func (gdo *GroupDeleteOne) Where(ps ...predicate.Group) *GroupDeleteOne {
+	gdo.gd.mutation.Where(ps...)
+	return gdo
+}
+
 // Exec executes the deletion query.
 func (gdo *GroupDeleteOne) Exec(ctx context.Context) error {
 	n, err := gdo.gd.Exec(ctx)
@@ -88,5 +94,7 @@ func (gdo *GroupDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (gdo *GroupDeleteOne) ExecX(ctx context.Context) {
-	gdo.gd.ExecX(ctx)
+	if err := gdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/edgeschema/ent/grouptag_delete.go
+++ b/entc/integration/edgeschema/ent/grouptag_delete.go
@@ -73,6 +73,12 @@ type GroupTagDeleteOne struct {
 	gtd *GroupTagDelete
 }
 
+// Where appends a list predicates to the GroupTagDelete builder.
+func (gtdo *GroupTagDeleteOne) Where(ps ...predicate.GroupTag) *GroupTagDeleteOne {
+	gtdo.gtd.mutation.Where(ps...)
+	return gtdo
+}
+
 // Exec executes the deletion query.
 func (gtdo *GroupTagDeleteOne) Exec(ctx context.Context) error {
 	n, err := gtdo.gtd.Exec(ctx)
@@ -88,5 +94,7 @@ func (gtdo *GroupTagDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (gtdo *GroupTagDeleteOne) ExecX(ctx context.Context) {
-	gtdo.gtd.ExecX(ctx)
+	if err := gtdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/edgeschema/ent/relationship_delete.go
+++ b/entc/integration/edgeschema/ent/relationship_delete.go
@@ -68,6 +68,12 @@ type RelationshipDeleteOne struct {
 	rd *RelationshipDelete
 }
 
+// Where appends a list predicates to the RelationshipDelete builder.
+func (rdo *RelationshipDeleteOne) Where(ps ...predicate.Relationship) *RelationshipDeleteOne {
+	rdo.rd.mutation.Where(ps...)
+	return rdo
+}
+
 // Exec executes the deletion query.
 func (rdo *RelationshipDeleteOne) Exec(ctx context.Context) error {
 	n, err := rdo.rd.Exec(ctx)
@@ -83,5 +89,7 @@ func (rdo *RelationshipDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (rdo *RelationshipDeleteOne) ExecX(ctx context.Context) {
-	rdo.rd.ExecX(ctx)
+	if err := rdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/edgeschema/ent/relationshipinfo_delete.go
+++ b/entc/integration/edgeschema/ent/relationshipinfo_delete.go
@@ -73,6 +73,12 @@ type RelationshipInfoDeleteOne struct {
 	rid *RelationshipInfoDelete
 }
 
+// Where appends a list predicates to the RelationshipInfoDelete builder.
+func (rido *RelationshipInfoDeleteOne) Where(ps ...predicate.RelationshipInfo) *RelationshipInfoDeleteOne {
+	rido.rid.mutation.Where(ps...)
+	return rido
+}
+
 // Exec executes the deletion query.
 func (rido *RelationshipInfoDeleteOne) Exec(ctx context.Context) error {
 	n, err := rido.rid.Exec(ctx)
@@ -88,5 +94,7 @@ func (rido *RelationshipInfoDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (rido *RelationshipInfoDeleteOne) ExecX(ctx context.Context) {
-	rido.rid.ExecX(ctx)
+	if err := rido.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/edgeschema/ent/role_delete.go
+++ b/entc/integration/edgeschema/ent/role_delete.go
@@ -73,6 +73,12 @@ type RoleDeleteOne struct {
 	rd *RoleDelete
 }
 
+// Where appends a list predicates to the RoleDelete builder.
+func (rdo *RoleDeleteOne) Where(ps ...predicate.Role) *RoleDeleteOne {
+	rdo.rd.mutation.Where(ps...)
+	return rdo
+}
+
 // Exec executes the deletion query.
 func (rdo *RoleDeleteOne) Exec(ctx context.Context) error {
 	n, err := rdo.rd.Exec(ctx)
@@ -88,5 +94,7 @@ func (rdo *RoleDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (rdo *RoleDeleteOne) ExecX(ctx context.Context) {
-	rdo.rd.ExecX(ctx)
+	if err := rdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/edgeschema/ent/roleuser_delete.go
+++ b/entc/integration/edgeschema/ent/roleuser_delete.go
@@ -68,6 +68,12 @@ type RoleUserDeleteOne struct {
 	rud *RoleUserDelete
 }
 
+// Where appends a list predicates to the RoleUserDelete builder.
+func (rudo *RoleUserDeleteOne) Where(ps ...predicate.RoleUser) *RoleUserDeleteOne {
+	rudo.rud.mutation.Where(ps...)
+	return rudo
+}
+
 // Exec executes the deletion query.
 func (rudo *RoleUserDeleteOne) Exec(ctx context.Context) error {
 	n, err := rudo.rud.Exec(ctx)
@@ -83,5 +89,7 @@ func (rudo *RoleUserDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (rudo *RoleUserDeleteOne) ExecX(ctx context.Context) {
-	rudo.rud.ExecX(ctx)
+	if err := rudo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/edgeschema/ent/tag_delete.go
+++ b/entc/integration/edgeschema/ent/tag_delete.go
@@ -73,6 +73,12 @@ type TagDeleteOne struct {
 	td *TagDelete
 }
 
+// Where appends a list predicates to the TagDelete builder.
+func (tdo *TagDeleteOne) Where(ps ...predicate.Tag) *TagDeleteOne {
+	tdo.td.mutation.Where(ps...)
+	return tdo
+}
+
 // Exec executes the deletion query.
 func (tdo *TagDeleteOne) Exec(ctx context.Context) error {
 	n, err := tdo.td.Exec(ctx)
@@ -88,5 +94,7 @@ func (tdo *TagDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (tdo *TagDeleteOne) ExecX(ctx context.Context) {
-	tdo.td.ExecX(ctx)
+	if err := tdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/edgeschema/ent/tweet_delete.go
+++ b/entc/integration/edgeschema/ent/tweet_delete.go
@@ -73,6 +73,12 @@ type TweetDeleteOne struct {
 	td *TweetDelete
 }
 
+// Where appends a list predicates to the TweetDelete builder.
+func (tdo *TweetDeleteOne) Where(ps ...predicate.Tweet) *TweetDeleteOne {
+	tdo.td.mutation.Where(ps...)
+	return tdo
+}
+
 // Exec executes the deletion query.
 func (tdo *TweetDeleteOne) Exec(ctx context.Context) error {
 	n, err := tdo.td.Exec(ctx)
@@ -88,5 +94,7 @@ func (tdo *TweetDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (tdo *TweetDeleteOne) ExecX(ctx context.Context) {
-	tdo.td.ExecX(ctx)
+	if err := tdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/edgeschema/ent/tweetlike_delete.go
+++ b/entc/integration/edgeschema/ent/tweetlike_delete.go
@@ -68,6 +68,12 @@ type TweetLikeDeleteOne struct {
 	tld *TweetLikeDelete
 }
 
+// Where appends a list predicates to the TweetLikeDelete builder.
+func (tldo *TweetLikeDeleteOne) Where(ps ...predicate.TweetLike) *TweetLikeDeleteOne {
+	tldo.tld.mutation.Where(ps...)
+	return tldo
+}
+
 // Exec executes the deletion query.
 func (tldo *TweetLikeDeleteOne) Exec(ctx context.Context) error {
 	n, err := tldo.tld.Exec(ctx)
@@ -83,5 +89,7 @@ func (tldo *TweetLikeDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (tldo *TweetLikeDeleteOne) ExecX(ctx context.Context) {
-	tldo.tld.ExecX(ctx)
+	if err := tldo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/edgeschema/ent/tweettag_delete.go
+++ b/entc/integration/edgeschema/ent/tweettag_delete.go
@@ -73,6 +73,12 @@ type TweetTagDeleteOne struct {
 	ttd *TweetTagDelete
 }
 
+// Where appends a list predicates to the TweetTagDelete builder.
+func (ttdo *TweetTagDeleteOne) Where(ps ...predicate.TweetTag) *TweetTagDeleteOne {
+	ttdo.ttd.mutation.Where(ps...)
+	return ttdo
+}
+
 // Exec executes the deletion query.
 func (ttdo *TweetTagDeleteOne) Exec(ctx context.Context) error {
 	n, err := ttdo.ttd.Exec(ctx)
@@ -88,5 +94,7 @@ func (ttdo *TweetTagDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (ttdo *TweetTagDeleteOne) ExecX(ctx context.Context) {
-	ttdo.ttd.ExecX(ctx)
+	if err := ttdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/edgeschema/ent/user_delete.go
+++ b/entc/integration/edgeschema/ent/user_delete.go
@@ -73,6 +73,12 @@ type UserDeleteOne struct {
 	ud *UserDelete
 }
 
+// Where appends a list predicates to the UserDelete builder.
+func (udo *UserDeleteOne) Where(ps ...predicate.User) *UserDeleteOne {
+	udo.ud.mutation.Where(ps...)
+	return udo
+}
+
 // Exec executes the deletion query.
 func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 	n, err := udo.ud.Exec(ctx)
@@ -88,5 +94,7 @@ func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (udo *UserDeleteOne) ExecX(ctx context.Context) {
-	udo.ud.ExecX(ctx)
+	if err := udo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/edgeschema/ent/usergroup_delete.go
+++ b/entc/integration/edgeschema/ent/usergroup_delete.go
@@ -73,6 +73,12 @@ type UserGroupDeleteOne struct {
 	ugd *UserGroupDelete
 }
 
+// Where appends a list predicates to the UserGroupDelete builder.
+func (ugdo *UserGroupDeleteOne) Where(ps ...predicate.UserGroup) *UserGroupDeleteOne {
+	ugdo.ugd.mutation.Where(ps...)
+	return ugdo
+}
+
 // Exec executes the deletion query.
 func (ugdo *UserGroupDeleteOne) Exec(ctx context.Context) error {
 	n, err := ugdo.ugd.Exec(ctx)
@@ -88,5 +94,7 @@ func (ugdo *UserGroupDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (ugdo *UserGroupDeleteOne) ExecX(ctx context.Context) {
-	ugdo.ugd.ExecX(ctx)
+	if err := ugdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/edgeschema/ent/usertweet_delete.go
+++ b/entc/integration/edgeschema/ent/usertweet_delete.go
@@ -73,6 +73,12 @@ type UserTweetDeleteOne struct {
 	utd *UserTweetDelete
 }
 
+// Where appends a list predicates to the UserTweetDelete builder.
+func (utdo *UserTweetDeleteOne) Where(ps ...predicate.UserTweet) *UserTweetDeleteOne {
+	utdo.utd.mutation.Where(ps...)
+	return utdo
+}
+
 // Exec executes the deletion query.
 func (utdo *UserTweetDeleteOne) Exec(ctx context.Context) error {
 	n, err := utdo.utd.Exec(ctx)
@@ -88,5 +94,7 @@ func (utdo *UserTweetDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (utdo *UserTweetDeleteOne) ExecX(ctx context.Context) {
-	utdo.utd.ExecX(ctx)
+	if err := utdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/ent/api_delete.go
+++ b/entc/integration/ent/api_delete.go
@@ -73,6 +73,12 @@ type APIDeleteOne struct {
 	ad *APIDelete
 }
 
+// Where appends a list predicates to the APIDelete builder.
+func (ado *APIDeleteOne) Where(ps ...predicate.Api) *APIDeleteOne {
+	ado.ad.mutation.Where(ps...)
+	return ado
+}
+
 // Exec executes the deletion query.
 func (ado *APIDeleteOne) Exec(ctx context.Context) error {
 	n, err := ado.ad.Exec(ctx)
@@ -88,5 +94,7 @@ func (ado *APIDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (ado *APIDeleteOne) ExecX(ctx context.Context) {
-	ado.ad.ExecX(ctx)
+	if err := ado.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/ent/card_delete.go
+++ b/entc/integration/ent/card_delete.go
@@ -73,6 +73,12 @@ type CardDeleteOne struct {
 	cd *CardDelete
 }
 
+// Where appends a list predicates to the CardDelete builder.
+func (cdo *CardDeleteOne) Where(ps ...predicate.Card) *CardDeleteOne {
+	cdo.cd.mutation.Where(ps...)
+	return cdo
+}
+
 // Exec executes the deletion query.
 func (cdo *CardDeleteOne) Exec(ctx context.Context) error {
 	n, err := cdo.cd.Exec(ctx)
@@ -88,5 +94,7 @@ func (cdo *CardDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (cdo *CardDeleteOne) ExecX(ctx context.Context) {
-	cdo.cd.ExecX(ctx)
+	if err := cdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/ent/comment_delete.go
+++ b/entc/integration/ent/comment_delete.go
@@ -73,6 +73,12 @@ type CommentDeleteOne struct {
 	cd *CommentDelete
 }
 
+// Where appends a list predicates to the CommentDelete builder.
+func (cdo *CommentDeleteOne) Where(ps ...predicate.Comment) *CommentDeleteOne {
+	cdo.cd.mutation.Where(ps...)
+	return cdo
+}
+
 // Exec executes the deletion query.
 func (cdo *CommentDeleteOne) Exec(ctx context.Context) error {
 	n, err := cdo.cd.Exec(ctx)
@@ -88,5 +94,7 @@ func (cdo *CommentDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (cdo *CommentDeleteOne) ExecX(ctx context.Context) {
-	cdo.cd.ExecX(ctx)
+	if err := cdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/ent/fieldtype_delete.go
+++ b/entc/integration/ent/fieldtype_delete.go
@@ -73,6 +73,12 @@ type FieldTypeDeleteOne struct {
 	ftd *FieldTypeDelete
 }
 
+// Where appends a list predicates to the FieldTypeDelete builder.
+func (ftdo *FieldTypeDeleteOne) Where(ps ...predicate.FieldType) *FieldTypeDeleteOne {
+	ftdo.ftd.mutation.Where(ps...)
+	return ftdo
+}
+
 // Exec executes the deletion query.
 func (ftdo *FieldTypeDeleteOne) Exec(ctx context.Context) error {
 	n, err := ftdo.ftd.Exec(ctx)
@@ -88,5 +94,7 @@ func (ftdo *FieldTypeDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (ftdo *FieldTypeDeleteOne) ExecX(ctx context.Context) {
-	ftdo.ftd.ExecX(ctx)
+	if err := ftdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/ent/file_delete.go
+++ b/entc/integration/ent/file_delete.go
@@ -73,6 +73,12 @@ type FileDeleteOne struct {
 	fd *FileDelete
 }
 
+// Where appends a list predicates to the FileDelete builder.
+func (fdo *FileDeleteOne) Where(ps ...predicate.File) *FileDeleteOne {
+	fdo.fd.mutation.Where(ps...)
+	return fdo
+}
+
 // Exec executes the deletion query.
 func (fdo *FileDeleteOne) Exec(ctx context.Context) error {
 	n, err := fdo.fd.Exec(ctx)
@@ -88,5 +94,7 @@ func (fdo *FileDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (fdo *FileDeleteOne) ExecX(ctx context.Context) {
-	fdo.fd.ExecX(ctx)
+	if err := fdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/ent/filetype_delete.go
+++ b/entc/integration/ent/filetype_delete.go
@@ -73,6 +73,12 @@ type FileTypeDeleteOne struct {
 	ftd *FileTypeDelete
 }
 
+// Where appends a list predicates to the FileTypeDelete builder.
+func (ftdo *FileTypeDeleteOne) Where(ps ...predicate.FileType) *FileTypeDeleteOne {
+	ftdo.ftd.mutation.Where(ps...)
+	return ftdo
+}
+
 // Exec executes the deletion query.
 func (ftdo *FileTypeDeleteOne) Exec(ctx context.Context) error {
 	n, err := ftdo.ftd.Exec(ctx)
@@ -88,5 +94,7 @@ func (ftdo *FileTypeDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (ftdo *FileTypeDeleteOne) ExecX(ctx context.Context) {
-	ftdo.ftd.ExecX(ctx)
+	if err := ftdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/ent/goods_delete.go
+++ b/entc/integration/ent/goods_delete.go
@@ -73,6 +73,12 @@ type GoodsDeleteOne struct {
 	gd *GoodsDelete
 }
 
+// Where appends a list predicates to the GoodsDelete builder.
+func (gdo *GoodsDeleteOne) Where(ps ...predicate.Goods) *GoodsDeleteOne {
+	gdo.gd.mutation.Where(ps...)
+	return gdo
+}
+
 // Exec executes the deletion query.
 func (gdo *GoodsDeleteOne) Exec(ctx context.Context) error {
 	n, err := gdo.gd.Exec(ctx)
@@ -88,5 +94,7 @@ func (gdo *GoodsDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (gdo *GoodsDeleteOne) ExecX(ctx context.Context) {
-	gdo.gd.ExecX(ctx)
+	if err := gdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/ent/group_delete.go
+++ b/entc/integration/ent/group_delete.go
@@ -73,6 +73,12 @@ type GroupDeleteOne struct {
 	gd *GroupDelete
 }
 
+// Where appends a list predicates to the GroupDelete builder.
+func (gdo *GroupDeleteOne) Where(ps ...predicate.Group) *GroupDeleteOne {
+	gdo.gd.mutation.Where(ps...)
+	return gdo
+}
+
 // Exec executes the deletion query.
 func (gdo *GroupDeleteOne) Exec(ctx context.Context) error {
 	n, err := gdo.gd.Exec(ctx)
@@ -88,5 +94,7 @@ func (gdo *GroupDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (gdo *GroupDeleteOne) ExecX(ctx context.Context) {
-	gdo.gd.ExecX(ctx)
+	if err := gdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/ent/groupinfo_delete.go
+++ b/entc/integration/ent/groupinfo_delete.go
@@ -73,6 +73,12 @@ type GroupInfoDeleteOne struct {
 	gid *GroupInfoDelete
 }
 
+// Where appends a list predicates to the GroupInfoDelete builder.
+func (gido *GroupInfoDeleteOne) Where(ps ...predicate.GroupInfo) *GroupInfoDeleteOne {
+	gido.gid.mutation.Where(ps...)
+	return gido
+}
+
 // Exec executes the deletion query.
 func (gido *GroupInfoDeleteOne) Exec(ctx context.Context) error {
 	n, err := gido.gid.Exec(ctx)
@@ -88,5 +94,7 @@ func (gido *GroupInfoDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (gido *GroupInfoDeleteOne) ExecX(ctx context.Context) {
-	gido.gid.ExecX(ctx)
+	if err := gido.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/ent/item_delete.go
+++ b/entc/integration/ent/item_delete.go
@@ -73,6 +73,12 @@ type ItemDeleteOne struct {
 	id *ItemDelete
 }
 
+// Where appends a list predicates to the ItemDelete builder.
+func (ido *ItemDeleteOne) Where(ps ...predicate.Item) *ItemDeleteOne {
+	ido.id.mutation.Where(ps...)
+	return ido
+}
+
 // Exec executes the deletion query.
 func (ido *ItemDeleteOne) Exec(ctx context.Context) error {
 	n, err := ido.id.Exec(ctx)
@@ -88,5 +94,7 @@ func (ido *ItemDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (ido *ItemDeleteOne) ExecX(ctx context.Context) {
-	ido.id.ExecX(ctx)
+	if err := ido.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/ent/license_delete.go
+++ b/entc/integration/ent/license_delete.go
@@ -73,6 +73,12 @@ type LicenseDeleteOne struct {
 	ld *LicenseDelete
 }
 
+// Where appends a list predicates to the LicenseDelete builder.
+func (ldo *LicenseDeleteOne) Where(ps ...predicate.License) *LicenseDeleteOne {
+	ldo.ld.mutation.Where(ps...)
+	return ldo
+}
+
 // Exec executes the deletion query.
 func (ldo *LicenseDeleteOne) Exec(ctx context.Context) error {
 	n, err := ldo.ld.Exec(ctx)
@@ -88,5 +94,7 @@ func (ldo *LicenseDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (ldo *LicenseDeleteOne) ExecX(ctx context.Context) {
-	ldo.ld.ExecX(ctx)
+	if err := ldo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/ent/node_delete.go
+++ b/entc/integration/ent/node_delete.go
@@ -73,6 +73,12 @@ type NodeDeleteOne struct {
 	nd *NodeDelete
 }
 
+// Where appends a list predicates to the NodeDelete builder.
+func (ndo *NodeDeleteOne) Where(ps ...predicate.Node) *NodeDeleteOne {
+	ndo.nd.mutation.Where(ps...)
+	return ndo
+}
+
 // Exec executes the deletion query.
 func (ndo *NodeDeleteOne) Exec(ctx context.Context) error {
 	n, err := ndo.nd.Exec(ctx)
@@ -88,5 +94,7 @@ func (ndo *NodeDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (ndo *NodeDeleteOne) ExecX(ctx context.Context) {
-	ndo.nd.ExecX(ctx)
+	if err := ndo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/ent/pet_delete.go
+++ b/entc/integration/ent/pet_delete.go
@@ -73,6 +73,12 @@ type PetDeleteOne struct {
 	pd *PetDelete
 }
 
+// Where appends a list predicates to the PetDelete builder.
+func (pdo *PetDeleteOne) Where(ps ...predicate.Pet) *PetDeleteOne {
+	pdo.pd.mutation.Where(ps...)
+	return pdo
+}
+
 // Exec executes the deletion query.
 func (pdo *PetDeleteOne) Exec(ctx context.Context) error {
 	n, err := pdo.pd.Exec(ctx)
@@ -88,5 +94,7 @@ func (pdo *PetDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (pdo *PetDeleteOne) ExecX(ctx context.Context) {
-	pdo.pd.ExecX(ctx)
+	if err := pdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/ent/spec_delete.go
+++ b/entc/integration/ent/spec_delete.go
@@ -73,6 +73,12 @@ type SpecDeleteOne struct {
 	sd *SpecDelete
 }
 
+// Where appends a list predicates to the SpecDelete builder.
+func (sdo *SpecDeleteOne) Where(ps ...predicate.Spec) *SpecDeleteOne {
+	sdo.sd.mutation.Where(ps...)
+	return sdo
+}
+
 // Exec executes the deletion query.
 func (sdo *SpecDeleteOne) Exec(ctx context.Context) error {
 	n, err := sdo.sd.Exec(ctx)
@@ -88,5 +94,7 @@ func (sdo *SpecDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (sdo *SpecDeleteOne) ExecX(ctx context.Context) {
-	sdo.sd.ExecX(ctx)
+	if err := sdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/ent/task_delete.go
+++ b/entc/integration/ent/task_delete.go
@@ -74,6 +74,12 @@ type TaskDeleteOne struct {
 	td *TaskDelete
 }
 
+// Where appends a list predicates to the TaskDelete builder.
+func (tdo *TaskDeleteOne) Where(ps ...predicate.Task) *TaskDeleteOne {
+	tdo.td.mutation.Where(ps...)
+	return tdo
+}
+
 // Exec executes the deletion query.
 func (tdo *TaskDeleteOne) Exec(ctx context.Context) error {
 	n, err := tdo.td.Exec(ctx)
@@ -89,5 +95,7 @@ func (tdo *TaskDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (tdo *TaskDeleteOne) ExecX(ctx context.Context) {
-	tdo.td.ExecX(ctx)
+	if err := tdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/ent/user_delete.go
+++ b/entc/integration/ent/user_delete.go
@@ -73,6 +73,12 @@ type UserDeleteOne struct {
 	ud *UserDelete
 }
 
+// Where appends a list predicates to the UserDelete builder.
+func (udo *UserDeleteOne) Where(ps ...predicate.User) *UserDeleteOne {
+	udo.ud.mutation.Where(ps...)
+	return udo
+}
+
 // Exec executes the deletion query.
 func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 	n, err := udo.ud.Exec(ctx)
@@ -88,5 +94,7 @@ func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (udo *UserDeleteOne) ExecX(ctx context.Context) {
-	udo.ud.ExecX(ctx)
+	if err := udo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/gremlin/ent/api_delete.go
+++ b/entc/integration/gremlin/ent/api_delete.go
@@ -67,6 +67,12 @@ type APIDeleteOne struct {
 	ad *APIDelete
 }
 
+// Where appends a list predicates to the APIDelete builder.
+func (ado *APIDeleteOne) Where(ps ...predicate.Api) *APIDeleteOne {
+	ado.ad.mutation.Where(ps...)
+	return ado
+}
+
 // Exec executes the deletion query.
 func (ado *APIDeleteOne) Exec(ctx context.Context) error {
 	n, err := ado.ad.Exec(ctx)
@@ -82,5 +88,7 @@ func (ado *APIDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (ado *APIDeleteOne) ExecX(ctx context.Context) {
-	ado.ad.ExecX(ctx)
+	if err := ado.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/gremlin/ent/card_delete.go
+++ b/entc/integration/gremlin/ent/card_delete.go
@@ -67,6 +67,12 @@ type CardDeleteOne struct {
 	cd *CardDelete
 }
 
+// Where appends a list predicates to the CardDelete builder.
+func (cdo *CardDeleteOne) Where(ps ...predicate.Card) *CardDeleteOne {
+	cdo.cd.mutation.Where(ps...)
+	return cdo
+}
+
 // Exec executes the deletion query.
 func (cdo *CardDeleteOne) Exec(ctx context.Context) error {
 	n, err := cdo.cd.Exec(ctx)
@@ -82,5 +88,7 @@ func (cdo *CardDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (cdo *CardDeleteOne) ExecX(ctx context.Context) {
-	cdo.cd.ExecX(ctx)
+	if err := cdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/gremlin/ent/comment_delete.go
+++ b/entc/integration/gremlin/ent/comment_delete.go
@@ -67,6 +67,12 @@ type CommentDeleteOne struct {
 	cd *CommentDelete
 }
 
+// Where appends a list predicates to the CommentDelete builder.
+func (cdo *CommentDeleteOne) Where(ps ...predicate.Comment) *CommentDeleteOne {
+	cdo.cd.mutation.Where(ps...)
+	return cdo
+}
+
 // Exec executes the deletion query.
 func (cdo *CommentDeleteOne) Exec(ctx context.Context) error {
 	n, err := cdo.cd.Exec(ctx)
@@ -82,5 +88,7 @@ func (cdo *CommentDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (cdo *CommentDeleteOne) ExecX(ctx context.Context) {
-	cdo.cd.ExecX(ctx)
+	if err := cdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/gremlin/ent/fieldtype_delete.go
+++ b/entc/integration/gremlin/ent/fieldtype_delete.go
@@ -67,6 +67,12 @@ type FieldTypeDeleteOne struct {
 	ftd *FieldTypeDelete
 }
 
+// Where appends a list predicates to the FieldTypeDelete builder.
+func (ftdo *FieldTypeDeleteOne) Where(ps ...predicate.FieldType) *FieldTypeDeleteOne {
+	ftdo.ftd.mutation.Where(ps...)
+	return ftdo
+}
+
 // Exec executes the deletion query.
 func (ftdo *FieldTypeDeleteOne) Exec(ctx context.Context) error {
 	n, err := ftdo.ftd.Exec(ctx)
@@ -82,5 +88,7 @@ func (ftdo *FieldTypeDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (ftdo *FieldTypeDeleteOne) ExecX(ctx context.Context) {
-	ftdo.ftd.ExecX(ctx)
+	if err := ftdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/gremlin/ent/file_delete.go
+++ b/entc/integration/gremlin/ent/file_delete.go
@@ -67,6 +67,12 @@ type FileDeleteOne struct {
 	fd *FileDelete
 }
 
+// Where appends a list predicates to the FileDelete builder.
+func (fdo *FileDeleteOne) Where(ps ...predicate.File) *FileDeleteOne {
+	fdo.fd.mutation.Where(ps...)
+	return fdo
+}
+
 // Exec executes the deletion query.
 func (fdo *FileDeleteOne) Exec(ctx context.Context) error {
 	n, err := fdo.fd.Exec(ctx)
@@ -82,5 +88,7 @@ func (fdo *FileDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (fdo *FileDeleteOne) ExecX(ctx context.Context) {
-	fdo.fd.ExecX(ctx)
+	if err := fdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/gremlin/ent/filetype_delete.go
+++ b/entc/integration/gremlin/ent/filetype_delete.go
@@ -67,6 +67,12 @@ type FileTypeDeleteOne struct {
 	ftd *FileTypeDelete
 }
 
+// Where appends a list predicates to the FileTypeDelete builder.
+func (ftdo *FileTypeDeleteOne) Where(ps ...predicate.FileType) *FileTypeDeleteOne {
+	ftdo.ftd.mutation.Where(ps...)
+	return ftdo
+}
+
 // Exec executes the deletion query.
 func (ftdo *FileTypeDeleteOne) Exec(ctx context.Context) error {
 	n, err := ftdo.ftd.Exec(ctx)
@@ -82,5 +88,7 @@ func (ftdo *FileTypeDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (ftdo *FileTypeDeleteOne) ExecX(ctx context.Context) {
-	ftdo.ftd.ExecX(ctx)
+	if err := ftdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/gremlin/ent/goods_delete.go
+++ b/entc/integration/gremlin/ent/goods_delete.go
@@ -67,6 +67,12 @@ type GoodsDeleteOne struct {
 	gd *GoodsDelete
 }
 
+// Where appends a list predicates to the GoodsDelete builder.
+func (gdo *GoodsDeleteOne) Where(ps ...predicate.Goods) *GoodsDeleteOne {
+	gdo.gd.mutation.Where(ps...)
+	return gdo
+}
+
 // Exec executes the deletion query.
 func (gdo *GoodsDeleteOne) Exec(ctx context.Context) error {
 	n, err := gdo.gd.Exec(ctx)
@@ -82,5 +88,7 @@ func (gdo *GoodsDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (gdo *GoodsDeleteOne) ExecX(ctx context.Context) {
-	gdo.gd.ExecX(ctx)
+	if err := gdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/gremlin/ent/group_delete.go
+++ b/entc/integration/gremlin/ent/group_delete.go
@@ -67,6 +67,12 @@ type GroupDeleteOne struct {
 	gd *GroupDelete
 }
 
+// Where appends a list predicates to the GroupDelete builder.
+func (gdo *GroupDeleteOne) Where(ps ...predicate.Group) *GroupDeleteOne {
+	gdo.gd.mutation.Where(ps...)
+	return gdo
+}
+
 // Exec executes the deletion query.
 func (gdo *GroupDeleteOne) Exec(ctx context.Context) error {
 	n, err := gdo.gd.Exec(ctx)
@@ -82,5 +88,7 @@ func (gdo *GroupDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (gdo *GroupDeleteOne) ExecX(ctx context.Context) {
-	gdo.gd.ExecX(ctx)
+	if err := gdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/gremlin/ent/groupinfo_delete.go
+++ b/entc/integration/gremlin/ent/groupinfo_delete.go
@@ -67,6 +67,12 @@ type GroupInfoDeleteOne struct {
 	gid *GroupInfoDelete
 }
 
+// Where appends a list predicates to the GroupInfoDelete builder.
+func (gido *GroupInfoDeleteOne) Where(ps ...predicate.GroupInfo) *GroupInfoDeleteOne {
+	gido.gid.mutation.Where(ps...)
+	return gido
+}
+
 // Exec executes the deletion query.
 func (gido *GroupInfoDeleteOne) Exec(ctx context.Context) error {
 	n, err := gido.gid.Exec(ctx)
@@ -82,5 +88,7 @@ func (gido *GroupInfoDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (gido *GroupInfoDeleteOne) ExecX(ctx context.Context) {
-	gido.gid.ExecX(ctx)
+	if err := gido.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/gremlin/ent/item_delete.go
+++ b/entc/integration/gremlin/ent/item_delete.go
@@ -67,6 +67,12 @@ type ItemDeleteOne struct {
 	id *ItemDelete
 }
 
+// Where appends a list predicates to the ItemDelete builder.
+func (ido *ItemDeleteOne) Where(ps ...predicate.Item) *ItemDeleteOne {
+	ido.id.mutation.Where(ps...)
+	return ido
+}
+
 // Exec executes the deletion query.
 func (ido *ItemDeleteOne) Exec(ctx context.Context) error {
 	n, err := ido.id.Exec(ctx)
@@ -82,5 +88,7 @@ func (ido *ItemDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (ido *ItemDeleteOne) ExecX(ctx context.Context) {
-	ido.id.ExecX(ctx)
+	if err := ido.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/gremlin/ent/license_delete.go
+++ b/entc/integration/gremlin/ent/license_delete.go
@@ -67,6 +67,12 @@ type LicenseDeleteOne struct {
 	ld *LicenseDelete
 }
 
+// Where appends a list predicates to the LicenseDelete builder.
+func (ldo *LicenseDeleteOne) Where(ps ...predicate.License) *LicenseDeleteOne {
+	ldo.ld.mutation.Where(ps...)
+	return ldo
+}
+
 // Exec executes the deletion query.
 func (ldo *LicenseDeleteOne) Exec(ctx context.Context) error {
 	n, err := ldo.ld.Exec(ctx)
@@ -82,5 +88,7 @@ func (ldo *LicenseDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (ldo *LicenseDeleteOne) ExecX(ctx context.Context) {
-	ldo.ld.ExecX(ctx)
+	if err := ldo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/gremlin/ent/node_delete.go
+++ b/entc/integration/gremlin/ent/node_delete.go
@@ -67,6 +67,12 @@ type NodeDeleteOne struct {
 	nd *NodeDelete
 }
 
+// Where appends a list predicates to the NodeDelete builder.
+func (ndo *NodeDeleteOne) Where(ps ...predicate.Node) *NodeDeleteOne {
+	ndo.nd.mutation.Where(ps...)
+	return ndo
+}
+
 // Exec executes the deletion query.
 func (ndo *NodeDeleteOne) Exec(ctx context.Context) error {
 	n, err := ndo.nd.Exec(ctx)
@@ -82,5 +88,7 @@ func (ndo *NodeDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (ndo *NodeDeleteOne) ExecX(ctx context.Context) {
-	ndo.nd.ExecX(ctx)
+	if err := ndo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/gremlin/ent/pet_delete.go
+++ b/entc/integration/gremlin/ent/pet_delete.go
@@ -67,6 +67,12 @@ type PetDeleteOne struct {
 	pd *PetDelete
 }
 
+// Where appends a list predicates to the PetDelete builder.
+func (pdo *PetDeleteOne) Where(ps ...predicate.Pet) *PetDeleteOne {
+	pdo.pd.mutation.Where(ps...)
+	return pdo
+}
+
 // Exec executes the deletion query.
 func (pdo *PetDeleteOne) Exec(ctx context.Context) error {
 	n, err := pdo.pd.Exec(ctx)
@@ -82,5 +88,7 @@ func (pdo *PetDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (pdo *PetDeleteOne) ExecX(ctx context.Context) {
-	pdo.pd.ExecX(ctx)
+	if err := pdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/gremlin/ent/spec_delete.go
+++ b/entc/integration/gremlin/ent/spec_delete.go
@@ -67,6 +67,12 @@ type SpecDeleteOne struct {
 	sd *SpecDelete
 }
 
+// Where appends a list predicates to the SpecDelete builder.
+func (sdo *SpecDeleteOne) Where(ps ...predicate.Spec) *SpecDeleteOne {
+	sdo.sd.mutation.Where(ps...)
+	return sdo
+}
+
 // Exec executes the deletion query.
 func (sdo *SpecDeleteOne) Exec(ctx context.Context) error {
 	n, err := sdo.sd.Exec(ctx)
@@ -82,5 +88,7 @@ func (sdo *SpecDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (sdo *SpecDeleteOne) ExecX(ctx context.Context) {
-	sdo.sd.ExecX(ctx)
+	if err := sdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/gremlin/ent/task_delete.go
+++ b/entc/integration/gremlin/ent/task_delete.go
@@ -68,6 +68,12 @@ type TaskDeleteOne struct {
 	td *TaskDelete
 }
 
+// Where appends a list predicates to the TaskDelete builder.
+func (tdo *TaskDeleteOne) Where(ps ...predicate.Task) *TaskDeleteOne {
+	tdo.td.mutation.Where(ps...)
+	return tdo
+}
+
 // Exec executes the deletion query.
 func (tdo *TaskDeleteOne) Exec(ctx context.Context) error {
 	n, err := tdo.td.Exec(ctx)
@@ -83,5 +89,7 @@ func (tdo *TaskDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (tdo *TaskDeleteOne) ExecX(ctx context.Context) {
-	tdo.td.ExecX(ctx)
+	if err := tdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/gremlin/ent/user_delete.go
+++ b/entc/integration/gremlin/ent/user_delete.go
@@ -67,6 +67,12 @@ type UserDeleteOne struct {
 	ud *UserDelete
 }
 
+// Where appends a list predicates to the UserDelete builder.
+func (udo *UserDeleteOne) Where(ps ...predicate.User) *UserDeleteOne {
+	udo.ud.mutation.Where(ps...)
+	return udo
+}
+
 // Exec executes the deletion query.
 func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 	n, err := udo.ud.Exec(ctx)
@@ -82,5 +88,7 @@ func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (udo *UserDeleteOne) ExecX(ctx context.Context) {
-	udo.ud.ExecX(ctx)
+	if err := udo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/hooks/ent/card_delete.go
+++ b/entc/integration/hooks/ent/card_delete.go
@@ -73,6 +73,12 @@ type CardDeleteOne struct {
 	cd *CardDelete
 }
 
+// Where appends a list predicates to the CardDelete builder.
+func (cdo *CardDeleteOne) Where(ps ...predicate.Card) *CardDeleteOne {
+	cdo.cd.mutation.Where(ps...)
+	return cdo
+}
+
 // Exec executes the deletion query.
 func (cdo *CardDeleteOne) Exec(ctx context.Context) error {
 	n, err := cdo.cd.Exec(ctx)
@@ -88,5 +94,7 @@ func (cdo *CardDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (cdo *CardDeleteOne) ExecX(ctx context.Context) {
-	cdo.cd.ExecX(ctx)
+	if err := cdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/hooks/ent/pet_delete.go
+++ b/entc/integration/hooks/ent/pet_delete.go
@@ -73,6 +73,12 @@ type PetDeleteOne struct {
 	pd *PetDelete
 }
 
+// Where appends a list predicates to the PetDelete builder.
+func (pdo *PetDeleteOne) Where(ps ...predicate.Pet) *PetDeleteOne {
+	pdo.pd.mutation.Where(ps...)
+	return pdo
+}
+
 // Exec executes the deletion query.
 func (pdo *PetDeleteOne) Exec(ctx context.Context) error {
 	n, err := pdo.pd.Exec(ctx)
@@ -88,5 +94,7 @@ func (pdo *PetDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (pdo *PetDeleteOne) ExecX(ctx context.Context) {
-	pdo.pd.ExecX(ctx)
+	if err := pdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/hooks/ent/user_delete.go
+++ b/entc/integration/hooks/ent/user_delete.go
@@ -73,6 +73,12 @@ type UserDeleteOne struct {
 	ud *UserDelete
 }
 
+// Where appends a list predicates to the UserDelete builder.
+func (udo *UserDeleteOne) Where(ps ...predicate.User) *UserDeleteOne {
+	udo.ud.mutation.Where(ps...)
+	return udo
+}
+
 // Exec executes the deletion query.
 func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 	n, err := udo.ud.Exec(ctx)
@@ -88,5 +94,7 @@ func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (udo *UserDeleteOne) ExecX(ctx context.Context) {
-	udo.ud.ExecX(ctx)
+	if err := udo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/idtype/ent/user_delete.go
+++ b/entc/integration/idtype/ent/user_delete.go
@@ -73,6 +73,12 @@ type UserDeleteOne struct {
 	ud *UserDelete
 }
 
+// Where appends a list predicates to the UserDelete builder.
+func (udo *UserDeleteOne) Where(ps ...predicate.User) *UserDeleteOne {
+	udo.ud.mutation.Where(ps...)
+	return udo
+}
+
 // Exec executes the deletion query.
 func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 	n, err := udo.ud.Exec(ctx)
@@ -88,5 +94,7 @@ func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (udo *UserDeleteOne) ExecX(ctx context.Context) {
-	udo.ud.ExecX(ctx)
+	if err := udo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/json/ent/user_delete.go
+++ b/entc/integration/json/ent/user_delete.go
@@ -73,6 +73,12 @@ type UserDeleteOne struct {
 	ud *UserDelete
 }
 
+// Where appends a list predicates to the UserDelete builder.
+func (udo *UserDeleteOne) Where(ps ...predicate.User) *UserDeleteOne {
+	udo.ud.mutation.Where(ps...)
+	return udo
+}
+
 // Exec executes the deletion query.
 func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 	n, err := udo.ud.Exec(ctx)
@@ -88,5 +94,7 @@ func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (udo *UserDeleteOne) ExecX(ctx context.Context) {
-	udo.ud.ExecX(ctx)
+	if err := udo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/migrate/entv1/car_delete.go
+++ b/entc/integration/migrate/entv1/car_delete.go
@@ -73,6 +73,12 @@ type CarDeleteOne struct {
 	cd *CarDelete
 }
 
+// Where appends a list predicates to the CarDelete builder.
+func (cdo *CarDeleteOne) Where(ps ...predicate.Car) *CarDeleteOne {
+	cdo.cd.mutation.Where(ps...)
+	return cdo
+}
+
 // Exec executes the deletion query.
 func (cdo *CarDeleteOne) Exec(ctx context.Context) error {
 	n, err := cdo.cd.Exec(ctx)
@@ -88,5 +94,7 @@ func (cdo *CarDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (cdo *CarDeleteOne) ExecX(ctx context.Context) {
-	cdo.cd.ExecX(ctx)
+	if err := cdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/migrate/entv1/conversion_delete.go
+++ b/entc/integration/migrate/entv1/conversion_delete.go
@@ -73,6 +73,12 @@ type ConversionDeleteOne struct {
 	cd *ConversionDelete
 }
 
+// Where appends a list predicates to the ConversionDelete builder.
+func (cdo *ConversionDeleteOne) Where(ps ...predicate.Conversion) *ConversionDeleteOne {
+	cdo.cd.mutation.Where(ps...)
+	return cdo
+}
+
 // Exec executes the deletion query.
 func (cdo *ConversionDeleteOne) Exec(ctx context.Context) error {
 	n, err := cdo.cd.Exec(ctx)
@@ -88,5 +94,7 @@ func (cdo *ConversionDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (cdo *ConversionDeleteOne) ExecX(ctx context.Context) {
-	cdo.cd.ExecX(ctx)
+	if err := cdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/migrate/entv1/customtype_delete.go
+++ b/entc/integration/migrate/entv1/customtype_delete.go
@@ -73,6 +73,12 @@ type CustomTypeDeleteOne struct {
 	ctd *CustomTypeDelete
 }
 
+// Where appends a list predicates to the CustomTypeDelete builder.
+func (ctdo *CustomTypeDeleteOne) Where(ps ...predicate.CustomType) *CustomTypeDeleteOne {
+	ctdo.ctd.mutation.Where(ps...)
+	return ctdo
+}
+
 // Exec executes the deletion query.
 func (ctdo *CustomTypeDeleteOne) Exec(ctx context.Context) error {
 	n, err := ctdo.ctd.Exec(ctx)
@@ -88,5 +94,7 @@ func (ctdo *CustomTypeDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (ctdo *CustomTypeDeleteOne) ExecX(ctx context.Context) {
-	ctdo.ctd.ExecX(ctx)
+	if err := ctdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/migrate/entv1/user_delete.go
+++ b/entc/integration/migrate/entv1/user_delete.go
@@ -73,6 +73,12 @@ type UserDeleteOne struct {
 	ud *UserDelete
 }
 
+// Where appends a list predicates to the UserDelete builder.
+func (udo *UserDeleteOne) Where(ps ...predicate.User) *UserDeleteOne {
+	udo.ud.mutation.Where(ps...)
+	return udo
+}
+
 // Exec executes the deletion query.
 func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 	n, err := udo.ud.Exec(ctx)
@@ -88,5 +94,7 @@ func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (udo *UserDeleteOne) ExecX(ctx context.Context) {
-	udo.ud.ExecX(ctx)
+	if err := udo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/migrate/entv2/blog_delete.go
+++ b/entc/integration/migrate/entv2/blog_delete.go
@@ -73,6 +73,12 @@ type BlogDeleteOne struct {
 	bd *BlogDelete
 }
 
+// Where appends a list predicates to the BlogDelete builder.
+func (bdo *BlogDeleteOne) Where(ps ...predicate.Blog) *BlogDeleteOne {
+	bdo.bd.mutation.Where(ps...)
+	return bdo
+}
+
 // Exec executes the deletion query.
 func (bdo *BlogDeleteOne) Exec(ctx context.Context) error {
 	n, err := bdo.bd.Exec(ctx)
@@ -88,5 +94,7 @@ func (bdo *BlogDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (bdo *BlogDeleteOne) ExecX(ctx context.Context) {
-	bdo.bd.ExecX(ctx)
+	if err := bdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/migrate/entv2/car_delete.go
+++ b/entc/integration/migrate/entv2/car_delete.go
@@ -73,6 +73,12 @@ type CarDeleteOne struct {
 	cd *CarDelete
 }
 
+// Where appends a list predicates to the CarDelete builder.
+func (cdo *CarDeleteOne) Where(ps ...predicate.Car) *CarDeleteOne {
+	cdo.cd.mutation.Where(ps...)
+	return cdo
+}
+
 // Exec executes the deletion query.
 func (cdo *CarDeleteOne) Exec(ctx context.Context) error {
 	n, err := cdo.cd.Exec(ctx)
@@ -88,5 +94,7 @@ func (cdo *CarDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (cdo *CarDeleteOne) ExecX(ctx context.Context) {
-	cdo.cd.ExecX(ctx)
+	if err := cdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/migrate/entv2/conversion_delete.go
+++ b/entc/integration/migrate/entv2/conversion_delete.go
@@ -73,6 +73,12 @@ type ConversionDeleteOne struct {
 	cd *ConversionDelete
 }
 
+// Where appends a list predicates to the ConversionDelete builder.
+func (cdo *ConversionDeleteOne) Where(ps ...predicate.Conversion) *ConversionDeleteOne {
+	cdo.cd.mutation.Where(ps...)
+	return cdo
+}
+
 // Exec executes the deletion query.
 func (cdo *ConversionDeleteOne) Exec(ctx context.Context) error {
 	n, err := cdo.cd.Exec(ctx)
@@ -88,5 +94,7 @@ func (cdo *ConversionDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (cdo *ConversionDeleteOne) ExecX(ctx context.Context) {
-	cdo.cd.ExecX(ctx)
+	if err := cdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/migrate/entv2/customtype_delete.go
+++ b/entc/integration/migrate/entv2/customtype_delete.go
@@ -73,6 +73,12 @@ type CustomTypeDeleteOne struct {
 	ctd *CustomTypeDelete
 }
 
+// Where appends a list predicates to the CustomTypeDelete builder.
+func (ctdo *CustomTypeDeleteOne) Where(ps ...predicate.CustomType) *CustomTypeDeleteOne {
+	ctdo.ctd.mutation.Where(ps...)
+	return ctdo
+}
+
 // Exec executes the deletion query.
 func (ctdo *CustomTypeDeleteOne) Exec(ctx context.Context) error {
 	n, err := ctdo.ctd.Exec(ctx)
@@ -88,5 +94,7 @@ func (ctdo *CustomTypeDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (ctdo *CustomTypeDeleteOne) ExecX(ctx context.Context) {
-	ctdo.ctd.ExecX(ctx)
+	if err := ctdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/migrate/entv2/group_delete.go
+++ b/entc/integration/migrate/entv2/group_delete.go
@@ -73,6 +73,12 @@ type GroupDeleteOne struct {
 	gd *GroupDelete
 }
 
+// Where appends a list predicates to the GroupDelete builder.
+func (gdo *GroupDeleteOne) Where(ps ...predicate.Group) *GroupDeleteOne {
+	gdo.gd.mutation.Where(ps...)
+	return gdo
+}
+
 // Exec executes the deletion query.
 func (gdo *GroupDeleteOne) Exec(ctx context.Context) error {
 	n, err := gdo.gd.Exec(ctx)
@@ -88,5 +94,7 @@ func (gdo *GroupDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (gdo *GroupDeleteOne) ExecX(ctx context.Context) {
-	gdo.gd.ExecX(ctx)
+	if err := gdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/migrate/entv2/media_delete.go
+++ b/entc/integration/migrate/entv2/media_delete.go
@@ -73,6 +73,12 @@ type MediaDeleteOne struct {
 	md *MediaDelete
 }
 
+// Where appends a list predicates to the MediaDelete builder.
+func (mdo *MediaDeleteOne) Where(ps ...predicate.Media) *MediaDeleteOne {
+	mdo.md.mutation.Where(ps...)
+	return mdo
+}
+
 // Exec executes the deletion query.
 func (mdo *MediaDeleteOne) Exec(ctx context.Context) error {
 	n, err := mdo.md.Exec(ctx)
@@ -88,5 +94,7 @@ func (mdo *MediaDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (mdo *MediaDeleteOne) ExecX(ctx context.Context) {
-	mdo.md.ExecX(ctx)
+	if err := mdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/migrate/entv2/pet_delete.go
+++ b/entc/integration/migrate/entv2/pet_delete.go
@@ -73,6 +73,12 @@ type PetDeleteOne struct {
 	pd *PetDelete
 }
 
+// Where appends a list predicates to the PetDelete builder.
+func (pdo *PetDeleteOne) Where(ps ...predicate.Pet) *PetDeleteOne {
+	pdo.pd.mutation.Where(ps...)
+	return pdo
+}
+
 // Exec executes the deletion query.
 func (pdo *PetDeleteOne) Exec(ctx context.Context) error {
 	n, err := pdo.pd.Exec(ctx)
@@ -88,5 +94,7 @@ func (pdo *PetDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (pdo *PetDeleteOne) ExecX(ctx context.Context) {
-	pdo.pd.ExecX(ctx)
+	if err := pdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/migrate/entv2/user_delete.go
+++ b/entc/integration/migrate/entv2/user_delete.go
@@ -73,6 +73,12 @@ type UserDeleteOne struct {
 	ud *UserDelete
 }
 
+// Where appends a list predicates to the UserDelete builder.
+func (udo *UserDeleteOne) Where(ps ...predicate.User) *UserDeleteOne {
+	udo.ud.mutation.Where(ps...)
+	return udo
+}
+
 // Exec executes the deletion query.
 func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 	n, err := udo.ud.Exec(ctx)
@@ -88,5 +94,7 @@ func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (udo *UserDeleteOne) ExecX(ctx context.Context) {
-	udo.ud.ExecX(ctx)
+	if err := udo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/migrate/entv2/zoo_delete.go
+++ b/entc/integration/migrate/entv2/zoo_delete.go
@@ -73,6 +73,12 @@ type ZooDeleteOne struct {
 	zd *ZooDelete
 }
 
+// Where appends a list predicates to the ZooDelete builder.
+func (zdo *ZooDeleteOne) Where(ps ...predicate.Zoo) *ZooDeleteOne {
+	zdo.zd.mutation.Where(ps...)
+	return zdo
+}
+
 // Exec executes the deletion query.
 func (zdo *ZooDeleteOne) Exec(ctx context.Context) error {
 	n, err := zdo.zd.Exec(ctx)
@@ -88,5 +94,7 @@ func (zdo *ZooDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (zdo *ZooDeleteOne) ExecX(ctx context.Context) {
-	zdo.zd.ExecX(ctx)
+	if err := zdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/migrate/versioned/group_delete.go
+++ b/entc/integration/migrate/versioned/group_delete.go
@@ -73,6 +73,12 @@ type GroupDeleteOne struct {
 	gd *GroupDelete
 }
 
+// Where appends a list predicates to the GroupDelete builder.
+func (gdo *GroupDeleteOne) Where(ps ...predicate.Group) *GroupDeleteOne {
+	gdo.gd.mutation.Where(ps...)
+	return gdo
+}
+
 // Exec executes the deletion query.
 func (gdo *GroupDeleteOne) Exec(ctx context.Context) error {
 	n, err := gdo.gd.Exec(ctx)
@@ -88,5 +94,7 @@ func (gdo *GroupDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (gdo *GroupDeleteOne) ExecX(ctx context.Context) {
-	gdo.gd.ExecX(ctx)
+	if err := gdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/migrate/versioned/user_delete.go
+++ b/entc/integration/migrate/versioned/user_delete.go
@@ -73,6 +73,12 @@ type UserDeleteOne struct {
 	ud *UserDelete
 }
 
+// Where appends a list predicates to the UserDelete builder.
+func (udo *UserDeleteOne) Where(ps ...predicate.User) *UserDeleteOne {
+	udo.ud.mutation.Where(ps...)
+	return udo
+}
+
 // Exec executes the deletion query.
 func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 	n, err := udo.ud.Exec(ctx)
@@ -88,5 +94,7 @@ func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (udo *UserDeleteOne) ExecX(ctx context.Context) {
-	udo.ud.ExecX(ctx)
+	if err := udo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/multischema/ent/friendship_delete.go
+++ b/entc/integration/multischema/ent/friendship_delete.go
@@ -76,6 +76,12 @@ type FriendshipDeleteOne struct {
 	fd *FriendshipDelete
 }
 
+// Where appends a list predicates to the FriendshipDelete builder.
+func (fdo *FriendshipDeleteOne) Where(ps ...predicate.Friendship) *FriendshipDeleteOne {
+	fdo.fd.mutation.Where(ps...)
+	return fdo
+}
+
 // Exec executes the deletion query.
 func (fdo *FriendshipDeleteOne) Exec(ctx context.Context) error {
 	n, err := fdo.fd.Exec(ctx)
@@ -91,5 +97,7 @@ func (fdo *FriendshipDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (fdo *FriendshipDeleteOne) ExecX(ctx context.Context) {
-	fdo.fd.ExecX(ctx)
+	if err := fdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/multischema/ent/group_delete.go
+++ b/entc/integration/multischema/ent/group_delete.go
@@ -76,6 +76,12 @@ type GroupDeleteOne struct {
 	gd *GroupDelete
 }
 
+// Where appends a list predicates to the GroupDelete builder.
+func (gdo *GroupDeleteOne) Where(ps ...predicate.Group) *GroupDeleteOne {
+	gdo.gd.mutation.Where(ps...)
+	return gdo
+}
+
 // Exec executes the deletion query.
 func (gdo *GroupDeleteOne) Exec(ctx context.Context) error {
 	n, err := gdo.gd.Exec(ctx)
@@ -91,5 +97,7 @@ func (gdo *GroupDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (gdo *GroupDeleteOne) ExecX(ctx context.Context) {
-	gdo.gd.ExecX(ctx)
+	if err := gdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/multischema/ent/pet_delete.go
+++ b/entc/integration/multischema/ent/pet_delete.go
@@ -76,6 +76,12 @@ type PetDeleteOne struct {
 	pd *PetDelete
 }
 
+// Where appends a list predicates to the PetDelete builder.
+func (pdo *PetDeleteOne) Where(ps ...predicate.Pet) *PetDeleteOne {
+	pdo.pd.mutation.Where(ps...)
+	return pdo
+}
+
 // Exec executes the deletion query.
 func (pdo *PetDeleteOne) Exec(ctx context.Context) error {
 	n, err := pdo.pd.Exec(ctx)
@@ -91,5 +97,7 @@ func (pdo *PetDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (pdo *PetDeleteOne) ExecX(ctx context.Context) {
-	pdo.pd.ExecX(ctx)
+	if err := pdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/multischema/ent/user_delete.go
+++ b/entc/integration/multischema/ent/user_delete.go
@@ -76,6 +76,12 @@ type UserDeleteOne struct {
 	ud *UserDelete
 }
 
+// Where appends a list predicates to the UserDelete builder.
+func (udo *UserDeleteOne) Where(ps ...predicate.User) *UserDeleteOne {
+	udo.ud.mutation.Where(ps...)
+	return udo
+}
+
 // Exec executes the deletion query.
 func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 	n, err := udo.ud.Exec(ctx)
@@ -91,5 +97,7 @@ func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (udo *UserDeleteOne) ExecX(ctx context.Context) {
-	udo.ud.ExecX(ctx)
+	if err := udo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/privacy/ent/task_delete.go
+++ b/entc/integration/privacy/ent/task_delete.go
@@ -73,6 +73,12 @@ type TaskDeleteOne struct {
 	td *TaskDelete
 }
 
+// Where appends a list predicates to the TaskDelete builder.
+func (tdo *TaskDeleteOne) Where(ps ...predicate.Task) *TaskDeleteOne {
+	tdo.td.mutation.Where(ps...)
+	return tdo
+}
+
 // Exec executes the deletion query.
 func (tdo *TaskDeleteOne) Exec(ctx context.Context) error {
 	n, err := tdo.td.Exec(ctx)
@@ -88,5 +94,7 @@ func (tdo *TaskDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (tdo *TaskDeleteOne) ExecX(ctx context.Context) {
-	tdo.td.ExecX(ctx)
+	if err := tdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/privacy/ent/team_delete.go
+++ b/entc/integration/privacy/ent/team_delete.go
@@ -73,6 +73,12 @@ type TeamDeleteOne struct {
 	td *TeamDelete
 }
 
+// Where appends a list predicates to the TeamDelete builder.
+func (tdo *TeamDeleteOne) Where(ps ...predicate.Team) *TeamDeleteOne {
+	tdo.td.mutation.Where(ps...)
+	return tdo
+}
+
 // Exec executes the deletion query.
 func (tdo *TeamDeleteOne) Exec(ctx context.Context) error {
 	n, err := tdo.td.Exec(ctx)
@@ -88,5 +94,7 @@ func (tdo *TeamDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (tdo *TeamDeleteOne) ExecX(ctx context.Context) {
-	tdo.td.ExecX(ctx)
+	if err := tdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/privacy/ent/user_delete.go
+++ b/entc/integration/privacy/ent/user_delete.go
@@ -73,6 +73,12 @@ type UserDeleteOne struct {
 	ud *UserDelete
 }
 
+// Where appends a list predicates to the UserDelete builder.
+func (udo *UserDeleteOne) Where(ps ...predicate.User) *UserDeleteOne {
+	udo.ud.mutation.Where(ps...)
+	return udo
+}
+
 // Exec executes the deletion query.
 func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 	n, err := udo.ud.Exec(ctx)
@@ -88,5 +94,7 @@ func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (udo *UserDeleteOne) ExecX(ctx context.Context) {
-	udo.ud.ExecX(ctx)
+	if err := udo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/template/ent/group_delete.go
+++ b/entc/integration/template/ent/group_delete.go
@@ -73,6 +73,12 @@ type GroupDeleteOne struct {
 	gd *GroupDelete
 }
 
+// Where appends a list predicates to the GroupDelete builder.
+func (gdo *GroupDeleteOne) Where(ps ...predicate.Group) *GroupDeleteOne {
+	gdo.gd.mutation.Where(ps...)
+	return gdo
+}
+
 // Exec executes the deletion query.
 func (gdo *GroupDeleteOne) Exec(ctx context.Context) error {
 	n, err := gdo.gd.Exec(ctx)
@@ -88,5 +94,7 @@ func (gdo *GroupDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (gdo *GroupDeleteOne) ExecX(ctx context.Context) {
-	gdo.gd.ExecX(ctx)
+	if err := gdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/template/ent/pet_delete.go
+++ b/entc/integration/template/ent/pet_delete.go
@@ -73,6 +73,12 @@ type PetDeleteOne struct {
 	pd *PetDelete
 }
 
+// Where appends a list predicates to the PetDelete builder.
+func (pdo *PetDeleteOne) Where(ps ...predicate.Pet) *PetDeleteOne {
+	pdo.pd.mutation.Where(ps...)
+	return pdo
+}
+
 // Exec executes the deletion query.
 func (pdo *PetDeleteOne) Exec(ctx context.Context) error {
 	n, err := pdo.pd.Exec(ctx)
@@ -88,5 +94,7 @@ func (pdo *PetDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (pdo *PetDeleteOne) ExecX(ctx context.Context) {
-	pdo.pd.ExecX(ctx)
+	if err := pdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/entc/integration/template/ent/user_delete.go
+++ b/entc/integration/template/ent/user_delete.go
@@ -73,6 +73,12 @@ type UserDeleteOne struct {
 	ud *UserDelete
 }
 
+// Where appends a list predicates to the UserDelete builder.
+func (udo *UserDeleteOne) Where(ps ...predicate.User) *UserDeleteOne {
+	udo.ud.mutation.Where(ps...)
+	return udo
+}
+
 // Exec executes the deletion query.
 func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 	n, err := udo.ud.Exec(ctx)
@@ -88,5 +94,7 @@ func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (udo *UserDeleteOne) ExecX(ctx context.Context) {
-	udo.ud.ExecX(ctx)
+	if err := udo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/edgeindex/ent/city_delete.go
+++ b/examples/edgeindex/ent/city_delete.go
@@ -73,6 +73,12 @@ type CityDeleteOne struct {
 	cd *CityDelete
 }
 
+// Where appends a list predicates to the CityDelete builder.
+func (cdo *CityDeleteOne) Where(ps ...predicate.City) *CityDeleteOne {
+	cdo.cd.mutation.Where(ps...)
+	return cdo
+}
+
 // Exec executes the deletion query.
 func (cdo *CityDeleteOne) Exec(ctx context.Context) error {
 	n, err := cdo.cd.Exec(ctx)
@@ -88,5 +94,7 @@ func (cdo *CityDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (cdo *CityDeleteOne) ExecX(ctx context.Context) {
-	cdo.cd.ExecX(ctx)
+	if err := cdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/edgeindex/ent/street_delete.go
+++ b/examples/edgeindex/ent/street_delete.go
@@ -73,6 +73,12 @@ type StreetDeleteOne struct {
 	sd *StreetDelete
 }
 
+// Where appends a list predicates to the StreetDelete builder.
+func (sdo *StreetDeleteOne) Where(ps ...predicate.Street) *StreetDeleteOne {
+	sdo.sd.mutation.Where(ps...)
+	return sdo
+}
+
 // Exec executes the deletion query.
 func (sdo *StreetDeleteOne) Exec(ctx context.Context) error {
 	n, err := sdo.sd.Exec(ctx)
@@ -88,5 +94,7 @@ func (sdo *StreetDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (sdo *StreetDeleteOne) ExecX(ctx context.Context) {
-	sdo.sd.ExecX(ctx)
+	if err := sdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/encryptfield/ent/user_delete.go
+++ b/examples/encryptfield/ent/user_delete.go
@@ -73,6 +73,12 @@ type UserDeleteOne struct {
 	ud *UserDelete
 }
 
+// Where appends a list predicates to the UserDelete builder.
+func (udo *UserDeleteOne) Where(ps ...predicate.User) *UserDeleteOne {
+	udo.ud.mutation.Where(ps...)
+	return udo
+}
+
 // Exec executes the deletion query.
 func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 	n, err := udo.ud.Exec(ctx)
@@ -88,5 +94,7 @@ func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (udo *UserDeleteOne) ExecX(ctx context.Context) {
-	udo.ud.ExecX(ctx)
+	if err := udo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/entcpkg/ent/user_delete.go
+++ b/examples/entcpkg/ent/user_delete.go
@@ -73,6 +73,12 @@ type UserDeleteOne struct {
 	ud *UserDelete
 }
 
+// Where appends a list predicates to the UserDelete builder.
+func (udo *UserDeleteOne) Where(ps ...predicate.User) *UserDeleteOne {
+	udo.ud.mutation.Where(ps...)
+	return udo
+}
+
 // Exec executes the deletion query.
 func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 	n, err := udo.ud.Exec(ctx)
@@ -88,5 +94,7 @@ func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (udo *UserDeleteOne) ExecX(ctx context.Context) {
-	udo.ud.ExecX(ctx)
+	if err := udo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/fs/ent/file_delete.go
+++ b/examples/fs/ent/file_delete.go
@@ -73,6 +73,12 @@ type FileDeleteOne struct {
 	fd *FileDelete
 }
 
+// Where appends a list predicates to the FileDelete builder.
+func (fdo *FileDeleteOne) Where(ps ...predicate.File) *FileDeleteOne {
+	fdo.fd.mutation.Where(ps...)
+	return fdo
+}
+
 // Exec executes the deletion query.
 func (fdo *FileDeleteOne) Exec(ctx context.Context) error {
 	n, err := fdo.fd.Exec(ctx)
@@ -88,5 +94,7 @@ func (fdo *FileDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (fdo *FileDeleteOne) ExecX(ctx context.Context) {
-	fdo.fd.ExecX(ctx)
+	if err := fdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/jsonencode/ent/card_delete.go
+++ b/examples/jsonencode/ent/card_delete.go
@@ -73,6 +73,12 @@ type CardDeleteOne struct {
 	cd *CardDelete
 }
 
+// Where appends a list predicates to the CardDelete builder.
+func (cdo *CardDeleteOne) Where(ps ...predicate.Card) *CardDeleteOne {
+	cdo.cd.mutation.Where(ps...)
+	return cdo
+}
+
 // Exec executes the deletion query.
 func (cdo *CardDeleteOne) Exec(ctx context.Context) error {
 	n, err := cdo.cd.Exec(ctx)
@@ -88,5 +94,7 @@ func (cdo *CardDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (cdo *CardDeleteOne) ExecX(ctx context.Context) {
-	cdo.cd.ExecX(ctx)
+	if err := cdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/jsonencode/ent/pet_delete.go
+++ b/examples/jsonencode/ent/pet_delete.go
@@ -73,6 +73,12 @@ type PetDeleteOne struct {
 	pd *PetDelete
 }
 
+// Where appends a list predicates to the PetDelete builder.
+func (pdo *PetDeleteOne) Where(ps ...predicate.Pet) *PetDeleteOne {
+	pdo.pd.mutation.Where(ps...)
+	return pdo
+}
+
 // Exec executes the deletion query.
 func (pdo *PetDeleteOne) Exec(ctx context.Context) error {
 	n, err := pdo.pd.Exec(ctx)
@@ -88,5 +94,7 @@ func (pdo *PetDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (pdo *PetDeleteOne) ExecX(ctx context.Context) {
-	pdo.pd.ExecX(ctx)
+	if err := pdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/jsonencode/ent/user_delete.go
+++ b/examples/jsonencode/ent/user_delete.go
@@ -73,6 +73,12 @@ type UserDeleteOne struct {
 	ud *UserDelete
 }
 
+// Where appends a list predicates to the UserDelete builder.
+func (udo *UserDeleteOne) Where(ps ...predicate.User) *UserDeleteOne {
+	udo.ud.mutation.Where(ps...)
+	return udo
+}
+
 // Exec executes the deletion query.
 func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 	n, err := udo.ud.Exec(ctx)
@@ -88,5 +94,7 @@ func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (udo *UserDeleteOne) ExecX(ctx context.Context) {
-	udo.ud.ExecX(ctx)
+	if err := udo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/m2m2types/ent/group_delete.go
+++ b/examples/m2m2types/ent/group_delete.go
@@ -73,6 +73,12 @@ type GroupDeleteOne struct {
 	gd *GroupDelete
 }
 
+// Where appends a list predicates to the GroupDelete builder.
+func (gdo *GroupDeleteOne) Where(ps ...predicate.Group) *GroupDeleteOne {
+	gdo.gd.mutation.Where(ps...)
+	return gdo
+}
+
 // Exec executes the deletion query.
 func (gdo *GroupDeleteOne) Exec(ctx context.Context) error {
 	n, err := gdo.gd.Exec(ctx)
@@ -88,5 +94,7 @@ func (gdo *GroupDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (gdo *GroupDeleteOne) ExecX(ctx context.Context) {
-	gdo.gd.ExecX(ctx)
+	if err := gdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/m2m2types/ent/user_delete.go
+++ b/examples/m2m2types/ent/user_delete.go
@@ -73,6 +73,12 @@ type UserDeleteOne struct {
 	ud *UserDelete
 }
 
+// Where appends a list predicates to the UserDelete builder.
+func (udo *UserDeleteOne) Where(ps ...predicate.User) *UserDeleteOne {
+	udo.ud.mutation.Where(ps...)
+	return udo
+}
+
 // Exec executes the deletion query.
 func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 	n, err := udo.ud.Exec(ctx)
@@ -88,5 +94,7 @@ func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (udo *UserDeleteOne) ExecX(ctx context.Context) {
-	udo.ud.ExecX(ctx)
+	if err := udo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/m2mbidi/ent/user_delete.go
+++ b/examples/m2mbidi/ent/user_delete.go
@@ -73,6 +73,12 @@ type UserDeleteOne struct {
 	ud *UserDelete
 }
 
+// Where appends a list predicates to the UserDelete builder.
+func (udo *UserDeleteOne) Where(ps ...predicate.User) *UserDeleteOne {
+	udo.ud.mutation.Where(ps...)
+	return udo
+}
+
 // Exec executes the deletion query.
 func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 	n, err := udo.ud.Exec(ctx)
@@ -88,5 +94,7 @@ func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (udo *UserDeleteOne) ExecX(ctx context.Context) {
-	udo.ud.ExecX(ctx)
+	if err := udo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/m2mrecur/ent/user_delete.go
+++ b/examples/m2mrecur/ent/user_delete.go
@@ -73,6 +73,12 @@ type UserDeleteOne struct {
 	ud *UserDelete
 }
 
+// Where appends a list predicates to the UserDelete builder.
+func (udo *UserDeleteOne) Where(ps ...predicate.User) *UserDeleteOne {
+	udo.ud.mutation.Where(ps...)
+	return udo
+}
+
 // Exec executes the deletion query.
 func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 	n, err := udo.ud.Exec(ctx)
@@ -88,5 +94,7 @@ func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (udo *UserDeleteOne) ExecX(ctx context.Context) {
-	udo.ud.ExecX(ctx)
+	if err := udo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/migration/ent/card_delete.go
+++ b/examples/migration/ent/card_delete.go
@@ -73,6 +73,12 @@ type CardDeleteOne struct {
 	cd *CardDelete
 }
 
+// Where appends a list predicates to the CardDelete builder.
+func (cdo *CardDeleteOne) Where(ps ...predicate.Card) *CardDeleteOne {
+	cdo.cd.mutation.Where(ps...)
+	return cdo
+}
+
 // Exec executes the deletion query.
 func (cdo *CardDeleteOne) Exec(ctx context.Context) error {
 	n, err := cdo.cd.Exec(ctx)
@@ -88,5 +94,7 @@ func (cdo *CardDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (cdo *CardDeleteOne) ExecX(ctx context.Context) {
-	cdo.cd.ExecX(ctx)
+	if err := cdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/migration/ent/pet_delete.go
+++ b/examples/migration/ent/pet_delete.go
@@ -73,6 +73,12 @@ type PetDeleteOne struct {
 	pd *PetDelete
 }
 
+// Where appends a list predicates to the PetDelete builder.
+func (pdo *PetDeleteOne) Where(ps ...predicate.Pet) *PetDeleteOne {
+	pdo.pd.mutation.Where(ps...)
+	return pdo
+}
+
 // Exec executes the deletion query.
 func (pdo *PetDeleteOne) Exec(ctx context.Context) error {
 	n, err := pdo.pd.Exec(ctx)
@@ -88,5 +94,7 @@ func (pdo *PetDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (pdo *PetDeleteOne) ExecX(ctx context.Context) {
-	pdo.pd.ExecX(ctx)
+	if err := pdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/migration/ent/user_delete.go
+++ b/examples/migration/ent/user_delete.go
@@ -73,6 +73,12 @@ type UserDeleteOne struct {
 	ud *UserDelete
 }
 
+// Where appends a list predicates to the UserDelete builder.
+func (udo *UserDeleteOne) Where(ps ...predicate.User) *UserDeleteOne {
+	udo.ud.mutation.Where(ps...)
+	return udo
+}
+
 // Exec executes the deletion query.
 func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 	n, err := udo.ud.Exec(ctx)
@@ -88,5 +94,7 @@ func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (udo *UserDeleteOne) ExecX(ctx context.Context) {
-	udo.ud.ExecX(ctx)
+	if err := udo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/o2m2types/ent/pet_delete.go
+++ b/examples/o2m2types/ent/pet_delete.go
@@ -73,6 +73,12 @@ type PetDeleteOne struct {
 	pd *PetDelete
 }
 
+// Where appends a list predicates to the PetDelete builder.
+func (pdo *PetDeleteOne) Where(ps ...predicate.Pet) *PetDeleteOne {
+	pdo.pd.mutation.Where(ps...)
+	return pdo
+}
+
 // Exec executes the deletion query.
 func (pdo *PetDeleteOne) Exec(ctx context.Context) error {
 	n, err := pdo.pd.Exec(ctx)
@@ -88,5 +94,7 @@ func (pdo *PetDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (pdo *PetDeleteOne) ExecX(ctx context.Context) {
-	pdo.pd.ExecX(ctx)
+	if err := pdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/o2m2types/ent/user_delete.go
+++ b/examples/o2m2types/ent/user_delete.go
@@ -73,6 +73,12 @@ type UserDeleteOne struct {
 	ud *UserDelete
 }
 
+// Where appends a list predicates to the UserDelete builder.
+func (udo *UserDeleteOne) Where(ps ...predicate.User) *UserDeleteOne {
+	udo.ud.mutation.Where(ps...)
+	return udo
+}
+
 // Exec executes the deletion query.
 func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 	n, err := udo.ud.Exec(ctx)
@@ -88,5 +94,7 @@ func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (udo *UserDeleteOne) ExecX(ctx context.Context) {
-	udo.ud.ExecX(ctx)
+	if err := udo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/o2mrecur/ent/node_delete.go
+++ b/examples/o2mrecur/ent/node_delete.go
@@ -73,6 +73,12 @@ type NodeDeleteOne struct {
 	nd *NodeDelete
 }
 
+// Where appends a list predicates to the NodeDelete builder.
+func (ndo *NodeDeleteOne) Where(ps ...predicate.Node) *NodeDeleteOne {
+	ndo.nd.mutation.Where(ps...)
+	return ndo
+}
+
 // Exec executes the deletion query.
 func (ndo *NodeDeleteOne) Exec(ctx context.Context) error {
 	n, err := ndo.nd.Exec(ctx)
@@ -88,5 +94,7 @@ func (ndo *NodeDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (ndo *NodeDeleteOne) ExecX(ctx context.Context) {
-	ndo.nd.ExecX(ctx)
+	if err := ndo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/o2o2types/ent/card_delete.go
+++ b/examples/o2o2types/ent/card_delete.go
@@ -73,6 +73,12 @@ type CardDeleteOne struct {
 	cd *CardDelete
 }
 
+// Where appends a list predicates to the CardDelete builder.
+func (cdo *CardDeleteOne) Where(ps ...predicate.Card) *CardDeleteOne {
+	cdo.cd.mutation.Where(ps...)
+	return cdo
+}
+
 // Exec executes the deletion query.
 func (cdo *CardDeleteOne) Exec(ctx context.Context) error {
 	n, err := cdo.cd.Exec(ctx)
@@ -88,5 +94,7 @@ func (cdo *CardDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (cdo *CardDeleteOne) ExecX(ctx context.Context) {
-	cdo.cd.ExecX(ctx)
+	if err := cdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/o2o2types/ent/user_delete.go
+++ b/examples/o2o2types/ent/user_delete.go
@@ -73,6 +73,12 @@ type UserDeleteOne struct {
 	ud *UserDelete
 }
 
+// Where appends a list predicates to the UserDelete builder.
+func (udo *UserDeleteOne) Where(ps ...predicate.User) *UserDeleteOne {
+	udo.ud.mutation.Where(ps...)
+	return udo
+}
+
 // Exec executes the deletion query.
 func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 	n, err := udo.ud.Exec(ctx)
@@ -88,5 +94,7 @@ func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (udo *UserDeleteOne) ExecX(ctx context.Context) {
-	udo.ud.ExecX(ctx)
+	if err := udo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/o2obidi/ent/user_delete.go
+++ b/examples/o2obidi/ent/user_delete.go
@@ -73,6 +73,12 @@ type UserDeleteOne struct {
 	ud *UserDelete
 }
 
+// Where appends a list predicates to the UserDelete builder.
+func (udo *UserDeleteOne) Where(ps ...predicate.User) *UserDeleteOne {
+	udo.ud.mutation.Where(ps...)
+	return udo
+}
+
 // Exec executes the deletion query.
 func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 	n, err := udo.ud.Exec(ctx)
@@ -88,5 +94,7 @@ func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (udo *UserDeleteOne) ExecX(ctx context.Context) {
-	udo.ud.ExecX(ctx)
+	if err := udo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/o2orecur/ent/node_delete.go
+++ b/examples/o2orecur/ent/node_delete.go
@@ -73,6 +73,12 @@ type NodeDeleteOne struct {
 	nd *NodeDelete
 }
 
+// Where appends a list predicates to the NodeDelete builder.
+func (ndo *NodeDeleteOne) Where(ps ...predicate.Node) *NodeDeleteOne {
+	ndo.nd.mutation.Where(ps...)
+	return ndo
+}
+
 // Exec executes the deletion query.
 func (ndo *NodeDeleteOne) Exec(ctx context.Context) error {
 	n, err := ndo.nd.Exec(ctx)
@@ -88,5 +94,7 @@ func (ndo *NodeDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (ndo *NodeDeleteOne) ExecX(ctx context.Context) {
-	ndo.nd.ExecX(ctx)
+	if err := ndo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/privacyadmin/ent/user_delete.go
+++ b/examples/privacyadmin/ent/user_delete.go
@@ -73,6 +73,12 @@ type UserDeleteOne struct {
 	ud *UserDelete
 }
 
+// Where appends a list predicates to the UserDelete builder.
+func (udo *UserDeleteOne) Where(ps ...predicate.User) *UserDeleteOne {
+	udo.ud.mutation.Where(ps...)
+	return udo
+}
+
 // Exec executes the deletion query.
 func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 	n, err := udo.ud.Exec(ctx)
@@ -88,5 +94,7 @@ func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (udo *UserDeleteOne) ExecX(ctx context.Context) {
-	udo.ud.ExecX(ctx)
+	if err := udo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/privacytenant/ent/group_delete.go
+++ b/examples/privacytenant/ent/group_delete.go
@@ -73,6 +73,12 @@ type GroupDeleteOne struct {
 	gd *GroupDelete
 }
 
+// Where appends a list predicates to the GroupDelete builder.
+func (gdo *GroupDeleteOne) Where(ps ...predicate.Group) *GroupDeleteOne {
+	gdo.gd.mutation.Where(ps...)
+	return gdo
+}
+
 // Exec executes the deletion query.
 func (gdo *GroupDeleteOne) Exec(ctx context.Context) error {
 	n, err := gdo.gd.Exec(ctx)
@@ -88,5 +94,7 @@ func (gdo *GroupDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (gdo *GroupDeleteOne) ExecX(ctx context.Context) {
-	gdo.gd.ExecX(ctx)
+	if err := gdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/privacytenant/ent/tenant_delete.go
+++ b/examples/privacytenant/ent/tenant_delete.go
@@ -73,6 +73,12 @@ type TenantDeleteOne struct {
 	td *TenantDelete
 }
 
+// Where appends a list predicates to the TenantDelete builder.
+func (tdo *TenantDeleteOne) Where(ps ...predicate.Tenant) *TenantDeleteOne {
+	tdo.td.mutation.Where(ps...)
+	return tdo
+}
+
 // Exec executes the deletion query.
 func (tdo *TenantDeleteOne) Exec(ctx context.Context) error {
 	n, err := tdo.td.Exec(ctx)
@@ -88,5 +94,7 @@ func (tdo *TenantDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (tdo *TenantDeleteOne) ExecX(ctx context.Context) {
-	tdo.td.ExecX(ctx)
+	if err := tdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/privacytenant/ent/user_delete.go
+++ b/examples/privacytenant/ent/user_delete.go
@@ -73,6 +73,12 @@ type UserDeleteOne struct {
 	ud *UserDelete
 }
 
+// Where appends a list predicates to the UserDelete builder.
+func (udo *UserDeleteOne) Where(ps ...predicate.User) *UserDeleteOne {
+	udo.ud.mutation.Where(ps...)
+	return udo
+}
+
 // Exec executes the deletion query.
 func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 	n, err := udo.ud.Exec(ctx)
@@ -88,5 +94,7 @@ func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (udo *UserDeleteOne) ExecX(ctx context.Context) {
-	udo.ud.ExecX(ctx)
+	if err := udo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/privacytenant/example_test.go
+++ b/examples/privacytenant/example_test.go
@@ -115,8 +115,11 @@ func Example_TenantView() {
 		client.User.Query().CountX(labView), // 0
 	)
 
-	// DeleteOne with wrong viewer-context is nop.
-	client.User.DeleteOne(hubUsers[0]).ExecX(labView)
+	// DeleteOne with wrong viewer-context should cause the operation to fail with NotFoundError.
+	err := client.User.DeleteOne(hubUsers[0]).Exec(labView)
+	if !ent.IsNotFound(err) {
+		log.Fatal("expect user deletion to fail, but got:", err)
+	}
 	fmt.Println(client.User.Query().CountX(hubView)) // 2
 
 	// Unlike queries, admin users are not allowed to mutate tenant specific data.

--- a/examples/start/ent/car_delete.go
+++ b/examples/start/ent/car_delete.go
@@ -73,6 +73,12 @@ type CarDeleteOne struct {
 	cd *CarDelete
 }
 
+// Where appends a list predicates to the CarDelete builder.
+func (cdo *CarDeleteOne) Where(ps ...predicate.Car) *CarDeleteOne {
+	cdo.cd.mutation.Where(ps...)
+	return cdo
+}
+
 // Exec executes the deletion query.
 func (cdo *CarDeleteOne) Exec(ctx context.Context) error {
 	n, err := cdo.cd.Exec(ctx)
@@ -88,5 +94,7 @@ func (cdo *CarDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (cdo *CarDeleteOne) ExecX(ctx context.Context) {
-	cdo.cd.ExecX(ctx)
+	if err := cdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/start/ent/group_delete.go
+++ b/examples/start/ent/group_delete.go
@@ -73,6 +73,12 @@ type GroupDeleteOne struct {
 	gd *GroupDelete
 }
 
+// Where appends a list predicates to the GroupDelete builder.
+func (gdo *GroupDeleteOne) Where(ps ...predicate.Group) *GroupDeleteOne {
+	gdo.gd.mutation.Where(ps...)
+	return gdo
+}
+
 // Exec executes the deletion query.
 func (gdo *GroupDeleteOne) Exec(ctx context.Context) error {
 	n, err := gdo.gd.Exec(ctx)
@@ -88,5 +94,7 @@ func (gdo *GroupDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (gdo *GroupDeleteOne) ExecX(ctx context.Context) {
-	gdo.gd.ExecX(ctx)
+	if err := gdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/start/ent/user_delete.go
+++ b/examples/start/ent/user_delete.go
@@ -73,6 +73,12 @@ type UserDeleteOne struct {
 	ud *UserDelete
 }
 
+// Where appends a list predicates to the UserDelete builder.
+func (udo *UserDeleteOne) Where(ps ...predicate.User) *UserDeleteOne {
+	udo.ud.mutation.Where(ps...)
+	return udo
+}
+
 // Exec executes the deletion query.
 func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 	n, err := udo.ud.Exec(ctx)
@@ -88,5 +94,7 @@ func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (udo *UserDeleteOne) ExecX(ctx context.Context) {
-	udo.ud.ExecX(ctx)
+	if err := udo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/traversal/ent/group_delete.go
+++ b/examples/traversal/ent/group_delete.go
@@ -73,6 +73,12 @@ type GroupDeleteOne struct {
 	gd *GroupDelete
 }
 
+// Where appends a list predicates to the GroupDelete builder.
+func (gdo *GroupDeleteOne) Where(ps ...predicate.Group) *GroupDeleteOne {
+	gdo.gd.mutation.Where(ps...)
+	return gdo
+}
+
 // Exec executes the deletion query.
 func (gdo *GroupDeleteOne) Exec(ctx context.Context) error {
 	n, err := gdo.gd.Exec(ctx)
@@ -88,5 +94,7 @@ func (gdo *GroupDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (gdo *GroupDeleteOne) ExecX(ctx context.Context) {
-	gdo.gd.ExecX(ctx)
+	if err := gdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/traversal/ent/pet_delete.go
+++ b/examples/traversal/ent/pet_delete.go
@@ -73,6 +73,12 @@ type PetDeleteOne struct {
 	pd *PetDelete
 }
 
+// Where appends a list predicates to the PetDelete builder.
+func (pdo *PetDeleteOne) Where(ps ...predicate.Pet) *PetDeleteOne {
+	pdo.pd.mutation.Where(ps...)
+	return pdo
+}
+
 // Exec executes the deletion query.
 func (pdo *PetDeleteOne) Exec(ctx context.Context) error {
 	n, err := pdo.pd.Exec(ctx)
@@ -88,5 +94,7 @@ func (pdo *PetDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (pdo *PetDeleteOne) ExecX(ctx context.Context) {
-	pdo.pd.ExecX(ctx)
+	if err := pdo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/traversal/ent/user_delete.go
+++ b/examples/traversal/ent/user_delete.go
@@ -73,6 +73,12 @@ type UserDeleteOne struct {
 	ud *UserDelete
 }
 
+// Where appends a list predicates to the UserDelete builder.
+func (udo *UserDeleteOne) Where(ps ...predicate.User) *UserDeleteOne {
+	udo.ud.mutation.Where(ps...)
+	return udo
+}
+
 // Exec executes the deletion query.
 func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 	n, err := udo.ud.Exec(ctx)
@@ -88,5 +94,7 @@ func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (udo *UserDeleteOne) ExecX(ctx context.Context) {
-	udo.ud.ExecX(ctx)
+	if err := udo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }

--- a/examples/version/ent/user_delete.go
+++ b/examples/version/ent/user_delete.go
@@ -73,6 +73,12 @@ type UserDeleteOne struct {
 	ud *UserDelete
 }
 
+// Where appends a list predicates to the UserDelete builder.
+func (udo *UserDeleteOne) Where(ps ...predicate.User) *UserDeleteOne {
+	udo.ud.mutation.Where(ps...)
+	return udo
+}
+
 // Exec executes the deletion query.
 func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 	n, err := udo.ud.Exec(ctx)
@@ -88,5 +94,7 @@ func (udo *UserDeleteOne) Exec(ctx context.Context) error {
 
 // ExecX is like Exec, but panics if an error occurs.
 func (udo *UserDeleteOne) ExecX(ctx context.Context) {
-	udo.ud.ExecX(ctx)
+	if err := udo.Exec(ctx); err != nil {
+		panic(err)
+	}
 }


### PR DESCRIPTION
Also, fixed a bug in DeleteOne.Exec where it was skipping NotFoundError