### PR TITLE
dialect/sql: improve support for subqueries

### DIFF
--- a/dialect/sql/builder.go
+++ b/dialect/sql/builder.go
@@ -2367,7 +2367,25 @@ func (s *Selector) Table() *SelectTable {
 	if len(s.from) == 0 {
 		return nil
 	}
-	return s.from[0].(*SelectTable)
+	return selectTable(s.from[0])
+}
+
+// selectTable returns a *SelectTable from the given TableView.
+func selectTable(tb TableView) *SelectTable {
+	if tb == nil {
+		return nil
+	}
+	switch view := tb.(type) {
+	case *SelectTable:
+		return view
+	case *Selector:
+		if len(view.from) == 0 {
+			return nil
+		}
+		return selectTable(view.from[0])
+	default:
+		panic(fmt.Sprintf("unhandled TableView type %T", tb))
+	}
 }
 
 // TableName returns the name of the selected table or alias of selector.


### PR DESCRIPTION
This PR improves the way we handle returning the `Table` for the `Selector`.

---

When handling complex queries, `Table()` will be called with a `*Selector`, causing a panic, this PR tries to solve this problem by checking the type and doing a recursive search for the first `SelectTable` found.

I'm not sure about the part were we use the first element, not sure if this is the correct behavior, but the test pass and things works.

We can improve code from:
```go
err = client.Debug().User.Query().Modify(func(s *sql.Selector) {
	f := sql.P()
	f.WriteString("calculate_score")
	f.Wrap(func(b *sql.Builder) {
		b.WriteString(s.C(user.FieldName)).Comma().WriteString("'" + searchString + "'") // <--- We improve this part
	})
	u := sql.Table(user.Table)
	subquery := sql.Select("*").AppendSelectExprAs(sql.Raw(f.String()), "score").From(u).As("user_with_score")
	s.Select("*").From(subquery)
	s.Where(sql.GT(subquery.C("score"), val))
	s.OrderBy(sql.Asc(subquery.C("score")))
}).Scan(ctx, &result)
```
To:
```go
err = client.Debug().User.Query().Modify(func(s *sql.Selector) {
	f := sql.P(func(b *sql.Builder) {
		b.SetDialect(s.Dialect())
		b.WriteString("calculate_score")
		b.Wrap(func(bb *sql.Builder) {
			bb.WriteString(s.Table().C(user.FieldName)).Comma().Args(searchString)
		})
	})
	u := sql.Table(user.Table)
	subquery := sql.Select("*").AppendSelectExprAs(f, "score").From(u).As("user_with_score")
	s.Select("*").From(subquery)
	s.Where(sql.GT(subquery.C("score"), val))
	s.OrderBy(sql.Asc(subquery.C("score")))
}).Scan(ctx, &result)
```

See https://github.com/ent/ent/issues/3261#issuecomment-1404058116 for more context.