### PR TITLE
doc/md: fix broken privacy.md links

### DIFF
--- a/doc/md/features.md
+++ b/doc/md/features.md
@@ -64,14 +64,14 @@ This option can be added to a project using the `--feature schema/snapshot` flag
 The privacy layer allows configuring privacy policy for queries and mutations of entities in the database.
 
 This option can be added to a project using the `--feature privacy` flag, and you can learn more about in the
-[privacy](privacy.md) documentation.
+[privacy](privacy.mdx) documentation.
 
 ### EntQL Filtering
 
 The `entql` option provides a generic and dynamic filtering capability at runtime for the different query builders.
 
 This option can be added to a project using the `--feature entql` flag, and you can learn more about in the
-[privacy](privacy.md#multi-tenancy) documentation.
+[privacy](privacy.mdx#multi-tenancy) documentation.
 
 ### Named Edges
 


### PR DESCRIPTION
privacy.md was renamed to privacy.mdx in commit f226627d6700.

When trying to click on one of the 'privacy' links on the features page you get the following error:

    <Error>
    <Code>AccessDenied</Code>
    <Message>Access Denied</Message>
    <RequestId>15DQ15S3VAEQA8PW</RequestId>
    <HostId>
    HxNShnveIK1dyPbqjFK/v7/x/VqKyysl4XWBPiEr75PgLkjl0CZjWN0PRzQcFMI0uZWPOpHS49Q=
    </HostId>
    </Error>