### PR TITLE
doc: Fix typo in tutorial

### DIFF
--- a/doc/md/getting-started.mdx
+++ b/doc/md/getting-started.mdx
@@ -533,7 +533,7 @@ func CreateGraph(ctx context.Context, client *ent.Client) error {
 		Create().
 		SetModel("Ford").
 		SetRegisteredAt(time.Now()).
-		// Attach this graph to Neta.
+		// Attach this car to Neta.
 		SetOwner(neta).
 		Exec(ctx)
 	if err != nil {

--- a/examples/start/start.go
+++ b/examples/start/start.go
@@ -200,7 +200,7 @@ func CreateGraph(ctx context.Context, client *ent.Client) error {
 		Create().
 		SetModel("Ford").
 		SetRegisteredAt(time.Now()).
-		// Attach this cat to Neta.
+		// Attach this car to Neta.
 		SetOwner(neta).
 		Exec(ctx)
 	if err != nil {


### PR DESCRIPTION
Hi, thanks for maintaining this awesome repository.

I found some typo while I was doing hand-on tutorial in getting-started document. It's really trivial but I think it's good to fix this because many newbies are reading this document.