### PR TITLE
Add auto increment for columns having annotation and uniq constraint #3090

### DIFF
--- a/entc/gen/type.go
+++ b/entc/gen/type.go
@@ -1497,6 +1497,13 @@ func (f Field) Column() *schema.Column {
 	if f.def != nil {
 		c.SchemaType = f.def.SchemaType
 	}
+
+	// if schema has annotation of incremental true and have a uniq constraint of the field,
+	// field does not have to be PK and can have auto-increment
+	if ant := f.EntSQL(); ant != nil && ant.Incremental != nil && *ant.Incremental && f.Unique {
+		c.Increment = true
+	}
+
 	return c
 }
 


### PR DESCRIPTION
super super unfamiliar with how ent works. doing a dig-in without bigger context, this seems to be the fix. Considerations need to be done for this change's implications on
- other DB types
- other scenarios (uniq not set, incremental set to false, and other combination)

This combo makes it work for mysql. Where a column can have auto increment with unique annotation, on non pk columns.