### PR TITLE
entc/gen: improve support for JSON types

### DIFF
--- a/entc/gen/template/dialect/sql/decode.tmpl
+++ b/entc/gen/template/dialect/sql/decode.tmpl
@@ -100,16 +100,22 @@ func ({{ $receiver }} *{{ $.Name }}) assignValues(columns []string, values []any
 	{{- $f := $.Scope.Field -}}
 	{{- $ret := $.Scope.Rec -}}
 	{{- $field := $f.StructField }}{{ with $.Scope.StructField }}{{ $field = . }}{{ end -}}
+	{{- $scantype := $f.ScanType -}}
 	{{- if $f.IsJSON -}}
-		if value, ok := values[{{ $i }}].(*{{ $f.ScanType }}); !ok {
+		if value, ok := values[{{ $i }}].(*{{ $scantype }}); !ok {
 			return fmt.Errorf("unexpected type %T for field {{ $f.Name }}", values[{{ $i }}])
+		{{- if hasPrefix $scantype "[]" }}
 		} else if value != nil && len(*value) > 0 {
 			if err := json.Unmarshal(*value, &{{ $ret }}.{{ $field }}); err != nil {
 				return fmt.Errorf("unmarshal field {{ $f.Name }}: %w", err)
 			}
 		}
-	{{- else }}
-		{{- $scantype := $f.ScanType -}}
+		{{- else }}
+		} else if value != nil {
+			{{ $ret }}.{{ $field }} = {{ if (not $f.Type.RType.IsPtr) }}*{{end}}value
+		}
+		{{- end }}
+	{{- else -}}
 		if value, ok := values[{{ $i }}].(*{{ $scantype }}); !ok {
 			return fmt.Errorf("unexpected type %T for field {{ $f.Name }}", values[{{ $i }}])
 		{{- if hasPrefix $scantype "sql.Null" }}

--- a/entc/integration/json/ent/migrate/schema.go
+++ b/entc/integration/json/ent/migrate/schema.go
@@ -16,6 +16,8 @@ var (
 	UsersColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "t", Type: field.TypeJSON, Nullable: true},
+		{Name: "my_json", Type: field.TypeJSON, Nullable: true},
+		{Name: "my_json_ptr", Type: field.TypeJSON, Nullable: true},
 		{Name: "url", Type: field.TypeJSON, Nullable: true},
 		{Name: "urls", Type: field.TypeJSON, Nullable: true},
 		{Name: "raw", Type: field.TypeJSON, Nullable: true},

--- a/entc/integration/json/ent/mutation.go
+++ b/entc/integration/json/ent/mutation.go
@@ -42,6 +42,8 @@ type UserMutation struct {
 	typ           string
 	id            *int
 	t             **schema.T
+	my_json       *schema.MyJSON
+	my_json_ptr   **schema.MyJSON
 	url           **url.URL
 	_URLs         *[]*url.URL
 	append_URLs   []*url.URL
@@ -207,6 +209,104 @@ func (m *UserMutation) TCleared() bool {
 func (m *UserMutation) ResetT() {
 	m.t = nil
 	delete(m.clearedFields, user.FieldT)
+}
+
+// SetMyJSON sets the "my_json" field.
+func (m *UserMutation) SetMyJSON(sj schema.MyJSON) {
+	m.my_json = &sj
+}
+
+// MyJSON returns the value of the "my_json" field in the mutation.
+func (m *UserMutation) MyJSON() (r schema.MyJSON, exists bool) {
+	v := m.my_json
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldMyJSON returns the old "my_json" field's value of the User entity.
+// If the User object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *UserMutation) OldMyJSON(ctx context.Context) (v schema.MyJSON, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldMyJSON is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldMyJSON requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldMyJSON: %w", err)
+	}
+	return oldValue.MyJSON, nil
+}
+
+// ClearMyJSON clears the value of the "my_json" field.
+func (m *UserMutation) ClearMyJSON() {
+	m.my_json = nil
+	m.clearedFields[user.FieldMyJSON] = struct{}{}
+}
+
+// MyJSONCleared returns if the "my_json" field was cleared in this mutation.
+func (m *UserMutation) MyJSONCleared() bool {
+	_, ok := m.clearedFields[user.FieldMyJSON]
+	return ok
+}
+
+// ResetMyJSON resets all changes to the "my_json" field.
+func (m *UserMutation) ResetMyJSON() {
+	m.my_json = nil
+	delete(m.clearedFields, user.FieldMyJSON)
+}
+
+// SetMyJSONPtr sets the "my_json_ptr" field.
+func (m *UserMutation) SetMyJSONPtr(sj *schema.MyJSON) {
+	m.my_json_ptr = &sj
+}
+
+// MyJSONPtr returns the value of the "my_json_ptr" field in the mutation.
+func (m *UserMutation) MyJSONPtr() (r *schema.MyJSON, exists bool) {
+	v := m.my_json_ptr
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldMyJSONPtr returns the old "my_json_ptr" field's value of the User entity.
+// If the User object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *UserMutation) OldMyJSONPtr(ctx context.Context) (v *schema.MyJSON, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldMyJSONPtr is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldMyJSONPtr requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldMyJSONPtr: %w", err)
+	}
+	return oldValue.MyJSONPtr, nil
+}
+
+// ClearMyJSONPtr clears the value of the "my_json_ptr" field.
+func (m *UserMutation) ClearMyJSONPtr() {
+	m.my_json_ptr = nil
+	m.clearedFields[user.FieldMyJSONPtr] = struct{}{}
+}
+
+// MyJSONPtrCleared returns if the "my_json_ptr" field was cleared in this mutation.
+func (m *UserMutation) MyJSONPtrCleared() bool {
+	_, ok := m.clearedFields[user.FieldMyJSONPtr]
+	return ok
+}
+
+// ResetMyJSONPtr resets all changes to the "my_json_ptr" field.
+func (m *UserMutation) ResetMyJSONPtr() {
+	m.my_json_ptr = nil
+	delete(m.clearedFields, user.FieldMyJSONPtr)
 }
 
 // SetURL sets the "url" field.
@@ -717,9 +817,15 @@ func (m *UserMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *UserMutation) Fields() []string {
-	fields := make([]string, 0, 9)
+	fields := make([]string, 0, 11)
 	if m.t != nil {
 		fields = append(fields, user.FieldT)
+	}
+	if m.my_json != nil {
+		fields = append(fields, user.FieldMyJSON)
+	}
+	if m.my_json_ptr != nil {
+		fields = append(fields, user.FieldMyJSONPtr)
 	}
 	if m.url != nil {
 		fields = append(fields, user.FieldURL)
@@ -755,6 +861,10 @@ func (m *UserMutation) Field(name string) (ent.Value, bool) {
 	switch name {
 	case user.FieldT:
 		return m.T()
+	case user.FieldMyJSON:
+		return m.MyJSON()
+	case user.FieldMyJSONPtr:
+		return m.MyJSONPtr()
 	case user.FieldURL:
 		return m.URL()
 	case user.FieldURLs:
@@ -782,6 +892,10 @@ func (m *UserMutation) OldField(ctx context.Context, name string) (ent.Value, er
 	switch name {
 	case user.FieldT:
 		return m.OldT(ctx)
+	case user.FieldMyJSON:
+		return m.OldMyJSON(ctx)
+	case user.FieldMyJSONPtr:
+		return m.OldMyJSONPtr(ctx)
 	case user.FieldURL:
 		return m.OldURL(ctx)
 	case user.FieldURLs:
@@ -813,6 +927,20 @@ func (m *UserMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetT(v)
+		return nil
+	case user.FieldMyJSON:
+		v, ok := value.(schema.MyJSON)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetMyJSON(v)
+		return nil
+	case user.FieldMyJSONPtr:
+		v, ok := value.(*schema.MyJSON)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetMyJSONPtr(v)
 		return nil
 	case user.FieldURL:
 		v, ok := value.(*url.URL)
@@ -903,6 +1031,12 @@ func (m *UserMutation) ClearedFields() []string {
 	if m.FieldCleared(user.FieldT) {
 		fields = append(fields, user.FieldT)
 	}
+	if m.FieldCleared(user.FieldMyJSON) {
+		fields = append(fields, user.FieldMyJSON)
+	}
+	if m.FieldCleared(user.FieldMyJSONPtr) {
+		fields = append(fields, user.FieldMyJSONPtr)
+	}
 	if m.FieldCleared(user.FieldURL) {
 		fields = append(fields, user.FieldURL)
 	}
@@ -941,6 +1075,12 @@ func (m *UserMutation) ClearField(name string) error {
 	case user.FieldT:
 		m.ClearT()
 		return nil
+	case user.FieldMyJSON:
+		m.ClearMyJSON()
+		return nil
+	case user.FieldMyJSONPtr:
+		m.ClearMyJSONPtr()
+		return nil
 	case user.FieldURL:
 		m.ClearURL()
 		return nil
@@ -972,6 +1112,12 @@ func (m *UserMutation) ResetField(name string) error {
 	switch name {
 	case user.FieldT:
 		m.ResetT()
+		return nil
+	case user.FieldMyJSON:
+		m.ResetMyJSON()
+		return nil
+	case user.FieldMyJSONPtr:
+		m.ResetMyJSONPtr()
 		return nil
 	case user.FieldURL:
 		m.ResetURL()

--- a/entc/integration/json/ent/runtime.go
+++ b/entc/integration/json/ent/runtime.go
@@ -20,11 +20,11 @@ func init() {
 	userFields := schema.User{}.Fields()
 	_ = userFields
 	// userDescDirs is the schema descriptor for dirs field.
-	userDescDirs := userFields[4].Descriptor()
+	userDescDirs := userFields[6].Descriptor()
 	// user.DefaultDirs holds the default value on creation for the dirs field.
 	user.DefaultDirs = userDescDirs.Default.(func() []http.Dir)
 	// userDescInts is the schema descriptor for ints field.
-	userDescInts := userFields[5].Descriptor()
+	userDescInts := userFields[7].Descriptor()
 	// user.DefaultInts holds the default value on creation for the ints field.
 	user.DefaultInts = userDescInts.Default.([]int)
 }

--- a/entc/integration/json/ent/user.go
+++ b/entc/integration/json/ent/user.go
@@ -25,6 +25,10 @@ type User struct {
 	ID int `json:"id,omitempty"`
 	// T holds the value of the "t" field.
 	T *schema.T `json:"t,omitempty"`
+	// MyJSON holds the value of the "my_json" field.
+	MyJSON schema.MyJSON `json:"my_json,omitempty"`
+	// MyJSONPtr holds the value of the "my_json_ptr" field.
+	MyJSONPtr *schema.MyJSON `json:"my_json_ptr,omitempty"`
 	// URL holds the value of the "url" field.
 	URL *url.URL `json:"url,omitempty"`
 	// URLs holds the value of the "URLs" field.
@@ -50,6 +54,8 @@ func (*User) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case user.FieldT, user.FieldURL, user.FieldURLs, user.FieldRaw, user.FieldDirs, user.FieldInts, user.FieldFloats, user.FieldStrings, user.FieldAddr:
 			values[i] = new([]byte)
+		case user.FieldMyJSON, user.FieldMyJSONPtr:
+			values[i] = new(schema.MyJSON)
 		case user.FieldID:
 			values[i] = new(sql.NullInt64)
 		default:
@@ -80,6 +86,18 @@ func (u *User) assignValues(columns []string, values []any) error {
 				if err := json.Unmarshal(*value, &u.T); err != nil {
 					return fmt.Errorf("unmarshal field t: %w", err)
 				}
+			}
+		case user.FieldMyJSON:
+			if value, ok := values[i].(*schema.MyJSON); !ok {
+				return fmt.Errorf("unexpected type %T for field my_json", values[i])
+			} else if value != nil {
+				u.MyJSON = *value
+			}
+		case user.FieldMyJSONPtr:
+			if value, ok := values[i].(*schema.MyJSON); !ok {
+				return fmt.Errorf("unexpected type %T for field my_json_ptr", values[i])
+			} else if value != nil {
+				u.MyJSONPtr = value
 			}
 		case user.FieldURL:
 			if value, ok := values[i].(*[]byte); !ok {
@@ -175,6 +193,12 @@ func (u *User) String() string {
 	builder.WriteString(fmt.Sprintf("id=%v, ", u.ID))
 	builder.WriteString("t=")
 	builder.WriteString(fmt.Sprintf("%v", u.T))
+	builder.WriteString(", ")
+	builder.WriteString("my_json=")
+	builder.WriteString(fmt.Sprintf("%v", u.MyJSON))
+	builder.WriteString(", ")
+	builder.WriteString("my_json_ptr=")
+	builder.WriteString(fmt.Sprintf("%v", u.MyJSONPtr))
 	builder.WriteString(", ")
 	builder.WriteString("url=")
 	builder.WriteString(fmt.Sprintf("%v", u.URL))

--- a/entc/integration/json/ent/user/user.go
+++ b/entc/integration/json/ent/user/user.go
@@ -17,6 +17,10 @@ const (
 	FieldID = "id"
 	// FieldT holds the string denoting the t field in the database.
 	FieldT = "t"
+	// FieldMyJSON holds the string denoting the my_json field in the database.
+	FieldMyJSON = "my_json"
+	// FieldMyJSONPtr holds the string denoting the my_json_ptr field in the database.
+	FieldMyJSONPtr = "my_json_ptr"
 	// FieldURL holds the string denoting the url field in the database.
 	FieldURL = "url"
 	// FieldURLs holds the string denoting the urls field in the database.
@@ -41,6 +45,8 @@ const (
 var Columns = []string{
 	FieldID,
 	FieldT,
+	FieldMyJSON,
+	FieldMyJSONPtr,
 	FieldURL,
 	FieldURLs,
 	FieldRaw,

--- a/entc/integration/json/ent/user/where.go
+++ b/entc/integration/json/ent/user/where.go
@@ -66,6 +66,26 @@ func TNotNil() predicate.User {
 	return predicate.User(sql.FieldNotNull(FieldT))
 }
 
+// MyJSONIsNil applies the IsNil predicate on the "my_json" field.
+func MyJSONIsNil() predicate.User {
+	return predicate.User(sql.FieldIsNull(FieldMyJSON))
+}
+
+// MyJSONNotNil applies the NotNil predicate on the "my_json" field.
+func MyJSONNotNil() predicate.User {
+	return predicate.User(sql.FieldNotNull(FieldMyJSON))
+}
+
+// MyJSONPtrIsNil applies the IsNil predicate on the "my_json_ptr" field.
+func MyJSONPtrIsNil() predicate.User {
+	return predicate.User(sql.FieldIsNull(FieldMyJSONPtr))
+}
+
+// MyJSONPtrNotNil applies the NotNil predicate on the "my_json_ptr" field.
+func MyJSONPtrNotNil() predicate.User {
+	return predicate.User(sql.FieldNotNull(FieldMyJSONPtr))
+}
+
 // URLIsNil applies the IsNil predicate on the "url" field.
 func URLIsNil() predicate.User {
 	return predicate.User(sql.FieldIsNull(FieldURL))

--- a/entc/integration/json/ent/user_create.go
+++ b/entc/integration/json/ent/user_create.go
@@ -33,6 +33,26 @@ func (uc *UserCreate) SetT(s *schema.T) *UserCreate {
 	return uc
 }
 
+// SetMyJSON sets the "my_json" field.
+func (uc *UserCreate) SetMyJSON(sj schema.MyJSON) *UserCreate {
+	uc.mutation.SetMyJSON(sj)
+	return uc
+}
+
+// SetNillableMyJSON sets the "my_json" field if the given value is not nil.
+func (uc *UserCreate) SetNillableMyJSON(sj *schema.MyJSON) *UserCreate {
+	if sj != nil {
+		uc.SetMyJSON(*sj)
+	}
+	return uc
+}
+
+// SetMyJSONPtr sets the "my_json_ptr" field.
+func (uc *UserCreate) SetMyJSONPtr(sj *schema.MyJSON) *UserCreate {
+	uc.mutation.SetMyJSONPtr(sj)
+	return uc
+}
+
 // SetURL sets the "url" field.
 func (uc *UserCreate) SetURL(u *url.URL) *UserCreate {
 	uc.mutation.SetURL(u)
@@ -174,6 +194,14 @@ func (uc *UserCreate) createSpec() (*User, *sqlgraph.CreateSpec) {
 	if value, ok := uc.mutation.T(); ok {
 		_spec.SetField(user.FieldT, field.TypeJSON, value)
 		_node.T = value
+	}
+	if value, ok := uc.mutation.MyJSON(); ok {
+		_spec.SetField(user.FieldMyJSON, field.TypeJSON, value)
+		_node.MyJSON = value
+	}
+	if value, ok := uc.mutation.MyJSONPtr(); ok {
+		_spec.SetField(user.FieldMyJSONPtr, field.TypeJSON, value)
+		_node.MyJSONPtr = value
 	}
 	if value, ok := uc.mutation.URL(); ok {
 		_spec.SetField(user.FieldURL, field.TypeJSON, value)

--- a/entc/integration/json/ent/user_update.go
+++ b/entc/integration/json/ent/user_update.go
@@ -49,6 +49,38 @@ func (uu *UserUpdate) ClearT() *UserUpdate {
 	return uu
 }
 
+// SetMyJSON sets the "my_json" field.
+func (uu *UserUpdate) SetMyJSON(sj schema.MyJSON) *UserUpdate {
+	uu.mutation.SetMyJSON(sj)
+	return uu
+}
+
+// SetNillableMyJSON sets the "my_json" field if the given value is not nil.
+func (uu *UserUpdate) SetNillableMyJSON(sj *schema.MyJSON) *UserUpdate {
+	if sj != nil {
+		uu.SetMyJSON(*sj)
+	}
+	return uu
+}
+
+// ClearMyJSON clears the value of the "my_json" field.
+func (uu *UserUpdate) ClearMyJSON() *UserUpdate {
+	uu.mutation.ClearMyJSON()
+	return uu
+}
+
+// SetMyJSONPtr sets the "my_json_ptr" field.
+func (uu *UserUpdate) SetMyJSONPtr(sj *schema.MyJSON) *UserUpdate {
+	uu.mutation.SetMyJSONPtr(sj)
+	return uu
+}
+
+// ClearMyJSONPtr clears the value of the "my_json_ptr" field.
+func (uu *UserUpdate) ClearMyJSONPtr() *UserUpdate {
+	uu.mutation.ClearMyJSONPtr()
+	return uu
+}
+
 // SetURL sets the "url" field.
 func (uu *UserUpdate) SetURL(u *url.URL) *UserUpdate {
 	uu.mutation.SetURL(u)
@@ -245,6 +277,18 @@ func (uu *UserUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	if uu.mutation.TCleared() {
 		_spec.ClearField(user.FieldT, field.TypeJSON)
 	}
+	if value, ok := uu.mutation.MyJSON(); ok {
+		_spec.SetField(user.FieldMyJSON, field.TypeJSON, value)
+	}
+	if uu.mutation.MyJSONCleared() {
+		_spec.ClearField(user.FieldMyJSON, field.TypeJSON)
+	}
+	if value, ok := uu.mutation.MyJSONPtr(); ok {
+		_spec.SetField(user.FieldMyJSONPtr, field.TypeJSON, value)
+	}
+	if uu.mutation.MyJSONPtrCleared() {
+		_spec.ClearField(user.FieldMyJSONPtr, field.TypeJSON)
+	}
 	if value, ok := uu.mutation.URL(); ok {
 		_spec.SetField(user.FieldURL, field.TypeJSON, value)
 	}
@@ -351,6 +395,38 @@ func (uuo *UserUpdateOne) SetT(s *schema.T) *UserUpdateOne {
 // ClearT clears the value of the "t" field.
 func (uuo *UserUpdateOne) ClearT() *UserUpdateOne {
 	uuo.mutation.ClearT()
+	return uuo
+}
+
+// SetMyJSON sets the "my_json" field.
+func (uuo *UserUpdateOne) SetMyJSON(sj schema.MyJSON) *UserUpdateOne {
+	uuo.mutation.SetMyJSON(sj)
+	return uuo
+}
+
+// SetNillableMyJSON sets the "my_json" field if the given value is not nil.
+func (uuo *UserUpdateOne) SetNillableMyJSON(sj *schema.MyJSON) *UserUpdateOne {
+	if sj != nil {
+		uuo.SetMyJSON(*sj)
+	}
+	return uuo
+}
+
+// ClearMyJSON clears the value of the "my_json" field.
+func (uuo *UserUpdateOne) ClearMyJSON() *UserUpdateOne {
+	uuo.mutation.ClearMyJSON()
+	return uuo
+}
+
+// SetMyJSONPtr sets the "my_json_ptr" field.
+func (uuo *UserUpdateOne) SetMyJSONPtr(sj *schema.MyJSON) *UserUpdateOne {
+	uuo.mutation.SetMyJSONPtr(sj)
+	return uuo
+}
+
+// ClearMyJSONPtr clears the value of the "my_json_ptr" field.
+func (uuo *UserUpdateOne) ClearMyJSONPtr() *UserUpdateOne {
+	uuo.mutation.ClearMyJSONPtr()
 	return uuo
 }
 
@@ -573,6 +649,18 @@ func (uuo *UserUpdateOne) sqlSave(ctx context.Context) (_node *User, err error) 
 	}
 	if uuo.mutation.TCleared() {
 		_spec.ClearField(user.FieldT, field.TypeJSON)
+	}
+	if value, ok := uuo.mutation.MyJSON(); ok {
+		_spec.SetField(user.FieldMyJSON, field.TypeJSON, value)
+	}
+	if uuo.mutation.MyJSONCleared() {
+		_spec.ClearField(user.FieldMyJSON, field.TypeJSON)
+	}
+	if value, ok := uuo.mutation.MyJSONPtr(); ok {
+		_spec.SetField(user.FieldMyJSONPtr, field.TypeJSON, value)
+	}
+	if uuo.mutation.MyJSONPtrCleared() {
+		_spec.ClearField(user.FieldMyJSONPtr, field.TypeJSON)
 	}
 	if value, ok := uuo.mutation.URL(); ok {
 		_spec.SetField(user.FieldURL, field.TypeJSON, value)

--- a/entc/integration/json/json_test.go
+++ b/entc/integration/json/json_test.go
@@ -56,6 +56,7 @@ func TestMySQL(t *testing.T) {
 				Predicates(t, client)
 			}
 			Scan(t, client)
+			MyJSON(t, client)
 		})
 	}
 }
@@ -88,6 +89,7 @@ func TestMaria(t *testing.T) {
 			RawMessage(t, client)
 			Predicates(t, client)
 			Scan(t, client)
+			MyJSON(t, client)
 		})
 	}
 }
@@ -120,6 +122,7 @@ func TestPostgres(t *testing.T) {
 			RawMessage(t, client)
 			Predicates(t, client)
 			Scan(t, client)
+			MyJSON(t, client)
 		})
 	}
 }
@@ -141,6 +144,7 @@ func TestSQLite(t *testing.T) {
 	RawMessage(t, client)
 	Predicates(t, client)
 	Scan(t, client)
+	MyJSON(t, client)
 }
 
 func Ints(t *testing.T, client *ent.Client) {
@@ -323,6 +327,19 @@ func URLs(t *testing.T, client *ent.Client) {
 	require.Len(t, usr.URLs, 2)
 	require.Equal(t, u1, usr.URLs[0])
 	require.Equal(t, u2, usr.URLs[1])
+}
+
+func MyJSON(t *testing.T, client *ent.Client) {
+	ctx := context.Background()
+	myJSON := schema.MyJSON{Field: "test"}
+	mjs := client.User.Create().SetMyJSON(myJSON).SaveX(ctx)
+	require.Equal(t, myJSON, mjs.MyJSON)
+	require.Equal(t, myJSON, client.User.GetX(ctx, mjs.ID).MyJSON)
+
+	myJSONPtr := &schema.MyJSON{Field: "test"}
+	mjsptr := client.User.Create().SetMyJSONPtr(myJSONPtr).SaveX(ctx)
+	require.Equal(t, myJSONPtr, mjsptr.MyJSONPtr)
+	require.Equal(t, myJSONPtr, client.User.GetX(ctx, mjsptr.ID).MyJSONPtr)
 }
 
 func Predicates(t *testing.T, client *ent.Client) {


### PR DESCRIPTION
This PR adds support for using `JSON` fields with types that implement the `ValueScanner` and are not slices.


This fixes: #3255