### PR TITLE
entc/gen: add fluent-api for order options

### DIFF
--- a/entc/gen/template/base.tmpl
+++ b/entc/gen/template/base.tmpl
@@ -71,7 +71,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 {{ range $f, $order := order }}
 	{{ $f = pascal $f }}
 	// {{ $f }} applies the given fields in {{ upper $f }} order.
-	func {{ $f }}(fields ...string) OrderFunc {
+	func {{ $f }}(fields ...string) func({{ $.Storage.Builder }}) {
 		{{- with extend (index $.Nodes 0) "Func" $f "Order" $order -}}
 			{{ $tmpl := printf "dialect/%s/order/func" $.Storage }}
 			return {{ xtemplate $tmpl . }}

--- a/entc/gen/template/builder/query.tmpl
+++ b/entc/gen/template/builder/query.tmpl
@@ -22,7 +22,7 @@ in the LICENSE file in the root directory of this source tree.
 type {{ $builder }} struct {
 	config
 	ctx			*QueryContext
-	order		[]OrderFunc
+	order		[]{{ $.Package }}.Order
 	inters		[]Interceptor
 	predicates 	[]predicate.{{ $.Name }}
 	{{- /* Eager loading fields. */}}
@@ -65,7 +65,7 @@ func ({{ $receiver }} *{{ $builder }}) Unique(unique bool) *{{ $builder }} {
 }
 
 // Order specifies how the records should be ordered.
-func ({{ $receiver }} *{{ $builder }}) Order(o ...OrderFunc) *{{ $builder }} {
+func ({{ $receiver }} *{{ $builder }}) Order(o ...{{ $.Package }}.Order) *{{ $builder }} {
 	{{ $receiver }}.order = append({{ $receiver }}.order, o...)
 	return {{ $receiver }}
 }
@@ -286,7 +286,7 @@ func ({{ $receiver }} *{{ $builder }}) Clone() *{{ $builder }} {
 	return &{{ $builder }}{
 		config: 	{{ $receiver }}.config,
 		ctx: 		{{ $receiver }}.ctx.Clone(),
-		order: 		append([]OrderFunc{}, {{ $receiver }}.order...),
+		order: 		append([]{{ $.Package }}.Order{}, {{ $receiver }}.order...),
 		inters: 	append([]Interceptor{}, {{ $receiver }}.inters...),
 		predicates: append([]predicate.{{ $.Name }}{}, {{ $receiver }}.predicates...),
 		{{- range $e := $.Edges }}

--- a/entc/gen/template/dialect/sql/by.tmpl
+++ b/entc/gen/template/dialect/sql/by.tmpl
@@ -8,6 +8,7 @@ in the LICENSE file in the root directory of this source tree.
 
 {{ define "dialect/sql/order/signature" -}}
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (

--- a/entc/gen/template/dialect/sql/meta.tmpl
+++ b/entc/gen/template/dialect/sql/meta.tmpl
@@ -6,7 +6,7 @@ in the LICENSE file in the root directory of this source tree.
 
 {{/* gotype: entgo.io/ent/entc/gen.Type */}}
 
-{{/* constants needed for sql dialects. */}}
+{{/* Constants needed for sql dialects. */}}
 {{ define "dialect/sql/meta/constants" }}
 	{{- range $t := $.RelatedTypes }}
 		{{- $withEID := $.HasCompositeID }}
@@ -71,7 +71,7 @@ in the LICENSE file in the root directory of this source tree.
 	{{ end }}
 {{ end }}
 
-{{/* functions needed for sql dialects. */}}
+{{/* Functions needed for sql dialects. */}}
 {{ define "dialect/sql/meta/functions" }}
 // ValidColumn reports if the column name is valid (part of the table columns).
 func ValidColumn(column string) bool {
@@ -89,4 +89,73 @@ func ValidColumn(column string) bool {
 	{{- end }}
 	return false
 }
+{{ end }}
+
+{{/* Type-safe order-by builders. */}}
+{{ define "dialect/sql/meta/order" }}
+	{{ if $.HasOneFieldID }}
+		// {{ $.ID.OrderName }} orders the results by the {{ $.ID.Name }} field.
+		func {{ $.ID.OrderName }}(opts ...sql.OrderTermOption) Order {
+			return sql.OrderByField({{ $.ID.Constant }}, opts...).ToFunc()
+		}
+	{{ end }}
+	{{- range $f := $.Fields }}
+		{{- if $f.Type.Comparable }}
+			// {{ $f.OrderName }} orders the results by the {{ $f.Name }} field.
+			func {{ $f.OrderName }}(opts ...sql.OrderTermOption) Order {
+				return sql.OrderByField({{ $f.Constant }}, opts...).ToFunc()
+			}
+		{{- end }}
+	{{- end }}
+	{{- range $e := $.Edges }}
+		{{- if $e.Unique }}
+			// {{ $e.OrderFieldName }} orders the results by {{ $e.Name }} field.
+			func {{ $e.OrderFieldName }}(field string, opts ...sql.OrderTermOption) Order {
+				return func(s *sql.Selector) {
+					sqlgraph.OrderByNeighborTerms(s, new{{ pascal $e.Name }}Step(), sql.OrderByField(field, opts...))
+				}
+			}
+		{{- else }}
+			// {{ $e.OrderCountName }} orders the results by {{ $e.Name }} count.
+			func {{ $e.OrderCountName }}(opts ...sql.OrderTermOption) Order {
+				return func(s *sql.Selector) {
+					sqlgraph.OrderByNeighborsCount(s, new{{ pascal $e.Name }}Step(), opts...)
+				}
+			}
+
+			// {{ $e.OrderTermsName }} orders the results by {{ $e.Name }} terms.
+			func {{ $e.OrderTermsName }}(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+				return func(s *sql.Selector) {
+					sqlgraph.OrderByNeighborTerms(s, new{{ pascal $e.Name }}Step(), append([]sql.OrderTerm{term}, terms...)...)
+				}
+			}
+		{{- end }}
+	{{- end }}
+	{{- range $e := $.Edges }}
+		func new{{ pascal $e.Name }}Step() *sqlgraph.Step {
+			return sqlgraph.NewStep(
+				{{- if $.HasCompositeID }}
+					{{- /* Query that goes from the edge schema. */}}
+					sqlgraph.From(Table, {{ $e.ColumnConstant }}),
+					sqlgraph.To({{ $e.InverseTableConstant }}, {{ print $e.Type.Name "FieldID" }}),
+				{{- else }}
+					sqlgraph.From(Table, {{ $.ID.Constant }}),
+					{{- if $e.Type.HasOneFieldID }}
+						{{- $refid := $.ID.Constant }}{{ if ne $e.Type.ID.StorageKey $.ID.StorageKey }}{{ $refid = print $e.Type.Name "FieldID" }}{{ end }}
+						sqlgraph.To({{ if ne $.Table $e.Type.Table }}{{ $e.InverseTableConstant }}{{ else }}Table{{ end }}, {{ $refid }}),
+					{{- else }}
+						{{- /* Query that goes to the edge schema. */}}
+						sqlgraph.To({{ if ne $.Table $e.Type.Table }}{{ $e.InverseTableConstant }}{{ else }}Table{{ end }}, {{ $e.ColumnConstant }}),
+					{{- end }}
+				{{- end }}
+				sqlgraph.Edge(sqlgraph.{{ $e.Rel.Type }}, {{ $e.IsInverse }}, {{ $e.TableConstant }},
+					{{- if $e.M2M -}}
+						{{ $e.PKConstant }}...
+					{{- else -}}
+						{{ $e.ColumnConstant }}
+					{{- end -}}
+				),
+			)
+		}
+	{{- end }}
 {{ end }}

--- a/entc/gen/template/dialect/sql/predicate.tmpl
+++ b/entc/gen/template/dialect/sql/predicate.tmpl
@@ -62,29 +62,7 @@ in the LICENSE file in the root directory of this source tree.
 {{ define "dialect/sql/predicate/edge/haswith" -}}
 	{{- $e := $.Scope.Edge -}}
 	func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			{{- if $.HasCompositeID }}
-				{{- /* Query that goes from the edge schema. */}}
-				sqlgraph.From(Table, {{ $e.ColumnConstant }}),
-				sqlgraph.To({{ $e.InverseTableConstant }}, {{ print $e.Type.Name "FieldID" }}),
-			{{- else }}
-				sqlgraph.From(Table, {{ $.ID.Constant }}),
-				{{- if $e.Type.HasOneFieldID }}
-					{{- $refid := $.ID.Constant }}{{ if ne $e.Type.ID.StorageKey $.ID.StorageKey }}{{ $refid = print $e.Type.Name "FieldID" }}{{ end }}
-					sqlgraph.To({{ if ne $.Table $e.Type.Table }}{{ $e.InverseTableConstant }}{{ else }}Table{{ end }}, {{ $refid }}),
-				{{- else }}
-					{{- /* Query that goes to the edge schema. */}}
-					sqlgraph.To({{ if ne $.Table $e.Type.Table }}{{ $e.InverseTableConstant }}{{ else }}Table{{ end }}, {{ $e.ColumnConstant }}),
-				{{- end }}
-			{{- end }}
-			sqlgraph.Edge(sqlgraph.{{ $e.Rel.Type }}, {{ $e.IsInverse }}, {{ $e.TableConstant }},
-				{{- if $e.M2M -}}
-					{{ $e.PKConstant }}...
-				{{- else -}}
-					{{ $e.ColumnConstant }}
-				{{- end -}}
-			),
-		)
+		step := new{{ pascal $e.Name }}Step()
 		{{- /* Allow mutating the sqlgraph.Step by ent extensions or user templates.*/}}
 		{{- with $tmpls := matchTemplate "dialect/sql/predicate/edge/haswith/*" }}
 			{{- range $tmpl := $tmpls }}

--- a/entc/gen/template/intercept.tmpl
+++ b/entc/gen/template/intercept.tmpl
@@ -29,7 +29,7 @@ type Query interface {
 	// Unique configures the query builder to filter duplicate records.
 	Unique(bool)
 	// Order specifies how the records should be ordered.
-	Order(...{{ $pkg }}.OrderFunc)
+	Order(...func({{ $.Storage.Builder }}))
 	// WhereP appends storage-level predicates to the query builder. Using this method, users
 	// can use type-assertion to append predicates that do not depend on any generated package.
 	WhereP(...func({{ $.Storage.Builder }}))
@@ -109,45 +109,49 @@ func NewQuery(q {{ $pkg }}.Query) (Query, error) {
 	switch q := q.(type) {
 	{{- range $n := $.Nodes }}
 		case *{{ $pkg }}.{{ $n.QueryName }}:
-		return &query[*{{ $pkg }}.{{ $n.QueryName }}, predicate.{{ $n.Name }}]{typ: {{ $pkg }}.{{ $n.TypeName }}, tq: q}, nil
+		return &query[*{{ $pkg }}.{{ $n.QueryName }}, predicate.{{ $n.Name }}, {{ $n.Package }}.Order]{typ: {{ $pkg }}.{{ $n.TypeName }}, tq: q}, nil
 	{{- end }}
 	default:
 		return nil, fmt.Errorf("unknown query type %T", q)
 	}
 }
 
-type query[T any, P ~func({{ $.Storage.Builder }})] struct {
+type query[T any, P ~func({{ $.Storage.Builder }}), R ~func({{ $.Storage.Builder }})] struct {
 	typ string
 	tq  interface {
 		Limit(int) T
 		Offset(int) T
 		Unique(bool) T
-		Order(...{{ $pkg }}.OrderFunc) T
+		Order(...R) T
 		Where(...P) T
 	}
 }
 
-func (q query[T, P]) Type() string {
+func (q query[T, P, R]) Type() string {
 	return q.typ
 }
 
-func (q query[T, P]) Limit(limit int) {
+func (q query[T, P, R]) Limit(limit int) {
 	q.tq.Limit(limit)
 }
 
-func (q query[T, P]) Offset(offset int) {
+func (q query[T, P, R]) Offset(offset int) {
 	q.tq.Offset(offset)
 }
 
-func (q query[T, P]) Unique(unique bool) {
+func (q query[T, P, R]) Unique(unique bool) {
 	q.tq.Unique(unique)
 }
 
-func (q query[T, P]) Order(orders ...{{ $pkg }}.OrderFunc) {
-	q.tq.Order(orders...)
+func (q query[T, P, R]) Order(orders ...func({{ $.Storage.Builder }})) {
+	rs := make([]R, len(orders))
+	for i := range orders {
+		rs[i] = orders[i]
+	}
+	q.tq.Order(rs...)
 }
 
-func (q query[T, P]) WhereP(ps ...func({{ $.Storage.Builder }})) {
+func (q query[T, P, R]) WhereP(ps ...func({{ $.Storage.Builder }})) {
 	p := make([]P, len(ps))
 	for i := range ps {
 		p[i] = ps[i]

--- a/entc/gen/template/meta.tmpl
+++ b/entc/gen/template/meta.tmpl
@@ -154,6 +154,13 @@ const (
 	}
 {{ end }}
 
+{{ $tmpl = printf "dialect/%s/meta/order" $.Storage }}
+// Order defines the ordering method for the {{ $.Name }} queries.
+type Order func({{ $.Config.Storage.Builder }})
+{{ if hasTemplate $tmpl }}
+	{{ xtemplate $tmpl $ }}
+{{ end }}
+
 {{ template "meta/additional" $ }}
 
 {{ with $tmpls := matchTemplate "meta/additional/*" }}

--- a/entc/gen/type.go
+++ b/entc/gen/type.go
@@ -1066,6 +1066,9 @@ func (f Field) DefaultValue() any { return f.def.DefaultValue }
 // DefaultFunc returns a bool stating if the default value is a func. Invoked by the template.
 func (f Field) DefaultFunc() bool { return f.def.DefaultKind == reflect.Func }
 
+// OrderName returns the function/option name for ordering by this field.
+func (f Field) OrderName() string { return "By" + pascal(f.Name) }
+
 // BuilderField returns the struct member of the field in the builder.
 func (f Field) BuilderField() string {
 	if f.IsEdgeField() {
@@ -1972,6 +1975,30 @@ func (e Edge) MutationCleared() string {
 		return pascal(e.Name) + "EdgeCleared"
 	}
 	return name
+}
+
+// OrderCountName returns the function/option name for ordering by the edge count.
+func (e Edge) OrderCountName() (string, error) {
+	if e.Unique {
+		return "", fmt.Errorf("edge %q is unique", e.Name)
+	}
+	return fmt.Sprintf("By%sCount", pascal(e.Name)), nil
+}
+
+// OrderTermsName returns the function/option name for ordering by any term.
+func (e Edge) OrderTermsName() (string, error) {
+	if e.Unique {
+		return "", fmt.Errorf("edge %q is unique", e.Name)
+	}
+	return fmt.Sprintf("By%s", pascal(e.Name)), nil
+}
+
+// OrderFieldName returns the function/option name for ordering by edge field.
+func (e Edge) OrderFieldName() (string, error) {
+	if !e.Unique {
+		return "", fmt.Errorf("edge %q is not-unique", e.Name)
+	}
+	return fmt.Sprintf("By%sField", pascal(e.Name)), nil
 }
 
 // setStorageKey sets the storage-key option in the schema or fail.

--- a/entc/integration/cascadelete/ent/comment/comment.go
+++ b/entc/integration/cascadelete/ent/comment/comment.go
@@ -6,6 +6,11 @@
 
 package comment
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the comment type in the database.
 	Label = "comment"
@@ -43,4 +48,36 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Comment queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByText orders the results by the text field.
+func ByText(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldText, opts...).ToFunc()
+}
+
+// ByPostID orders the results by the post_id field.
+func ByPostID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldPostID, opts...).ToFunc()
+}
+
+// ByPostField orders the results by post field.
+func ByPostField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newPostStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newPostStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(PostInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, PostTable, PostColumn),
+	)
 }

--- a/entc/integration/cascadelete/ent/comment/where.go
+++ b/entc/integration/cascadelete/ent/comment/where.go
@@ -166,11 +166,7 @@ func HasPost() predicate.Comment {
 // HasPostWith applies the HasEdge predicate on the "post" edge with a given conditions (other predicates).
 func HasPostWith(preds ...predicate.Post) predicate.Comment {
 	return predicate.Comment(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(PostInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, PostTable, PostColumn),
-		)
+		step := newPostStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/cascadelete/ent/comment_query.go
+++ b/entc/integration/cascadelete/ent/comment_query.go
@@ -23,7 +23,7 @@ import (
 type CommentQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []comment.Order
 	inters     []Interceptor
 	predicates []predicate.Comment
 	withPost   *PostQuery
@@ -58,7 +58,7 @@ func (cq *CommentQuery) Unique(unique bool) *CommentQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *CommentQuery) Order(o ...OrderFunc) *CommentQuery {
+func (cq *CommentQuery) Order(o ...comment.Order) *CommentQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -274,7 +274,7 @@ func (cq *CommentQuery) Clone() *CommentQuery {
 	return &CommentQuery{
 		config:     cq.config,
 		ctx:        cq.ctx.Clone(),
-		order:      append([]OrderFunc{}, cq.order...),
+		order:      append([]comment.Order{}, cq.order...),
 		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Comment{}, cq.predicates...),
 		withPost:   cq.withPost.Clone(),

--- a/entc/integration/cascadelete/ent/ent.go
+++ b/entc/integration/cascadelete/ent/ent.go
@@ -67,6 +67,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -87,7 +88,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -99,7 +100,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/entc/integration/cascadelete/ent/post/post.go
+++ b/entc/integration/cascadelete/ent/post/post.go
@@ -6,6 +6,11 @@
 
 package post
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the post type in the database.
 	Label = "post"
@@ -58,3 +63,56 @@ var (
 	// DefaultText holds the default value on creation for the "text" field.
 	DefaultText string
 )
+
+// Order defines the ordering method for the Post queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByText orders the results by the text field.
+func ByText(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldText, opts...).ToFunc()
+}
+
+// ByAuthorID orders the results by the author_id field.
+func ByAuthorID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldAuthorID, opts...).ToFunc()
+}
+
+// ByAuthorField orders the results by author field.
+func ByAuthorField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newAuthorStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByCommentsCount orders the results by comments count.
+func ByCommentsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newCommentsStep(), opts...)
+	}
+}
+
+// ByComments orders the results by comments terms.
+func ByComments(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newCommentsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newAuthorStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(AuthorInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, AuthorTable, AuthorColumn),
+	)
+}
+func newCommentsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(CommentsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, CommentsTable, CommentsColumn),
+	)
+}

--- a/entc/integration/cascadelete/ent/post/where.go
+++ b/entc/integration/cascadelete/ent/post/where.go
@@ -176,11 +176,7 @@ func HasAuthor() predicate.Post {
 // HasAuthorWith applies the HasEdge predicate on the "author" edge with a given conditions (other predicates).
 func HasAuthorWith(preds ...predicate.User) predicate.Post {
 	return predicate.Post(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(AuthorInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, AuthorTable, AuthorColumn),
-		)
+		step := newAuthorStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -203,11 +199,7 @@ func HasComments() predicate.Post {
 // HasCommentsWith applies the HasEdge predicate on the "comments" edge with a given conditions (other predicates).
 func HasCommentsWith(preds ...predicate.Comment) predicate.Post {
 	return predicate.Post(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(CommentsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, CommentsTable, CommentsColumn),
-		)
+		step := newCommentsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/cascadelete/ent/post_query.go
+++ b/entc/integration/cascadelete/ent/post_query.go
@@ -25,7 +25,7 @@ import (
 type PostQuery struct {
 	config
 	ctx          *QueryContext
-	order        []OrderFunc
+	order        []post.Order
 	inters       []Interceptor
 	predicates   []predicate.Post
 	withAuthor   *UserQuery
@@ -61,7 +61,7 @@ func (pq *PostQuery) Unique(unique bool) *PostQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (pq *PostQuery) Order(o ...OrderFunc) *PostQuery {
+func (pq *PostQuery) Order(o ...post.Order) *PostQuery {
 	pq.order = append(pq.order, o...)
 	return pq
 }
@@ -299,7 +299,7 @@ func (pq *PostQuery) Clone() *PostQuery {
 	return &PostQuery{
 		config:       pq.config,
 		ctx:          pq.ctx.Clone(),
-		order:        append([]OrderFunc{}, pq.order...),
+		order:        append([]post.Order{}, pq.order...),
 		inters:       append([]Interceptor{}, pq.inters...),
 		predicates:   append([]predicate.Post{}, pq.predicates...),
 		withAuthor:   pq.withAuthor.Clone(),

--- a/entc/integration/cascadelete/ent/user/user.go
+++ b/entc/integration/cascadelete/ent/user/user.go
@@ -6,6 +6,11 @@
 
 package user
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the user type in the database.
 	Label = "user"
@@ -46,3 +51,37 @@ var (
 	// DefaultName holds the default value on creation for the "name" field.
 	DefaultName string
 )
+
+// Order defines the ordering method for the User queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByPostsCount orders the results by posts count.
+func ByPostsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newPostsStep(), opts...)
+	}
+}
+
+// ByPosts orders the results by posts terms.
+func ByPosts(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newPostsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newPostsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(PostsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, PostsTable, PostsColumn),
+	)
+}

--- a/entc/integration/cascadelete/ent/user/where.go
+++ b/entc/integration/cascadelete/ent/user/where.go
@@ -141,11 +141,7 @@ func HasPosts() predicate.User {
 // HasPostsWith applies the HasEdge predicate on the "posts" edge with a given conditions (other predicates).
 func HasPostsWith(preds ...predicate.Post) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(PostsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, PostsTable, PostsColumn),
-		)
+		step := newPostsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/cascadelete/ent/user_query.go
+++ b/entc/integration/cascadelete/ent/user_query.go
@@ -24,7 +24,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []user.Order
 	inters     []Interceptor
 	predicates []predicate.User
 	withPosts  *PostQuery
@@ -59,7 +59,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...OrderFunc) *UserQuery {
+func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -275,7 +275,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]OrderFunc{}, uq.order...),
+		order:      append([]user.Order{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		withPosts:  uq.withPosts.Clone(),

--- a/entc/integration/config/ent/ent.go
+++ b/entc/integration/config/ent/ent.go
@@ -65,6 +65,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -83,7 +84,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -95,7 +96,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/entc/integration/config/ent/user/user.go
+++ b/entc/integration/config/ent/user/user.go
@@ -6,6 +6,10 @@
 
 package user
 
+import (
+	"entgo.io/ent/dialect/sql"
+)
+
 const (
 	// Label holds the string label denoting the user type in the database.
 	Label = "user"
@@ -34,4 +38,22 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the User queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByLabel orders the results by the label field.
+func ByLabel(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldLabel, opts...).ToFunc()
 }

--- a/entc/integration/config/ent/user_query.go
+++ b/entc/integration/config/ent/user_query.go
@@ -22,7 +22,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []user.Order
 	inters     []Interceptor
 	predicates []predicate.User
 	// intermediate query (i.e. traversal path).
@@ -56,7 +56,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...OrderFunc) *UserQuery {
+func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -250,7 +250,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]OrderFunc{}, uq.order...),
+		order:      append([]user.Order{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/customid/ent/account/where.go
+++ b/entc/integration/customid/ent/account/where.go
@@ -142,11 +142,7 @@ func HasToken() predicate.Account {
 // HasTokenWith applies the HasEdge predicate on the "token" edge with a given conditions (other predicates).
 func HasTokenWith(preds ...predicate.Token) predicate.Account {
 	return predicate.Account(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(TokenInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, TokenTable, TokenColumn),
-		)
+		step := newTokenStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/customid/ent/account_query.go
+++ b/entc/integration/customid/ent/account_query.go
@@ -25,7 +25,7 @@ import (
 type AccountQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []account.Order
 	inters     []Interceptor
 	predicates []predicate.Account
 	withToken  *TokenQuery
@@ -60,7 +60,7 @@ func (aq *AccountQuery) Unique(unique bool) *AccountQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (aq *AccountQuery) Order(o ...OrderFunc) *AccountQuery {
+func (aq *AccountQuery) Order(o ...account.Order) *AccountQuery {
 	aq.order = append(aq.order, o...)
 	return aq
 }
@@ -276,7 +276,7 @@ func (aq *AccountQuery) Clone() *AccountQuery {
 	return &AccountQuery{
 		config:     aq.config,
 		ctx:        aq.ctx.Clone(),
-		order:      append([]OrderFunc{}, aq.order...),
+		order:      append([]account.Order{}, aq.order...),
 		inters:     append([]Interceptor{}, aq.inters...),
 		predicates: append([]predicate.Account{}, aq.predicates...),
 		withToken:  aq.withToken.Clone(),

--- a/entc/integration/customid/ent/blob/where.go
+++ b/entc/integration/customid/ent/blob/where.go
@@ -162,11 +162,7 @@ func HasParent() predicate.Blob {
 // HasParentWith applies the HasEdge predicate on the "parent" edge with a given conditions (other predicates).
 func HasParentWith(preds ...predicate.Blob) predicate.Blob {
 	return predicate.Blob(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, false, ParentTable, ParentColumn),
-		)
+		step := newParentStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -189,11 +185,7 @@ func HasLinks() predicate.Blob {
 // HasLinksWith applies the HasEdge predicate on the "links" edge with a given conditions (other predicates).
 func HasLinksWith(preds ...predicate.Blob) predicate.Blob {
 	return predicate.Blob(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, LinksTable, LinksPrimaryKey...),
-		)
+		step := newLinksStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -216,11 +208,7 @@ func HasBlobLinks() predicate.Blob {
 // HasBlobLinksWith applies the HasEdge predicate on the "blob_links" edge with a given conditions (other predicates).
 func HasBlobLinksWith(preds ...predicate.BlobLink) predicate.Blob {
 	return predicate.Blob(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(BlobLinksInverseTable, BlobLinksColumn),
-			sqlgraph.Edge(sqlgraph.O2M, true, BlobLinksTable, BlobLinksColumn),
-		)
+		step := newBlobLinksStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/customid/ent/blob_query.go
+++ b/entc/integration/customid/ent/blob_query.go
@@ -25,7 +25,7 @@ import (
 type BlobQuery struct {
 	config
 	ctx           *QueryContext
-	order         []OrderFunc
+	order         []blob.Order
 	inters        []Interceptor
 	predicates    []predicate.Blob
 	withParent    *BlobQuery
@@ -63,7 +63,7 @@ func (bq *BlobQuery) Unique(unique bool) *BlobQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (bq *BlobQuery) Order(o ...OrderFunc) *BlobQuery {
+func (bq *BlobQuery) Order(o ...blob.Order) *BlobQuery {
 	bq.order = append(bq.order, o...)
 	return bq
 }
@@ -323,7 +323,7 @@ func (bq *BlobQuery) Clone() *BlobQuery {
 	return &BlobQuery{
 		config:        bq.config,
 		ctx:           bq.ctx.Clone(),
-		order:         append([]OrderFunc{}, bq.order...),
+		order:         append([]blob.Order{}, bq.order...),
 		inters:        append([]Interceptor{}, bq.inters...),
 		predicates:    append([]predicate.Blob{}, bq.predicates...),
 		withParent:    bq.withParent.Clone(),

--- a/entc/integration/customid/ent/bloblink/bloblink.go
+++ b/entc/integration/customid/ent/bloblink/bloblink.go
@@ -8,6 +8,9 @@ package bloblink
 
 import (
 	"time"
+
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
 )
 
 const (
@@ -64,3 +67,49 @@ var (
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time
 )
+
+// Order defines the ordering method for the BlobLink queries.
+type Order func(*sql.Selector)
+
+// ByCreatedAt orders the results by the created_at field.
+func ByCreatedAt(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldCreatedAt, opts...).ToFunc()
+}
+
+// ByBlobID orders the results by the blob_id field.
+func ByBlobID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldBlobID, opts...).ToFunc()
+}
+
+// ByLinkID orders the results by the link_id field.
+func ByLinkID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldLinkID, opts...).ToFunc()
+}
+
+// ByBlobField orders the results by blob field.
+func ByBlobField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newBlobStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByLinkField orders the results by link field.
+func ByLinkField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newLinkStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newBlobStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, BlobColumn),
+		sqlgraph.To(BlobInverseTable, BlobFieldID),
+		sqlgraph.Edge(sqlgraph.M2O, false, BlobTable, BlobColumn),
+	)
+}
+func newLinkStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, LinkColumn),
+		sqlgraph.To(LinkInverseTable, BlobFieldID),
+		sqlgraph.Edge(sqlgraph.M2O, false, LinkTable, LinkColumn),
+	)
+}

--- a/entc/integration/customid/ent/bloblink/where.go
+++ b/entc/integration/customid/ent/bloblink/where.go
@@ -124,11 +124,7 @@ func HasBlob() predicate.BlobLink {
 // HasBlobWith applies the HasEdge predicate on the "blob" edge with a given conditions (other predicates).
 func HasBlobWith(preds ...predicate.Blob) predicate.BlobLink {
 	return predicate.BlobLink(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, BlobColumn),
-			sqlgraph.To(BlobInverseTable, BlobFieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, BlobTable, BlobColumn),
-		)
+		step := newBlobStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -151,11 +147,7 @@ func HasLink() predicate.BlobLink {
 // HasLinkWith applies the HasEdge predicate on the "link" edge with a given conditions (other predicates).
 func HasLinkWith(preds ...predicate.Blob) predicate.BlobLink {
 	return predicate.BlobLink(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, LinkColumn),
-			sqlgraph.To(LinkInverseTable, BlobFieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, LinkTable, LinkColumn),
-		)
+		step := newLinkStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/customid/ent/bloblink_query.go
+++ b/entc/integration/customid/ent/bloblink_query.go
@@ -23,7 +23,7 @@ import (
 type BlobLinkQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []bloblink.Order
 	inters     []Interceptor
 	predicates []predicate.BlobLink
 	withBlob   *BlobQuery
@@ -59,7 +59,7 @@ func (blq *BlobLinkQuery) Unique(unique bool) *BlobLinkQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (blq *BlobLinkQuery) Order(o ...OrderFunc) *BlobLinkQuery {
+func (blq *BlobLinkQuery) Order(o ...bloblink.Order) *BlobLinkQuery {
 	blq.order = append(blq.order, o...)
 	return blq
 }
@@ -225,7 +225,7 @@ func (blq *BlobLinkQuery) Clone() *BlobLinkQuery {
 	return &BlobLinkQuery{
 		config:     blq.config,
 		ctx:        blq.ctx.Clone(),
-		order:      append([]OrderFunc{}, blq.order...),
+		order:      append([]bloblink.Order{}, blq.order...),
 		inters:     append([]Interceptor{}, blq.inters...),
 		predicates: append([]predicate.BlobLink{}, blq.predicates...),
 		withBlob:   blq.withBlob.Clone(),

--- a/entc/integration/customid/ent/car/car.go
+++ b/entc/integration/customid/ent/car/car.go
@@ -6,6 +6,11 @@
 
 package car
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the car type in the database.
 	Label = "car"
@@ -67,3 +72,40 @@ var (
 	// IDValidator is a validator for the "id" field. It is called by the builders before save.
 	IDValidator func(int) error
 )
+
+// Order defines the ordering method for the Car queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByBeforeID orders the results by the before_id field.
+func ByBeforeID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldBeforeID, opts...).ToFunc()
+}
+
+// ByAfterID orders the results by the after_id field.
+func ByAfterID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldAfterID, opts...).ToFunc()
+}
+
+// ByModel orders the results by the model field.
+func ByModel(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldModel, opts...).ToFunc()
+}
+
+// ByOwnerField orders the results by owner field.
+func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newOwnerStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(OwnerInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
+	)
+}

--- a/entc/integration/customid/ent/car/where.go
+++ b/entc/integration/customid/ent/car/where.go
@@ -251,11 +251,7 @@ func HasOwner() predicate.Car {
 // HasOwnerWith applies the HasEdge predicate on the "owner" edge with a given conditions (other predicates).
 func HasOwnerWith(preds ...predicate.Pet) predicate.Car {
 	return predicate.Car(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(OwnerInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
-		)
+		step := newOwnerStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/customid/ent/car_query.go
+++ b/entc/integration/customid/ent/car_query.go
@@ -23,7 +23,7 @@ import (
 type CarQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []car.Order
 	inters     []Interceptor
 	predicates []predicate.Car
 	withOwner  *PetQuery
@@ -59,7 +59,7 @@ func (cq *CarQuery) Unique(unique bool) *CarQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *CarQuery) Order(o ...OrderFunc) *CarQuery {
+func (cq *CarQuery) Order(o ...car.Order) *CarQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -275,7 +275,7 @@ func (cq *CarQuery) Clone() *CarQuery {
 	return &CarQuery{
 		config:     cq.config,
 		ctx:        cq.ctx.Clone(),
-		order:      append([]OrderFunc{}, cq.order...),
+		order:      append([]car.Order{}, cq.order...),
 		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Car{}, cq.predicates...),
 		withOwner:  cq.withOwner.Clone(),

--- a/entc/integration/customid/ent/device/where.go
+++ b/entc/integration/customid/ent/device/where.go
@@ -72,11 +72,7 @@ func HasActiveSession() predicate.Device {
 // HasActiveSessionWith applies the HasEdge predicate on the "active_session" edge with a given conditions (other predicates).
 func HasActiveSessionWith(preds ...predicate.Session) predicate.Device {
 	return predicate.Device(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(ActiveSessionInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, ActiveSessionTable, ActiveSessionColumn),
-		)
+		step := newActiveSessionStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -99,11 +95,7 @@ func HasSessions() predicate.Device {
 // HasSessionsWith applies the HasEdge predicate on the "sessions" edge with a given conditions (other predicates).
 func HasSessionsWith(preds ...predicate.Session) predicate.Device {
 	return predicate.Device(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(SessionsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, SessionsTable, SessionsColumn),
-		)
+		step := newSessionsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/customid/ent/device_query.go
+++ b/entc/integration/customid/ent/device_query.go
@@ -25,7 +25,7 @@ import (
 type DeviceQuery struct {
 	config
 	ctx               *QueryContext
-	order             []OrderFunc
+	order             []device.Order
 	inters            []Interceptor
 	predicates        []predicate.Device
 	withActiveSession *SessionQuery
@@ -62,7 +62,7 @@ func (dq *DeviceQuery) Unique(unique bool) *DeviceQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (dq *DeviceQuery) Order(o ...OrderFunc) *DeviceQuery {
+func (dq *DeviceQuery) Order(o ...device.Order) *DeviceQuery {
 	dq.order = append(dq.order, o...)
 	return dq
 }
@@ -300,7 +300,7 @@ func (dq *DeviceQuery) Clone() *DeviceQuery {
 	return &DeviceQuery{
 		config:            dq.config,
 		ctx:               dq.ctx.Clone(),
-		order:             append([]OrderFunc{}, dq.order...),
+		order:             append([]device.Order{}, dq.order...),
 		inters:            append([]Interceptor{}, dq.inters...),
 		predicates:        append([]predicate.Device{}, dq.predicates...),
 		withActiveSession: dq.withActiveSession.Clone(),

--- a/entc/integration/customid/ent/doc/doc.go
+++ b/entc/integration/customid/ent/doc/doc.go
@@ -7,6 +7,8 @@
 package doc
 
 import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/entc/integration/customid/ent/schema"
 )
 
@@ -76,3 +78,72 @@ var (
 	// IDValidator is a validator for the "id" field. It is called by the builders before save.
 	IDValidator func(string) error
 )
+
+// Order defines the ordering method for the Doc queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByText orders the results by the text field.
+func ByText(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldText, opts...).ToFunc()
+}
+
+// ByParentField orders the results by parent field.
+func ByParentField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newParentStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByChildrenCount orders the results by children count.
+func ByChildrenCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newChildrenStep(), opts...)
+	}
+}
+
+// ByChildren orders the results by children terms.
+func ByChildren(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newChildrenStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByRelatedCount orders the results by related count.
+func ByRelatedCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newRelatedStep(), opts...)
+	}
+}
+
+// ByRelated orders the results by related terms.
+func ByRelated(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newRelatedStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newParentStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, ParentTable, ParentColumn),
+	)
+}
+func newChildrenStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, ChildrenTable, ChildrenColumn),
+	)
+}
+func newRelatedStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, RelatedTable, RelatedPrimaryKey...),
+	)
+}

--- a/entc/integration/customid/ent/doc/where.go
+++ b/entc/integration/customid/ent/doc/where.go
@@ -152,11 +152,7 @@ func HasParent() predicate.Doc {
 // HasParentWith applies the HasEdge predicate on the "parent" edge with a given conditions (other predicates).
 func HasParentWith(preds ...predicate.Doc) predicate.Doc {
 	return predicate.Doc(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, ParentTable, ParentColumn),
-		)
+		step := newParentStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -179,11 +175,7 @@ func HasChildren() predicate.Doc {
 // HasChildrenWith applies the HasEdge predicate on the "children" edge with a given conditions (other predicates).
 func HasChildrenWith(preds ...predicate.Doc) predicate.Doc {
 	return predicate.Doc(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, ChildrenTable, ChildrenColumn),
-		)
+		step := newChildrenStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -206,11 +198,7 @@ func HasRelated() predicate.Doc {
 // HasRelatedWith applies the HasEdge predicate on the "related" edge with a given conditions (other predicates).
 func HasRelatedWith(preds ...predicate.Doc) predicate.Doc {
 	return predicate.Doc(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, RelatedTable, RelatedPrimaryKey...),
-		)
+		step := newRelatedStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/customid/ent/doc_query.go
+++ b/entc/integration/customid/ent/doc_query.go
@@ -24,7 +24,7 @@ import (
 type DocQuery struct {
 	config
 	ctx          *QueryContext
-	order        []OrderFunc
+	order        []doc.Order
 	inters       []Interceptor
 	predicates   []predicate.Doc
 	withParent   *DocQuery
@@ -62,7 +62,7 @@ func (dq *DocQuery) Unique(unique bool) *DocQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (dq *DocQuery) Order(o ...OrderFunc) *DocQuery {
+func (dq *DocQuery) Order(o ...doc.Order) *DocQuery {
 	dq.order = append(dq.order, o...)
 	return dq
 }
@@ -322,7 +322,7 @@ func (dq *DocQuery) Clone() *DocQuery {
 	return &DocQuery{
 		config:       dq.config,
 		ctx:          dq.ctx.Clone(),
-		order:        append([]OrderFunc{}, dq.order...),
+		order:        append([]doc.Order{}, dq.order...),
 		inters:       append([]Interceptor{}, dq.inters...),
 		predicates:   append([]predicate.Doc{}, dq.predicates...),
 		withParent:   dq.withParent.Clone(),

--- a/entc/integration/customid/ent/ent.go
+++ b/entc/integration/customid/ent/ent.go
@@ -81,6 +81,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -115,7 +116,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -127,7 +128,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/entc/integration/customid/ent/group/group.go
+++ b/entc/integration/customid/ent/group/group.go
@@ -6,6 +6,11 @@
 
 package group
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the group type in the database.
 	Label = "group"
@@ -43,4 +48,33 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Group queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByUsersCount orders the results by users count.
+func ByUsersCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newUsersStep(), opts...)
+	}
+}
+
+// ByUsers orders the results by users terms.
+func ByUsers(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newUsersStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newUsersStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(UsersInverseTable, UserFieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, UsersTable, UsersPrimaryKey...),
+	)
 }

--- a/entc/integration/customid/ent/group/where.go
+++ b/entc/integration/customid/ent/group/where.go
@@ -71,11 +71,7 @@ func HasUsers() predicate.Group {
 // HasUsersWith applies the HasEdge predicate on the "users" edge with a given conditions (other predicates).
 func HasUsersWith(preds ...predicate.User) predicate.Group {
 	return predicate.Group(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(UsersInverseTable, UserFieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, UsersTable, UsersPrimaryKey...),
-		)
+		step := newUsersStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/customid/ent/group_query.go
+++ b/entc/integration/customid/ent/group_query.go
@@ -24,7 +24,7 @@ import (
 type GroupQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []group.Order
 	inters     []Interceptor
 	predicates []predicate.Group
 	withUsers  *UserQuery
@@ -59,7 +59,7 @@ func (gq *GroupQuery) Unique(unique bool) *GroupQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (gq *GroupQuery) Order(o ...OrderFunc) *GroupQuery {
+func (gq *GroupQuery) Order(o ...group.Order) *GroupQuery {
 	gq.order = append(gq.order, o...)
 	return gq
 }
@@ -275,7 +275,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 	return &GroupQuery{
 		config:     gq.config,
 		ctx:        gq.ctx.Clone(),
-		order:      append([]OrderFunc{}, gq.order...),
+		order:      append([]group.Order{}, gq.order...),
 		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Group{}, gq.predicates...),
 		withUsers:  gq.withUsers.Clone(),

--- a/entc/integration/customid/ent/intsid/where.go
+++ b/entc/integration/customid/ent/intsid/where.go
@@ -72,11 +72,7 @@ func HasParent() predicate.IntSID {
 // HasParentWith applies the HasEdge predicate on the "parent" edge with a given conditions (other predicates).
 func HasParentWith(preds ...predicate.IntSID) predicate.IntSID {
 	return predicate.IntSID(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, ParentTable, ParentColumn),
-		)
+		step := newParentStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -99,11 +95,7 @@ func HasChildren() predicate.IntSID {
 // HasChildrenWith applies the HasEdge predicate on the "children" edge with a given conditions (other predicates).
 func HasChildrenWith(preds ...predicate.IntSID) predicate.IntSID {
 	return predicate.IntSID(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, true, ChildrenTable, ChildrenColumn),
-		)
+		step := newChildrenStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/customid/ent/intsid_query.go
+++ b/entc/integration/customid/ent/intsid_query.go
@@ -24,7 +24,7 @@ import (
 type IntSIDQuery struct {
 	config
 	ctx          *QueryContext
-	order        []OrderFunc
+	order        []intsid.Order
 	inters       []Interceptor
 	predicates   []predicate.IntSID
 	withParent   *IntSIDQuery
@@ -61,7 +61,7 @@ func (isq *IntSIDQuery) Unique(unique bool) *IntSIDQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (isq *IntSIDQuery) Order(o ...OrderFunc) *IntSIDQuery {
+func (isq *IntSIDQuery) Order(o ...intsid.Order) *IntSIDQuery {
 	isq.order = append(isq.order, o...)
 	return isq
 }
@@ -299,7 +299,7 @@ func (isq *IntSIDQuery) Clone() *IntSIDQuery {
 	return &IntSIDQuery{
 		config:       isq.config,
 		ctx:          isq.ctx.Clone(),
-		order:        append([]OrderFunc{}, isq.order...),
+		order:        append([]intsid.Order{}, isq.order...),
 		inters:       append([]Interceptor{}, isq.inters...),
 		predicates:   append([]predicate.IntSID{}, isq.predicates...),
 		withParent:   isq.withParent.Clone(),

--- a/entc/integration/customid/ent/link/link.go
+++ b/entc/integration/customid/ent/link/link.go
@@ -7,6 +7,7 @@
 package link
 
 import (
+	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/entc/integration/customid/ent/schema"
 	uuidc "entgo.io/ent/entc/integration/customid/uuidcompatible"
 )
@@ -44,3 +45,11 @@ var (
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() uuidc.UUIDC
 )
+
+// Order defines the ordering method for the Link queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}

--- a/entc/integration/customid/ent/link_query.go
+++ b/entc/integration/customid/ent/link_query.go
@@ -23,7 +23,7 @@ import (
 type LinkQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []link.Order
 	inters     []Interceptor
 	predicates []predicate.Link
 	// intermediate query (i.e. traversal path).
@@ -57,7 +57,7 @@ func (lq *LinkQuery) Unique(unique bool) *LinkQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (lq *LinkQuery) Order(o ...OrderFunc) *LinkQuery {
+func (lq *LinkQuery) Order(o ...link.Order) *LinkQuery {
 	lq.order = append(lq.order, o...)
 	return lq
 }
@@ -251,7 +251,7 @@ func (lq *LinkQuery) Clone() *LinkQuery {
 	return &LinkQuery{
 		config:     lq.config,
 		ctx:        lq.ctx.Clone(),
-		order:      append([]OrderFunc{}, lq.order...),
+		order:      append([]link.Order{}, lq.order...),
 		inters:     append([]Interceptor{}, lq.inters...),
 		predicates: append([]predicate.Link{}, lq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/customid/ent/mixinid/mixinid.go
+++ b/entc/integration/customid/ent/mixinid/mixinid.go
@@ -7,6 +7,7 @@
 package mixinid
 
 import (
+	"entgo.io/ent/dialect/sql"
 	"github.com/google/uuid"
 )
 
@@ -44,3 +45,21 @@ var (
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() uuid.UUID
 )
+
+// Order defines the ordering method for the MixinID queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// BySomeField orders the results by the some_field field.
+func BySomeField(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldSomeField, opts...).ToFunc()
+}
+
+// ByMixinField orders the results by the mixin_field field.
+func ByMixinField(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldMixinField, opts...).ToFunc()
+}

--- a/entc/integration/customid/ent/mixinid_query.go
+++ b/entc/integration/customid/ent/mixinid_query.go
@@ -23,7 +23,7 @@ import (
 type MixinIDQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []mixinid.Order
 	inters     []Interceptor
 	predicates []predicate.MixinID
 	// intermediate query (i.e. traversal path).
@@ -57,7 +57,7 @@ func (miq *MixinIDQuery) Unique(unique bool) *MixinIDQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (miq *MixinIDQuery) Order(o ...OrderFunc) *MixinIDQuery {
+func (miq *MixinIDQuery) Order(o ...mixinid.Order) *MixinIDQuery {
 	miq.order = append(miq.order, o...)
 	return miq
 }
@@ -251,7 +251,7 @@ func (miq *MixinIDQuery) Clone() *MixinIDQuery {
 	return &MixinIDQuery{
 		config:     miq.config,
 		ctx:        miq.ctx.Clone(),
-		order:      append([]OrderFunc{}, miq.order...),
+		order:      append([]mixinid.Order{}, miq.order...),
 		inters:     append([]Interceptor{}, miq.inters...),
 		predicates: append([]predicate.MixinID{}, miq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/customid/ent/note/note.go
+++ b/entc/integration/customid/ent/note/note.go
@@ -7,6 +7,8 @@
 package note
 
 import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/entc/integration/customid/ent/schema"
 )
 
@@ -66,3 +68,51 @@ var (
 	// IDValidator is a validator for the "id" field. It is called by the builders before save.
 	IDValidator func(string) error
 )
+
+// Order defines the ordering method for the Note queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByText orders the results by the text field.
+func ByText(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldText, opts...).ToFunc()
+}
+
+// ByParentField orders the results by parent field.
+func ByParentField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newParentStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByChildrenCount orders the results by children count.
+func ByChildrenCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newChildrenStep(), opts...)
+	}
+}
+
+// ByChildren orders the results by children terms.
+func ByChildren(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newChildrenStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newParentStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, ParentTable, ParentColumn),
+	)
+}
+func newChildrenStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, ChildrenTable, ChildrenColumn),
+	)
+}

--- a/entc/integration/customid/ent/note/where.go
+++ b/entc/integration/customid/ent/note/where.go
@@ -152,11 +152,7 @@ func HasParent() predicate.Note {
 // HasParentWith applies the HasEdge predicate on the "parent" edge with a given conditions (other predicates).
 func HasParentWith(preds ...predicate.Note) predicate.Note {
 	return predicate.Note(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, ParentTable, ParentColumn),
-		)
+		step := newParentStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -179,11 +175,7 @@ func HasChildren() predicate.Note {
 // HasChildrenWith applies the HasEdge predicate on the "children" edge with a given conditions (other predicates).
 func HasChildrenWith(preds ...predicate.Note) predicate.Note {
 	return predicate.Note(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, ChildrenTable, ChildrenColumn),
-		)
+		step := newChildrenStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/customid/ent/note_query.go
+++ b/entc/integration/customid/ent/note_query.go
@@ -24,7 +24,7 @@ import (
 type NoteQuery struct {
 	config
 	ctx          *QueryContext
-	order        []OrderFunc
+	order        []note.Order
 	inters       []Interceptor
 	predicates   []predicate.Note
 	withParent   *NoteQuery
@@ -61,7 +61,7 @@ func (nq *NoteQuery) Unique(unique bool) *NoteQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (nq *NoteQuery) Order(o ...OrderFunc) *NoteQuery {
+func (nq *NoteQuery) Order(o ...note.Order) *NoteQuery {
 	nq.order = append(nq.order, o...)
 	return nq
 }
@@ -299,7 +299,7 @@ func (nq *NoteQuery) Clone() *NoteQuery {
 	return &NoteQuery{
 		config:       nq.config,
 		ctx:          nq.ctx.Clone(),
-		order:        append([]OrderFunc{}, nq.order...),
+		order:        append([]note.Order{}, nq.order...),
 		inters:       append([]Interceptor{}, nq.inters...),
 		predicates:   append([]predicate.Note{}, nq.predicates...),
 		withParent:   nq.withParent.Clone(),

--- a/entc/integration/customid/ent/other/other.go
+++ b/entc/integration/customid/ent/other/other.go
@@ -7,6 +7,7 @@
 package other
 
 import (
+	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/entc/integration/customid/sid"
 )
 
@@ -38,3 +39,11 @@ var (
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() sid.ID
 )
+
+// Order defines the ordering method for the Other queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}

--- a/entc/integration/customid/ent/other_query.go
+++ b/entc/integration/customid/ent/other_query.go
@@ -23,7 +23,7 @@ import (
 type OtherQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []other.Order
 	inters     []Interceptor
 	predicates []predicate.Other
 	// intermediate query (i.e. traversal path).
@@ -57,7 +57,7 @@ func (oq *OtherQuery) Unique(unique bool) *OtherQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (oq *OtherQuery) Order(o ...OrderFunc) *OtherQuery {
+func (oq *OtherQuery) Order(o ...other.Order) *OtherQuery {
 	oq.order = append(oq.order, o...)
 	return oq
 }
@@ -251,7 +251,7 @@ func (oq *OtherQuery) Clone() *OtherQuery {
 	return &OtherQuery{
 		config:     oq.config,
 		ctx:        oq.ctx.Clone(),
-		order:      append([]OrderFunc{}, oq.order...),
+		order:      append([]other.Order{}, oq.order...),
 		inters:     append([]Interceptor{}, oq.inters...),
 		predicates: append([]predicate.Other{}, oq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/customid/ent/pet/pet.go
+++ b/entc/integration/customid/ent/pet/pet.go
@@ -6,6 +6,11 @@
 
 package pet
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the pet type in the database.
 	Label = "pet"
@@ -84,3 +89,81 @@ var (
 	// IDValidator is a validator for the "id" field. It is called by the builders before save.
 	IDValidator func(string) error
 )
+
+// Order defines the ordering method for the Pet queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByOwnerField orders the results by owner field.
+func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByCarsCount orders the results by cars count.
+func ByCarsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newCarsStep(), opts...)
+	}
+}
+
+// ByCars orders the results by cars terms.
+func ByCars(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newCarsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByFriendsCount orders the results by friends count.
+func ByFriendsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newFriendsStep(), opts...)
+	}
+}
+
+// ByFriends orders the results by friends terms.
+func ByFriends(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newFriendsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByBestFriendField orders the results by best_friend field.
+func ByBestFriendField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newBestFriendStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newOwnerStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(OwnerInverseTable, UserFieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
+	)
+}
+func newCarsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(CarsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, CarsTable, CarsColumn),
+	)
+}
+func newFriendsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, FriendsTable, FriendsPrimaryKey...),
+	)
+}
+func newBestFriendStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.O2O, false, BestFriendTable, BestFriendColumn),
+	)
+}

--- a/entc/integration/customid/ent/pet/where.go
+++ b/entc/integration/customid/ent/pet/where.go
@@ -81,11 +81,7 @@ func HasOwner() predicate.Pet {
 // HasOwnerWith applies the HasEdge predicate on the "owner" edge with a given conditions (other predicates).
 func HasOwnerWith(preds ...predicate.User) predicate.Pet {
 	return predicate.Pet(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(OwnerInverseTable, UserFieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
-		)
+		step := newOwnerStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -108,11 +104,7 @@ func HasCars() predicate.Pet {
 // HasCarsWith applies the HasEdge predicate on the "cars" edge with a given conditions (other predicates).
 func HasCarsWith(preds ...predicate.Car) predicate.Pet {
 	return predicate.Pet(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(CarsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, CarsTable, CarsColumn),
-		)
+		step := newCarsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -135,11 +127,7 @@ func HasFriends() predicate.Pet {
 // HasFriendsWith applies the HasEdge predicate on the "friends" edge with a given conditions (other predicates).
 func HasFriendsWith(preds ...predicate.Pet) predicate.Pet {
 	return predicate.Pet(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, FriendsTable, FriendsPrimaryKey...),
-		)
+		step := newFriendsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -162,11 +150,7 @@ func HasBestFriend() predicate.Pet {
 // HasBestFriendWith applies the HasEdge predicate on the "best_friend" edge with a given conditions (other predicates).
 func HasBestFriendWith(preds ...predicate.Pet) predicate.Pet {
 	return predicate.Pet(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, false, BestFriendTable, BestFriendColumn),
-		)
+		step := newBestFriendStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/customid/ent/pet_query.go
+++ b/entc/integration/customid/ent/pet_query.go
@@ -25,7 +25,7 @@ import (
 type PetQuery struct {
 	config
 	ctx            *QueryContext
-	order          []OrderFunc
+	order          []pet.Order
 	inters         []Interceptor
 	predicates     []predicate.Pet
 	withOwner      *UserQuery
@@ -64,7 +64,7 @@ func (pq *PetQuery) Unique(unique bool) *PetQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (pq *PetQuery) Order(o ...OrderFunc) *PetQuery {
+func (pq *PetQuery) Order(o ...pet.Order) *PetQuery {
 	pq.order = append(pq.order, o...)
 	return pq
 }
@@ -346,7 +346,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 	return &PetQuery{
 		config:         pq.config,
 		ctx:            pq.ctx.Clone(),
-		order:          append([]OrderFunc{}, pq.order...),
+		order:          append([]pet.Order{}, pq.order...),
 		inters:         append([]Interceptor{}, pq.inters...),
 		predicates:     append([]predicate.Pet{}, pq.predicates...),
 		withOwner:      pq.withOwner.Clone(),

--- a/entc/integration/customid/ent/revision/revision.go
+++ b/entc/integration/customid/ent/revision/revision.go
@@ -6,6 +6,10 @@
 
 package revision
 
+import (
+	"entgo.io/ent/dialect/sql"
+)
+
 const (
 	// Label holds the string label denoting the revision type in the database.
 	Label = "revision"
@@ -28,4 +32,12 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Revision queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
 }

--- a/entc/integration/customid/ent/revision_query.go
+++ b/entc/integration/customid/ent/revision_query.go
@@ -22,7 +22,7 @@ import (
 type RevisionQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []revision.Order
 	inters     []Interceptor
 	predicates []predicate.Revision
 	// intermediate query (i.e. traversal path).
@@ -56,7 +56,7 @@ func (rq *RevisionQuery) Unique(unique bool) *RevisionQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (rq *RevisionQuery) Order(o ...OrderFunc) *RevisionQuery {
+func (rq *RevisionQuery) Order(o ...revision.Order) *RevisionQuery {
 	rq.order = append(rq.order, o...)
 	return rq
 }
@@ -250,7 +250,7 @@ func (rq *RevisionQuery) Clone() *RevisionQuery {
 	return &RevisionQuery{
 		config:     rq.config,
 		ctx:        rq.ctx.Clone(),
-		order:      append([]OrderFunc{}, rq.order...),
+		order:      append([]revision.Order{}, rq.order...),
 		inters:     append([]Interceptor{}, rq.inters...),
 		predicates: append([]predicate.Revision{}, rq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/customid/ent/session/session.go
+++ b/entc/integration/customid/ent/session/session.go
@@ -7,6 +7,8 @@
 package session
 
 import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/entc/integration/customid/ent/schema"
 )
 
@@ -60,3 +62,25 @@ var (
 	// IDValidator is a validator for the "id" field. It is called by the builders before save.
 	IDValidator func([]byte) error
 )
+
+// Order defines the ordering method for the Session queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByDeviceField orders the results by device field.
+func ByDeviceField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newDeviceStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newDeviceStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(DeviceInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, DeviceTable, DeviceColumn),
+	)
+}

--- a/entc/integration/customid/ent/session/where.go
+++ b/entc/integration/customid/ent/session/where.go
@@ -72,11 +72,7 @@ func HasDevice() predicate.Session {
 // HasDeviceWith applies the HasEdge predicate on the "device" edge with a given conditions (other predicates).
 func HasDeviceWith(preds ...predicate.Device) predicate.Session {
 	return predicate.Session(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(DeviceInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, DeviceTable, DeviceColumn),
-		)
+		step := newDeviceStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/customid/ent/session_query.go
+++ b/entc/integration/customid/ent/session_query.go
@@ -24,7 +24,7 @@ import (
 type SessionQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []session.Order
 	inters     []Interceptor
 	predicates []predicate.Session
 	withDevice *DeviceQuery
@@ -60,7 +60,7 @@ func (sq *SessionQuery) Unique(unique bool) *SessionQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (sq *SessionQuery) Order(o ...OrderFunc) *SessionQuery {
+func (sq *SessionQuery) Order(o ...session.Order) *SessionQuery {
 	sq.order = append(sq.order, o...)
 	return sq
 }
@@ -276,7 +276,7 @@ func (sq *SessionQuery) Clone() *SessionQuery {
 	return &SessionQuery{
 		config:     sq.config,
 		ctx:        sq.ctx.Clone(),
-		order:      append([]OrderFunc{}, sq.order...),
+		order:      append([]session.Order{}, sq.order...),
 		inters:     append([]Interceptor{}, sq.inters...),
 		predicates: append([]predicate.Session{}, sq.predicates...),
 		withDevice: sq.withDevice.Clone(),

--- a/entc/integration/customid/ent/token/token.go
+++ b/entc/integration/customid/ent/token/token.go
@@ -7,6 +7,8 @@
 package token
 
 import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/entc/integration/customid/sid"
 )
 
@@ -63,3 +65,30 @@ var (
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() sid.ID
 )
+
+// Order defines the ordering method for the Token queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByBody orders the results by the body field.
+func ByBody(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldBody, opts...).ToFunc()
+}
+
+// ByAccountField orders the results by account field.
+func ByAccountField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newAccountStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newAccountStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(AccountInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, AccountTable, AccountColumn),
+	)
+}

--- a/entc/integration/customid/ent/token/where.go
+++ b/entc/integration/customid/ent/token/where.go
@@ -142,11 +142,7 @@ func HasAccount() predicate.Token {
 // HasAccountWith applies the HasEdge predicate on the "account" edge with a given conditions (other predicates).
 func HasAccountWith(preds ...predicate.Account) predicate.Token {
 	return predicate.Token(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(AccountInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, AccountTable, AccountColumn),
-		)
+		step := newAccountStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/customid/ent/token_query.go
+++ b/entc/integration/customid/ent/token_query.go
@@ -24,7 +24,7 @@ import (
 type TokenQuery struct {
 	config
 	ctx         *QueryContext
-	order       []OrderFunc
+	order       []token.Order
 	inters      []Interceptor
 	predicates  []predicate.Token
 	withAccount *AccountQuery
@@ -60,7 +60,7 @@ func (tq *TokenQuery) Unique(unique bool) *TokenQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (tq *TokenQuery) Order(o ...OrderFunc) *TokenQuery {
+func (tq *TokenQuery) Order(o ...token.Order) *TokenQuery {
 	tq.order = append(tq.order, o...)
 	return tq
 }
@@ -276,7 +276,7 @@ func (tq *TokenQuery) Clone() *TokenQuery {
 	return &TokenQuery{
 		config:      tq.config,
 		ctx:         tq.ctx.Clone(),
-		order:       append([]OrderFunc{}, tq.order...),
+		order:       append([]token.Order{}, tq.order...),
 		inters:      append([]Interceptor{}, tq.inters...),
 		predicates:  append([]predicate.Token{}, tq.predicates...),
 		withAccount: tq.withAccount.Clone(),

--- a/entc/integration/customid/ent/user/where.go
+++ b/entc/integration/customid/ent/user/where.go
@@ -71,11 +71,7 @@ func HasGroups() predicate.User {
 // HasGroupsWith applies the HasEdge predicate on the "groups" edge with a given conditions (other predicates).
 func HasGroupsWith(preds ...predicate.Group) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(GroupsInverseTable, GroupFieldID),
-			sqlgraph.Edge(sqlgraph.M2M, true, GroupsTable, GroupsPrimaryKey...),
-		)
+		step := newGroupsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -98,11 +94,7 @@ func HasParent() predicate.User {
 // HasParentWith applies the HasEdge predicate on the "parent" edge with a given conditions (other predicates).
 func HasParentWith(preds ...predicate.User) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, ParentTable, ParentColumn),
-		)
+		step := newParentStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -125,11 +117,7 @@ func HasChildren() predicate.User {
 // HasChildrenWith applies the HasEdge predicate on the "children" edge with a given conditions (other predicates).
 func HasChildrenWith(preds ...predicate.User) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, ChildrenTable, ChildrenColumn),
-		)
+		step := newChildrenStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -152,11 +140,7 @@ func HasPets() predicate.User {
 // HasPetsWith applies the HasEdge predicate on the "pets" edge with a given conditions (other predicates).
 func HasPetsWith(preds ...predicate.Pet) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(PetsInverseTable, PetFieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, PetsTable, PetsColumn),
-		)
+		step := newPetsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/customid/ent/user_query.go
+++ b/entc/integration/customid/ent/user_query.go
@@ -25,7 +25,7 @@ import (
 type UserQuery struct {
 	config
 	ctx          *QueryContext
-	order        []OrderFunc
+	order        []user.Order
 	inters       []Interceptor
 	predicates   []predicate.User
 	withGroups   *GroupQuery
@@ -64,7 +64,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...OrderFunc) *UserQuery {
+func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -346,7 +346,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:       uq.config,
 		ctx:          uq.ctx.Clone(),
-		order:        append([]OrderFunc{}, uq.order...),
+		order:        append([]user.Order{}, uq.order...),
 		inters:       append([]Interceptor{}, uq.inters...),
 		predicates:   append([]predicate.User{}, uq.predicates...),
 		withGroups:   uq.withGroups.Clone(),

--- a/entc/integration/edgefield/ent/car/where.go
+++ b/entc/integration/edgefield/ent/car/where.go
@@ -152,11 +152,7 @@ func HasRentals() predicate.Car {
 // HasRentalsWith applies the HasEdge predicate on the "rentals" edge with a given conditions (other predicates).
 func HasRentalsWith(preds ...predicate.Rental) predicate.Car {
 	return predicate.Car(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(RentalsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, RentalsTable, RentalsColumn),
-		)
+		step := newRentalsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/edgefield/ent/car_query.go
+++ b/entc/integration/edgefield/ent/car_query.go
@@ -25,7 +25,7 @@ import (
 type CarQuery struct {
 	config
 	ctx         *QueryContext
-	order       []OrderFunc
+	order       []car.Order
 	inters      []Interceptor
 	predicates  []predicate.Car
 	withRentals *RentalQuery
@@ -60,7 +60,7 @@ func (cq *CarQuery) Unique(unique bool) *CarQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *CarQuery) Order(o ...OrderFunc) *CarQuery {
+func (cq *CarQuery) Order(o ...car.Order) *CarQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -276,7 +276,7 @@ func (cq *CarQuery) Clone() *CarQuery {
 	return &CarQuery{
 		config:      cq.config,
 		ctx:         cq.ctx.Clone(),
-		order:       append([]OrderFunc{}, cq.order...),
+		order:       append([]car.Order{}, cq.order...),
 		inters:      append([]Interceptor{}, cq.inters...),
 		predicates:  append([]predicate.Car{}, cq.predicates...),
 		withRentals: cq.withRentals.Clone(),

--- a/entc/integration/edgefield/ent/card/card.go
+++ b/entc/integration/edgefield/ent/card/card.go
@@ -6,6 +6,11 @@
 
 package card
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the card type in the database.
 	Label = "card"
@@ -43,4 +48,36 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Card queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByNumber orders the results by the number field.
+func ByNumber(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldNumber, opts...).ToFunc()
+}
+
+// ByOwnerID orders the results by the owner_id field.
+func ByOwnerID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldOwnerID, opts...).ToFunc()
+}
+
+// ByOwnerField orders the results by owner field.
+func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newOwnerStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(OwnerInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2O, true, OwnerTable, OwnerColumn),
+	)
 }

--- a/entc/integration/edgefield/ent/card/where.go
+++ b/entc/integration/edgefield/ent/card/where.go
@@ -186,11 +186,7 @@ func HasOwner() predicate.Card {
 // HasOwnerWith applies the HasEdge predicate on the "owner" edge with a given conditions (other predicates).
 func HasOwnerWith(preds ...predicate.User) predicate.Card {
 	return predicate.Card(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(OwnerInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, true, OwnerTable, OwnerColumn),
-		)
+		step := newOwnerStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/edgefield/ent/card_query.go
+++ b/entc/integration/edgefield/ent/card_query.go
@@ -23,7 +23,7 @@ import (
 type CardQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []card.Order
 	inters     []Interceptor
 	predicates []predicate.Card
 	withOwner  *UserQuery
@@ -58,7 +58,7 @@ func (cq *CardQuery) Unique(unique bool) *CardQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *CardQuery) Order(o ...OrderFunc) *CardQuery {
+func (cq *CardQuery) Order(o ...card.Order) *CardQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -274,7 +274,7 @@ func (cq *CardQuery) Clone() *CardQuery {
 	return &CardQuery{
 		config:     cq.config,
 		ctx:        cq.ctx.Clone(),
-		order:      append([]OrderFunc{}, cq.order...),
+		order:      append([]card.Order{}, cq.order...),
 		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Card{}, cq.predicates...),
 		withOwner:  cq.withOwner.Clone(),

--- a/entc/integration/edgefield/ent/ent.go
+++ b/entc/integration/edgefield/ent/ent.go
@@ -73,6 +73,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -99,7 +100,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -111,7 +112,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/entc/integration/edgefield/ent/info/info.go
+++ b/entc/integration/edgefield/ent/info/info.go
@@ -6,6 +6,11 @@
 
 package info
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the info type in the database.
 	Label = "info"
@@ -40,4 +45,26 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Info queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByUserField orders the results by user field.
+func ByUserField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newUserStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newUserStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(UserInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, false, UserTable, UserColumn),
+	)
 }

--- a/entc/integration/edgefield/ent/info/where.go
+++ b/entc/integration/edgefield/ent/info/where.go
@@ -71,11 +71,7 @@ func HasUser() predicate.Info {
 // HasUserWith applies the HasEdge predicate on the "user" edge with a given conditions (other predicates).
 func HasUserWith(preds ...predicate.User) predicate.Info {
 	return predicate.Info(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(UserInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, UserTable, UserColumn),
-		)
+		step := newUserStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/edgefield/ent/info_query.go
+++ b/entc/integration/edgefield/ent/info_query.go
@@ -23,7 +23,7 @@ import (
 type InfoQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []info.Order
 	inters     []Interceptor
 	predicates []predicate.Info
 	withUser   *UserQuery
@@ -58,7 +58,7 @@ func (iq *InfoQuery) Unique(unique bool) *InfoQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (iq *InfoQuery) Order(o ...OrderFunc) *InfoQuery {
+func (iq *InfoQuery) Order(o ...info.Order) *InfoQuery {
 	iq.order = append(iq.order, o...)
 	return iq
 }
@@ -274,7 +274,7 @@ func (iq *InfoQuery) Clone() *InfoQuery {
 	return &InfoQuery{
 		config:     iq.config,
 		ctx:        iq.ctx.Clone(),
-		order:      append([]OrderFunc{}, iq.order...),
+		order:      append([]info.Order{}, iq.order...),
 		inters:     append([]Interceptor{}, iq.inters...),
 		predicates: append([]predicate.Info{}, iq.predicates...),
 		withUser:   iq.withUser.Clone(),

--- a/entc/integration/edgefield/ent/metadata/where.go
+++ b/entc/integration/edgefield/ent/metadata/where.go
@@ -151,11 +151,7 @@ func HasUser() predicate.Metadata {
 // HasUserWith applies the HasEdge predicate on the "user" edge with a given conditions (other predicates).
 func HasUserWith(preds ...predicate.User) predicate.Metadata {
 	return predicate.Metadata(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(UserInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, true, UserTable, UserColumn),
-		)
+		step := newUserStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -178,11 +174,7 @@ func HasChildren() predicate.Metadata {
 // HasChildrenWith applies the HasEdge predicate on the "children" edge with a given conditions (other predicates).
 func HasChildrenWith(preds ...predicate.Metadata) predicate.Metadata {
 	return predicate.Metadata(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, true, ChildrenTable, ChildrenColumn),
-		)
+		step := newChildrenStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -205,11 +197,7 @@ func HasParent() predicate.Metadata {
 // HasParentWith applies the HasEdge predicate on the "parent" edge with a given conditions (other predicates).
 func HasParentWith(preds ...predicate.Metadata) predicate.Metadata {
 	return predicate.Metadata(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, ParentTable, ParentColumn),
-		)
+		step := newParentStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/edgefield/ent/metadata_query.go
+++ b/entc/integration/edgefield/ent/metadata_query.go
@@ -24,7 +24,7 @@ import (
 type MetadataQuery struct {
 	config
 	ctx          *QueryContext
-	order        []OrderFunc
+	order        []metadata.Order
 	inters       []Interceptor
 	predicates   []predicate.Metadata
 	withUser     *UserQuery
@@ -61,7 +61,7 @@ func (mq *MetadataQuery) Unique(unique bool) *MetadataQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (mq *MetadataQuery) Order(o ...OrderFunc) *MetadataQuery {
+func (mq *MetadataQuery) Order(o ...metadata.Order) *MetadataQuery {
 	mq.order = append(mq.order, o...)
 	return mq
 }
@@ -321,7 +321,7 @@ func (mq *MetadataQuery) Clone() *MetadataQuery {
 	return &MetadataQuery{
 		config:       mq.config,
 		ctx:          mq.ctx.Clone(),
-		order:        append([]OrderFunc{}, mq.order...),
+		order:        append([]metadata.Order{}, mq.order...),
 		inters:       append([]Interceptor{}, mq.inters...),
 		predicates:   append([]predicate.Metadata{}, mq.predicates...),
 		withUser:     mq.withUser.Clone(),

--- a/entc/integration/edgefield/ent/node/node.go
+++ b/entc/integration/edgefield/ent/node/node.go
@@ -6,6 +6,11 @@
 
 package node
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the node type in the database.
 	Label = "node"
@@ -52,3 +57,49 @@ var (
 	// DefaultValue holds the default value on creation for the "value" field.
 	DefaultValue int
 )
+
+// Order defines the ordering method for the Node queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByValue orders the results by the value field.
+func ByValue(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldValue, opts...).ToFunc()
+}
+
+// ByPrevID orders the results by the prev_id field.
+func ByPrevID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldPrevID, opts...).ToFunc()
+}
+
+// ByPrevField orders the results by prev field.
+func ByPrevField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newPrevStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByNextField orders the results by next field.
+func ByNextField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newNextStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newPrevStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.O2O, true, PrevTable, PrevColumn),
+	)
+}
+func newNextStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.O2O, false, NextTable, NextColumn),
+	)
+}

--- a/entc/integration/edgefield/ent/node/where.go
+++ b/entc/integration/edgefield/ent/node/where.go
@@ -151,11 +151,7 @@ func HasPrev() predicate.Node {
 // HasPrevWith applies the HasEdge predicate on the "prev" edge with a given conditions (other predicates).
 func HasPrevWith(preds ...predicate.Node) predicate.Node {
 	return predicate.Node(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, true, PrevTable, PrevColumn),
-		)
+		step := newPrevStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -178,11 +174,7 @@ func HasNext() predicate.Node {
 // HasNextWith applies the HasEdge predicate on the "next" edge with a given conditions (other predicates).
 func HasNextWith(preds ...predicate.Node) predicate.Node {
 	return predicate.Node(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, false, NextTable, NextColumn),
-		)
+		step := newNextStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/edgefield/ent/node_query.go
+++ b/entc/integration/edgefield/ent/node_query.go
@@ -23,7 +23,7 @@ import (
 type NodeQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []node.Order
 	inters     []Interceptor
 	predicates []predicate.Node
 	withPrev   *NodeQuery
@@ -59,7 +59,7 @@ func (nq *NodeQuery) Unique(unique bool) *NodeQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (nq *NodeQuery) Order(o ...OrderFunc) *NodeQuery {
+func (nq *NodeQuery) Order(o ...node.Order) *NodeQuery {
 	nq.order = append(nq.order, o...)
 	return nq
 }
@@ -297,7 +297,7 @@ func (nq *NodeQuery) Clone() *NodeQuery {
 	return &NodeQuery{
 		config:     nq.config,
 		ctx:        nq.ctx.Clone(),
-		order:      append([]OrderFunc{}, nq.order...),
+		order:      append([]node.Order{}, nq.order...),
 		inters:     append([]Interceptor{}, nq.inters...),
 		predicates: append([]predicate.Node{}, nq.predicates...),
 		withPrev:   nq.withPrev.Clone(),

--- a/entc/integration/edgefield/ent/pet/pet.go
+++ b/entc/integration/edgefield/ent/pet/pet.go
@@ -6,6 +6,11 @@
 
 package pet
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the pet type in the database.
 	Label = "pet"
@@ -40,4 +45,31 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Pet queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByOwnerID orders the results by the owner_id field.
+func ByOwnerID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldOwnerID, opts...).ToFunc()
+}
+
+// ByOwnerField orders the results by owner field.
+func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newOwnerStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(OwnerInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
+	)
 }

--- a/entc/integration/edgefield/ent/pet/where.go
+++ b/entc/integration/edgefield/ent/pet/where.go
@@ -106,11 +106,7 @@ func HasOwner() predicate.Pet {
 // HasOwnerWith applies the HasEdge predicate on the "owner" edge with a given conditions (other predicates).
 func HasOwnerWith(preds ...predicate.User) predicate.Pet {
 	return predicate.Pet(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(OwnerInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
-		)
+		step := newOwnerStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/edgefield/ent/pet_query.go
+++ b/entc/integration/edgefield/ent/pet_query.go
@@ -23,7 +23,7 @@ import (
 type PetQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []pet.Order
 	inters     []Interceptor
 	predicates []predicate.Pet
 	withOwner  *UserQuery
@@ -58,7 +58,7 @@ func (pq *PetQuery) Unique(unique bool) *PetQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (pq *PetQuery) Order(o ...OrderFunc) *PetQuery {
+func (pq *PetQuery) Order(o ...pet.Order) *PetQuery {
 	pq.order = append(pq.order, o...)
 	return pq
 }
@@ -274,7 +274,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 	return &PetQuery{
 		config:     pq.config,
 		ctx:        pq.ctx.Clone(),
-		order:      append([]OrderFunc{}, pq.order...),
+		order:      append([]pet.Order{}, pq.order...),
 		inters:     append([]Interceptor{}, pq.inters...),
 		predicates: append([]predicate.Pet{}, pq.predicates...),
 		withOwner:  pq.withOwner.Clone(),

--- a/entc/integration/edgefield/ent/post/post.go
+++ b/entc/integration/edgefield/ent/post/post.go
@@ -6,6 +6,11 @@
 
 package post
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the post type in the database.
 	Label = "post"
@@ -43,4 +48,36 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Post queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByText orders the results by the text field.
+func ByText(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldText, opts...).ToFunc()
+}
+
+// ByAuthorID orders the results by the author_id field.
+func ByAuthorID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldAuthorID, opts...).ToFunc()
+}
+
+// ByAuthorField orders the results by author field.
+func ByAuthorField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newAuthorStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newAuthorStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(AuthorInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, false, AuthorTable, AuthorColumn),
+	)
 }

--- a/entc/integration/edgefield/ent/post/where.go
+++ b/entc/integration/edgefield/ent/post/where.go
@@ -176,11 +176,7 @@ func HasAuthor() predicate.Post {
 // HasAuthorWith applies the HasEdge predicate on the "author" edge with a given conditions (other predicates).
 func HasAuthorWith(preds ...predicate.User) predicate.Post {
 	return predicate.Post(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(AuthorInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, AuthorTable, AuthorColumn),
-		)
+		step := newAuthorStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/edgefield/ent/post_query.go
+++ b/entc/integration/edgefield/ent/post_query.go
@@ -23,7 +23,7 @@ import (
 type PostQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []post.Order
 	inters     []Interceptor
 	predicates []predicate.Post
 	withAuthor *UserQuery
@@ -58,7 +58,7 @@ func (pq *PostQuery) Unique(unique bool) *PostQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (pq *PostQuery) Order(o ...OrderFunc) *PostQuery {
+func (pq *PostQuery) Order(o ...post.Order) *PostQuery {
 	pq.order = append(pq.order, o...)
 	return pq
 }
@@ -274,7 +274,7 @@ func (pq *PostQuery) Clone() *PostQuery {
 	return &PostQuery{
 		config:     pq.config,
 		ctx:        pq.ctx.Clone(),
-		order:      append([]OrderFunc{}, pq.order...),
+		order:      append([]post.Order{}, pq.order...),
 		inters:     append([]Interceptor{}, pq.inters...),
 		predicates: append([]predicate.Post{}, pq.predicates...),
 		withAuthor: pq.withAuthor.Clone(),

--- a/entc/integration/edgefield/ent/rental/rental.go
+++ b/entc/integration/edgefield/ent/rental/rental.go
@@ -8,6 +8,9 @@ package rental
 
 import (
 	"time"
+
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
 )
 
 const (
@@ -65,3 +68,54 @@ var (
 	// DefaultDate holds the default value on creation for the "date" field.
 	DefaultDate func() time.Time
 )
+
+// Order defines the ordering method for the Rental queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByDate orders the results by the date field.
+func ByDate(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldDate, opts...).ToFunc()
+}
+
+// ByUserID orders the results by the user_id field.
+func ByUserID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldUserID, opts...).ToFunc()
+}
+
+// ByCarID orders the results by the car_id field.
+func ByCarID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldCarID, opts...).ToFunc()
+}
+
+// ByUserField orders the results by user field.
+func ByUserField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newUserStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByCarField orders the results by car field.
+func ByCarField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newCarStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newUserStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(UserInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, UserTable, UserColumn),
+	)
+}
+func newCarStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(CarInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, CarTable, CarColumn),
+	)
+}

--- a/entc/integration/edgefield/ent/rental/where.go
+++ b/entc/integration/edgefield/ent/rental/where.go
@@ -169,11 +169,7 @@ func HasUser() predicate.Rental {
 // HasUserWith applies the HasEdge predicate on the "user" edge with a given conditions (other predicates).
 func HasUserWith(preds ...predicate.User) predicate.Rental {
 	return predicate.Rental(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(UserInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, UserTable, UserColumn),
-		)
+		step := newUserStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -196,11 +192,7 @@ func HasCar() predicate.Rental {
 // HasCarWith applies the HasEdge predicate on the "car" edge with a given conditions (other predicates).
 func HasCarWith(preds ...predicate.Car) predicate.Rental {
 	return predicate.Rental(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(CarInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, CarTable, CarColumn),
-		)
+		step := newCarStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/edgefield/ent/rental_query.go
+++ b/entc/integration/edgefield/ent/rental_query.go
@@ -25,7 +25,7 @@ import (
 type RentalQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []rental.Order
 	inters     []Interceptor
 	predicates []predicate.Rental
 	withUser   *UserQuery
@@ -61,7 +61,7 @@ func (rq *RentalQuery) Unique(unique bool) *RentalQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (rq *RentalQuery) Order(o ...OrderFunc) *RentalQuery {
+func (rq *RentalQuery) Order(o ...rental.Order) *RentalQuery {
 	rq.order = append(rq.order, o...)
 	return rq
 }
@@ -299,7 +299,7 @@ func (rq *RentalQuery) Clone() *RentalQuery {
 	return &RentalQuery{
 		config:     rq.config,
 		ctx:        rq.ctx.Clone(),
-		order:      append([]OrderFunc{}, rq.order...),
+		order:      append([]rental.Order{}, rq.order...),
 		inters:     append([]Interceptor{}, rq.inters...),
 		predicates: append([]predicate.Rental{}, rq.predicates...),
 		withUser:   rq.withUser.Clone(),

--- a/entc/integration/edgefield/ent/user/user.go
+++ b/entc/integration/edgefield/ent/user/user.go
@@ -6,6 +6,11 @@
 
 package user
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the user type in the database.
 	Label = "user"
@@ -97,4 +102,162 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the User queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByParentID orders the results by the parent_id field.
+func ByParentID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldParentID, opts...).ToFunc()
+}
+
+// BySpouseID orders the results by the spouse_id field.
+func BySpouseID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldSpouseID, opts...).ToFunc()
+}
+
+// ByPetsCount orders the results by pets count.
+func ByPetsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newPetsStep(), opts...)
+	}
+}
+
+// ByPets orders the results by pets terms.
+func ByPets(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newPetsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByParentField orders the results by parent field.
+func ByParentField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newParentStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByChildrenCount orders the results by children count.
+func ByChildrenCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newChildrenStep(), opts...)
+	}
+}
+
+// ByChildren orders the results by children terms.
+func ByChildren(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newChildrenStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// BySpouseField orders the results by spouse field.
+func BySpouseField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newSpouseStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByCardField orders the results by card field.
+func ByCardField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newCardStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByMetadataField orders the results by metadata field.
+func ByMetadataField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newMetadataStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByInfoCount orders the results by info count.
+func ByInfoCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newInfoStep(), opts...)
+	}
+}
+
+// ByInfo orders the results by info terms.
+func ByInfo(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newInfoStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByRentalsCount orders the results by rentals count.
+func ByRentalsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newRentalsStep(), opts...)
+	}
+}
+
+// ByRentals orders the results by rentals terms.
+func ByRentals(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newRentalsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newPetsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(PetsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, PetsTable, PetsColumn),
+	)
+}
+func newParentStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, ParentTable, ParentColumn),
+	)
+}
+func newChildrenStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, ChildrenTable, ChildrenColumn),
+	)
+}
+func newSpouseStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.O2O, false, SpouseTable, SpouseColumn),
+	)
+}
+func newCardStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(CardInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2O, false, CardTable, CardColumn),
+	)
+}
+func newMetadataStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(MetadataInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2O, false, MetadataTable, MetadataColumn),
+	)
+}
+func newInfoStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(InfoInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, true, InfoTable, InfoColumn),
+	)
+}
+func newRentalsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(RentalsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, RentalsTable, RentalsColumn),
+	)
 }

--- a/entc/integration/edgefield/ent/user/where.go
+++ b/entc/integration/edgefield/ent/user/where.go
@@ -141,11 +141,7 @@ func HasPets() predicate.User {
 // HasPetsWith applies the HasEdge predicate on the "pets" edge with a given conditions (other predicates).
 func HasPetsWith(preds ...predicate.Pet) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(PetsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, PetsTable, PetsColumn),
-		)
+		step := newPetsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -168,11 +164,7 @@ func HasParent() predicate.User {
 // HasParentWith applies the HasEdge predicate on the "parent" edge with a given conditions (other predicates).
 func HasParentWith(preds ...predicate.User) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, ParentTable, ParentColumn),
-		)
+		step := newParentStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -195,11 +187,7 @@ func HasChildren() predicate.User {
 // HasChildrenWith applies the HasEdge predicate on the "children" edge with a given conditions (other predicates).
 func HasChildrenWith(preds ...predicate.User) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, ChildrenTable, ChildrenColumn),
-		)
+		step := newChildrenStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -222,11 +210,7 @@ func HasSpouse() predicate.User {
 // HasSpouseWith applies the HasEdge predicate on the "spouse" edge with a given conditions (other predicates).
 func HasSpouseWith(preds ...predicate.User) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, false, SpouseTable, SpouseColumn),
-		)
+		step := newSpouseStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -249,11 +233,7 @@ func HasCard() predicate.User {
 // HasCardWith applies the HasEdge predicate on the "card" edge with a given conditions (other predicates).
 func HasCardWith(preds ...predicate.Card) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(CardInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, false, CardTable, CardColumn),
-		)
+		step := newCardStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -276,11 +256,7 @@ func HasMetadata() predicate.User {
 // HasMetadataWith applies the HasEdge predicate on the "metadata" edge with a given conditions (other predicates).
 func HasMetadataWith(preds ...predicate.Metadata) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(MetadataInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, false, MetadataTable, MetadataColumn),
-		)
+		step := newMetadataStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -303,11 +279,7 @@ func HasInfo() predicate.User {
 // HasInfoWith applies the HasEdge predicate on the "info" edge with a given conditions (other predicates).
 func HasInfoWith(preds ...predicate.Info) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(InfoInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, true, InfoTable, InfoColumn),
-		)
+		step := newInfoStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -330,11 +302,7 @@ func HasRentals() predicate.User {
 // HasRentalsWith applies the HasEdge predicate on the "rentals" edge with a given conditions (other predicates).
 func HasRentalsWith(preds ...predicate.Rental) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(RentalsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, RentalsTable, RentalsColumn),
-		)
+		step := newRentalsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/edgefield/ent/user_query.go
+++ b/entc/integration/edgefield/ent/user_query.go
@@ -28,7 +28,7 @@ import (
 type UserQuery struct {
 	config
 	ctx          *QueryContext
-	order        []OrderFunc
+	order        []user.Order
 	inters       []Interceptor
 	predicates   []predicate.User
 	withPets     *PetQuery
@@ -70,7 +70,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...OrderFunc) *UserQuery {
+func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -440,7 +440,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:       uq.config,
 		ctx:          uq.ctx.Clone(),
-		order:        append([]OrderFunc{}, uq.order...),
+		order:        append([]user.Order{}, uq.order...),
 		inters:       append([]Interceptor{}, uq.inters...),
 		predicates:   append([]predicate.User{}, uq.predicates...),
 		withPets:     uq.withPets.Clone(),

--- a/entc/integration/edgeschema/ent/attachedfile/attachedfile.go
+++ b/entc/integration/edgeschema/ent/attachedfile/attachedfile.go
@@ -8,6 +8,9 @@ package attachedfile
 
 import (
 	"time"
+
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
 )
 
 const (
@@ -65,3 +68,54 @@ var (
 	// DefaultAttachTime holds the default value on creation for the "attach_time" field.
 	DefaultAttachTime func() time.Time
 )
+
+// Order defines the ordering method for the AttachedFile queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByAttachTime orders the results by the attach_time field.
+func ByAttachTime(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldAttachTime, opts...).ToFunc()
+}
+
+// ByFID orders the results by the f_id field.
+func ByFID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldFID, opts...).ToFunc()
+}
+
+// ByProcID orders the results by the proc_id field.
+func ByProcID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldProcID, opts...).ToFunc()
+}
+
+// ByFiField orders the results by fi field.
+func ByFiField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newFiStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByProcField orders the results by proc field.
+func ByProcField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newProcStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newFiStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(FiInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, false, FiTable, FiColumn),
+	)
+}
+func newProcStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(ProcInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, false, ProcTable, ProcColumn),
+	)
+}

--- a/entc/integration/edgeschema/ent/attachedfile/where.go
+++ b/entc/integration/edgeschema/ent/attachedfile/where.go
@@ -168,11 +168,7 @@ func HasFi() predicate.AttachedFile {
 // HasFiWith applies the HasEdge predicate on the "fi" edge with a given conditions (other predicates).
 func HasFiWith(preds ...predicate.File) predicate.AttachedFile {
 	return predicate.AttachedFile(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(FiInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, FiTable, FiColumn),
-		)
+		step := newFiStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -195,11 +191,7 @@ func HasProc() predicate.AttachedFile {
 // HasProcWith applies the HasEdge predicate on the "proc" edge with a given conditions (other predicates).
 func HasProcWith(preds ...predicate.Process) predicate.AttachedFile {
 	return predicate.AttachedFile(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(ProcInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, ProcTable, ProcColumn),
-		)
+		step := newProcStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/edgeschema/ent/attachedfile_query.go
+++ b/entc/integration/edgeschema/ent/attachedfile_query.go
@@ -24,7 +24,7 @@ import (
 type AttachedFileQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []attachedfile.Order
 	inters     []Interceptor
 	predicates []predicate.AttachedFile
 	withFi     *FileQuery
@@ -60,7 +60,7 @@ func (afq *AttachedFileQuery) Unique(unique bool) *AttachedFileQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (afq *AttachedFileQuery) Order(o ...OrderFunc) *AttachedFileQuery {
+func (afq *AttachedFileQuery) Order(o ...attachedfile.Order) *AttachedFileQuery {
 	afq.order = append(afq.order, o...)
 	return afq
 }
@@ -298,7 +298,7 @@ func (afq *AttachedFileQuery) Clone() *AttachedFileQuery {
 	return &AttachedFileQuery{
 		config:     afq.config,
 		ctx:        afq.ctx.Clone(),
-		order:      append([]OrderFunc{}, afq.order...),
+		order:      append([]attachedfile.Order{}, afq.order...),
 		inters:     append([]Interceptor{}, afq.inters...),
 		predicates: append([]predicate.AttachedFile{}, afq.predicates...),
 		withFi:     afq.withFi.Clone(),

--- a/entc/integration/edgeschema/ent/ent.go
+++ b/entc/integration/edgeschema/ent/ent.go
@@ -81,6 +81,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -115,7 +116,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -127,7 +128,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/entc/integration/edgeschema/ent/file/file.go
+++ b/entc/integration/edgeschema/ent/file/file.go
@@ -6,6 +6,11 @@
 
 package file
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the file type in the database.
 	Label = "file"
@@ -44,4 +49,38 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the File queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByProcessesCount orders the results by processes count.
+func ByProcessesCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newProcessesStep(), opts...)
+	}
+}
+
+// ByProcesses orders the results by processes terms.
+func ByProcesses(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newProcessesStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newProcessesStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(ProcessesInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, true, ProcessesTable, ProcessesPrimaryKey...),
+	)
 }

--- a/entc/integration/edgeschema/ent/file/where.go
+++ b/entc/integration/edgeschema/ent/file/where.go
@@ -141,11 +141,7 @@ func HasProcesses() predicate.File {
 // HasProcessesWith applies the HasEdge predicate on the "processes" edge with a given conditions (other predicates).
 func HasProcessesWith(preds ...predicate.Process) predicate.File {
 	return predicate.File(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(ProcessesInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, true, ProcessesTable, ProcessesPrimaryKey...),
-		)
+		step := newProcessesStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/edgeschema/ent/file_query.go
+++ b/entc/integration/edgeschema/ent/file_query.go
@@ -24,7 +24,7 @@ import (
 type FileQuery struct {
 	config
 	ctx           *QueryContext
-	order         []OrderFunc
+	order         []file.Order
 	inters        []Interceptor
 	predicates    []predicate.File
 	withProcesses *ProcessQuery
@@ -59,7 +59,7 @@ func (fq *FileQuery) Unique(unique bool) *FileQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (fq *FileQuery) Order(o ...OrderFunc) *FileQuery {
+func (fq *FileQuery) Order(o ...file.Order) *FileQuery {
 	fq.order = append(fq.order, o...)
 	return fq
 }
@@ -275,7 +275,7 @@ func (fq *FileQuery) Clone() *FileQuery {
 	return &FileQuery{
 		config:        fq.config,
 		ctx:           fq.ctx.Clone(),
-		order:         append([]OrderFunc{}, fq.order...),
+		order:         append([]file.Order{}, fq.order...),
 		inters:        append([]Interceptor{}, fq.inters...),
 		predicates:    append([]predicate.File{}, fq.predicates...),
 		withProcesses: fq.withProcesses.Clone(),

--- a/entc/integration/edgeschema/ent/friendship/friendship.go
+++ b/entc/integration/edgeschema/ent/friendship/friendship.go
@@ -8,6 +8,9 @@ package friendship
 
 import (
 	"time"
+
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
 )
 
 const (
@@ -70,3 +73,59 @@ var (
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time
 )
+
+// Order defines the ordering method for the Friendship queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByWeight orders the results by the weight field.
+func ByWeight(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldWeight, opts...).ToFunc()
+}
+
+// ByCreatedAt orders the results by the created_at field.
+func ByCreatedAt(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldCreatedAt, opts...).ToFunc()
+}
+
+// ByUserID orders the results by the user_id field.
+func ByUserID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldUserID, opts...).ToFunc()
+}
+
+// ByFriendID orders the results by the friend_id field.
+func ByFriendID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldFriendID, opts...).ToFunc()
+}
+
+// ByUserField orders the results by user field.
+func ByUserField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newUserStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByFriendField orders the results by friend field.
+func ByFriendField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newFriendStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newUserStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(UserInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, false, UserTable, UserColumn),
+	)
+}
+func newFriendStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(FriendInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, false, FriendTable, FriendColumn),
+	)
+}

--- a/entc/integration/edgeschema/ent/friendship/where.go
+++ b/entc/integration/edgeschema/ent/friendship/where.go
@@ -213,11 +213,7 @@ func HasUser() predicate.Friendship {
 // HasUserWith applies the HasEdge predicate on the "user" edge with a given conditions (other predicates).
 func HasUserWith(preds ...predicate.User) predicate.Friendship {
 	return predicate.Friendship(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(UserInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, UserTable, UserColumn),
-		)
+		step := newUserStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -240,11 +236,7 @@ func HasFriend() predicate.Friendship {
 // HasFriendWith applies the HasEdge predicate on the "friend" edge with a given conditions (other predicates).
 func HasFriendWith(preds ...predicate.User) predicate.Friendship {
 	return predicate.Friendship(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(FriendInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, FriendTable, FriendColumn),
-		)
+		step := newFriendStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/edgeschema/ent/friendship_query.go
+++ b/entc/integration/edgeschema/ent/friendship_query.go
@@ -23,7 +23,7 @@ import (
 type FriendshipQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []friendship.Order
 	inters     []Interceptor
 	predicates []predicate.Friendship
 	withUser   *UserQuery
@@ -59,7 +59,7 @@ func (fq *FriendshipQuery) Unique(unique bool) *FriendshipQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (fq *FriendshipQuery) Order(o ...OrderFunc) *FriendshipQuery {
+func (fq *FriendshipQuery) Order(o ...friendship.Order) *FriendshipQuery {
 	fq.order = append(fq.order, o...)
 	return fq
 }
@@ -297,7 +297,7 @@ func (fq *FriendshipQuery) Clone() *FriendshipQuery {
 	return &FriendshipQuery{
 		config:     fq.config,
 		ctx:        fq.ctx.Clone(),
-		order:      append([]OrderFunc{}, fq.order...),
+		order:      append([]friendship.Order{}, fq.order...),
 		inters:     append([]Interceptor{}, fq.inters...),
 		predicates: append([]predicate.Friendship{}, fq.predicates...),
 		withUser:   fq.withUser.Clone(),

--- a/entc/integration/edgeschema/ent/group/group.go
+++ b/entc/integration/edgeschema/ent/group/group.go
@@ -6,6 +6,11 @@
 
 package group
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the group type in the database.
 	Label = "group"
@@ -78,3 +83,100 @@ var (
 	// DefaultName holds the default value on creation for the "name" field.
 	DefaultName string
 )
+
+// Order defines the ordering method for the Group queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByUsersCount orders the results by users count.
+func ByUsersCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newUsersStep(), opts...)
+	}
+}
+
+// ByUsers orders the results by users terms.
+func ByUsers(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newUsersStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByTagsCount orders the results by tags count.
+func ByTagsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newTagsStep(), opts...)
+	}
+}
+
+// ByTags orders the results by tags terms.
+func ByTags(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newTagsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByJoinedUsersCount orders the results by joined_users count.
+func ByJoinedUsersCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newJoinedUsersStep(), opts...)
+	}
+}
+
+// ByJoinedUsers orders the results by joined_users terms.
+func ByJoinedUsers(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newJoinedUsersStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByGroupTagsCount orders the results by group_tags count.
+func ByGroupTagsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newGroupTagsStep(), opts...)
+	}
+}
+
+// ByGroupTags orders the results by group_tags terms.
+func ByGroupTags(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newGroupTagsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newUsersStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(UsersInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, true, UsersTable, UsersPrimaryKey...),
+	)
+}
+func newTagsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(TagsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, true, TagsTable, TagsPrimaryKey...),
+	)
+}
+func newJoinedUsersStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(JoinedUsersInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, true, JoinedUsersTable, JoinedUsersColumn),
+	)
+}
+func newGroupTagsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(GroupTagsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, true, GroupTagsTable, GroupTagsColumn),
+	)
+}

--- a/entc/integration/edgeschema/ent/group/where.go
+++ b/entc/integration/edgeschema/ent/group/where.go
@@ -141,11 +141,7 @@ func HasUsers() predicate.Group {
 // HasUsersWith applies the HasEdge predicate on the "users" edge with a given conditions (other predicates).
 func HasUsersWith(preds ...predicate.User) predicate.Group {
 	return predicate.Group(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(UsersInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, true, UsersTable, UsersPrimaryKey...),
-		)
+		step := newUsersStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -168,11 +164,7 @@ func HasTags() predicate.Group {
 // HasTagsWith applies the HasEdge predicate on the "tags" edge with a given conditions (other predicates).
 func HasTagsWith(preds ...predicate.Tag) predicate.Group {
 	return predicate.Group(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(TagsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, true, TagsTable, TagsPrimaryKey...),
-		)
+		step := newTagsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -195,11 +187,7 @@ func HasJoinedUsers() predicate.Group {
 // HasJoinedUsersWith applies the HasEdge predicate on the "joined_users" edge with a given conditions (other predicates).
 func HasJoinedUsersWith(preds ...predicate.UserGroup) predicate.Group {
 	return predicate.Group(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(JoinedUsersInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, true, JoinedUsersTable, JoinedUsersColumn),
-		)
+		step := newJoinedUsersStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -222,11 +210,7 @@ func HasGroupTags() predicate.Group {
 // HasGroupTagsWith applies the HasEdge predicate on the "group_tags" edge with a given conditions (other predicates).
 func HasGroupTagsWith(preds ...predicate.GroupTag) predicate.Group {
 	return predicate.Group(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(GroupTagsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, true, GroupTagsTable, GroupTagsColumn),
-		)
+		step := newGroupTagsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/edgeschema/ent/group_query.go
+++ b/entc/integration/edgeschema/ent/group_query.go
@@ -27,7 +27,7 @@ import (
 type GroupQuery struct {
 	config
 	ctx             *QueryContext
-	order           []OrderFunc
+	order           []group.Order
 	inters          []Interceptor
 	predicates      []predicate.Group
 	withUsers       *UserQuery
@@ -65,7 +65,7 @@ func (gq *GroupQuery) Unique(unique bool) *GroupQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (gq *GroupQuery) Order(o ...OrderFunc) *GroupQuery {
+func (gq *GroupQuery) Order(o ...group.Order) *GroupQuery {
 	gq.order = append(gq.order, o...)
 	return gq
 }
@@ -347,7 +347,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 	return &GroupQuery{
 		config:          gq.config,
 		ctx:             gq.ctx.Clone(),
-		order:           append([]OrderFunc{}, gq.order...),
+		order:           append([]group.Order{}, gq.order...),
 		inters:          append([]Interceptor{}, gq.inters...),
 		predicates:      append([]predicate.Group{}, gq.predicates...),
 		withUsers:       gq.withUsers.Clone(),

--- a/entc/integration/edgeschema/ent/grouptag/grouptag.go
+++ b/entc/integration/edgeschema/ent/grouptag/grouptag.go
@@ -6,6 +6,11 @@
 
 package grouptag
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the grouptag type in the database.
 	Label = "group_tag"
@@ -52,4 +57,50 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the GroupTag queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByTagID orders the results by the tag_id field.
+func ByTagID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldTagID, opts...).ToFunc()
+}
+
+// ByGroupID orders the results by the group_id field.
+func ByGroupID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldGroupID, opts...).ToFunc()
+}
+
+// ByTagField orders the results by tag field.
+func ByTagField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newTagStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByGroupField orders the results by group field.
+func ByGroupField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newGroupStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newTagStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(TagInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, false, TagTable, TagColumn),
+	)
+}
+func newGroupStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(GroupInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, false, GroupTable, GroupColumn),
+	)
 }

--- a/entc/integration/edgeschema/ent/grouptag/where.go
+++ b/entc/integration/edgeschema/ent/grouptag/where.go
@@ -121,11 +121,7 @@ func HasTag() predicate.GroupTag {
 // HasTagWith applies the HasEdge predicate on the "tag" edge with a given conditions (other predicates).
 func HasTagWith(preds ...predicate.Tag) predicate.GroupTag {
 	return predicate.GroupTag(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(TagInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, TagTable, TagColumn),
-		)
+		step := newTagStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -148,11 +144,7 @@ func HasGroup() predicate.GroupTag {
 // HasGroupWith applies the HasEdge predicate on the "group" edge with a given conditions (other predicates).
 func HasGroupWith(preds ...predicate.Group) predicate.GroupTag {
 	return predicate.GroupTag(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(GroupInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, GroupTable, GroupColumn),
-		)
+		step := newGroupStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/edgeschema/ent/grouptag_query.go
+++ b/entc/integration/edgeschema/ent/grouptag_query.go
@@ -24,7 +24,7 @@ import (
 type GroupTagQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []grouptag.Order
 	inters     []Interceptor
 	predicates []predicate.GroupTag
 	withTag    *TagQuery
@@ -60,7 +60,7 @@ func (gtq *GroupTagQuery) Unique(unique bool) *GroupTagQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (gtq *GroupTagQuery) Order(o ...OrderFunc) *GroupTagQuery {
+func (gtq *GroupTagQuery) Order(o ...grouptag.Order) *GroupTagQuery {
 	gtq.order = append(gtq.order, o...)
 	return gtq
 }
@@ -298,7 +298,7 @@ func (gtq *GroupTagQuery) Clone() *GroupTagQuery {
 	return &GroupTagQuery{
 		config:     gtq.config,
 		ctx:        gtq.ctx.Clone(),
-		order:      append([]OrderFunc{}, gtq.order...),
+		order:      append([]grouptag.Order{}, gtq.order...),
 		inters:     append([]Interceptor{}, gtq.inters...),
 		predicates: append([]predicate.GroupTag{}, gtq.predicates...),
 		withTag:    gtq.withTag.Clone(),

--- a/entc/integration/edgeschema/ent/process/where.go
+++ b/entc/integration/edgeschema/ent/process/where.go
@@ -71,11 +71,7 @@ func HasFiles() predicate.Process {
 // HasFilesWith applies the HasEdge predicate on the "files" edge with a given conditions (other predicates).
 func HasFilesWith(preds ...predicate.File) predicate.Process {
 	return predicate.Process(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(FilesInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, FilesTable, FilesPrimaryKey...),
-		)
+		step := newFilesStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -98,11 +94,7 @@ func HasAttachedFiles() predicate.Process {
 // HasAttachedFilesWith applies the HasEdge predicate on the "attached_files" edge with a given conditions (other predicates).
 func HasAttachedFilesWith(preds ...predicate.AttachedFile) predicate.Process {
 	return predicate.Process(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(AttachedFilesInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, true, AttachedFilesTable, AttachedFilesColumn),
-		)
+		step := newAttachedFilesStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/edgeschema/ent/process_query.go
+++ b/entc/integration/edgeschema/ent/process_query.go
@@ -25,7 +25,7 @@ import (
 type ProcessQuery struct {
 	config
 	ctx               *QueryContext
-	order             []OrderFunc
+	order             []process.Order
 	inters            []Interceptor
 	predicates        []predicate.Process
 	withFiles         *FileQuery
@@ -61,7 +61,7 @@ func (pq *ProcessQuery) Unique(unique bool) *ProcessQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (pq *ProcessQuery) Order(o ...OrderFunc) *ProcessQuery {
+func (pq *ProcessQuery) Order(o ...process.Order) *ProcessQuery {
 	pq.order = append(pq.order, o...)
 	return pq
 }
@@ -299,7 +299,7 @@ func (pq *ProcessQuery) Clone() *ProcessQuery {
 	return &ProcessQuery{
 		config:            pq.config,
 		ctx:               pq.ctx.Clone(),
-		order:             append([]OrderFunc{}, pq.order...),
+		order:             append([]process.Order{}, pq.order...),
 		inters:            append([]Interceptor{}, pq.inters...),
 		predicates:        append([]predicate.Process{}, pq.predicates...),
 		withFiles:         pq.withFiles.Clone(),

--- a/entc/integration/edgeschema/ent/relationship/relationship.go
+++ b/entc/integration/edgeschema/ent/relationship/relationship.go
@@ -8,6 +8,8 @@ package relationship
 
 import (
 	"entgo.io/ent"
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
 )
 
 const (
@@ -85,3 +87,68 @@ var (
 	// DefaultWeight holds the default value on creation for the "weight" field.
 	DefaultWeight int
 )
+
+// Order defines the ordering method for the Relationship queries.
+type Order func(*sql.Selector)
+
+// ByWeight orders the results by the weight field.
+func ByWeight(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldWeight, opts...).ToFunc()
+}
+
+// ByUserID orders the results by the user_id field.
+func ByUserID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldUserID, opts...).ToFunc()
+}
+
+// ByRelativeID orders the results by the relative_id field.
+func ByRelativeID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldRelativeID, opts...).ToFunc()
+}
+
+// ByInfoID orders the results by the info_id field.
+func ByInfoID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldInfoID, opts...).ToFunc()
+}
+
+// ByUserField orders the results by user field.
+func ByUserField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newUserStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByRelativeField orders the results by relative field.
+func ByRelativeField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newRelativeStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByInfoField orders the results by info field.
+func ByInfoField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newInfoStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newUserStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, UserColumn),
+		sqlgraph.To(UserInverseTable, UserFieldID),
+		sqlgraph.Edge(sqlgraph.M2O, false, UserTable, UserColumn),
+	)
+}
+func newRelativeStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, RelativeColumn),
+		sqlgraph.To(RelativeInverseTable, UserFieldID),
+		sqlgraph.Edge(sqlgraph.M2O, false, RelativeTable, RelativeColumn),
+	)
+}
+func newInfoStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, InfoColumn),
+		sqlgraph.To(InfoInverseTable, RelationshipInfoFieldID),
+		sqlgraph.Edge(sqlgraph.M2O, false, InfoTable, InfoColumn),
+	)
+}

--- a/entc/integration/edgeschema/ent/relationship/where.go
+++ b/entc/integration/edgeschema/ent/relationship/where.go
@@ -156,11 +156,7 @@ func HasUser() predicate.Relationship {
 // HasUserWith applies the HasEdge predicate on the "user" edge with a given conditions (other predicates).
 func HasUserWith(preds ...predicate.User) predicate.Relationship {
 	return predicate.Relationship(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, UserColumn),
-			sqlgraph.To(UserInverseTable, UserFieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, UserTable, UserColumn),
-		)
+		step := newUserStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -183,11 +179,7 @@ func HasRelative() predicate.Relationship {
 // HasRelativeWith applies the HasEdge predicate on the "relative" edge with a given conditions (other predicates).
 func HasRelativeWith(preds ...predicate.User) predicate.Relationship {
 	return predicate.Relationship(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, RelativeColumn),
-			sqlgraph.To(RelativeInverseTable, UserFieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, RelativeTable, RelativeColumn),
-		)
+		step := newRelativeStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -210,11 +202,7 @@ func HasInfo() predicate.Relationship {
 // HasInfoWith applies the HasEdge predicate on the "info" edge with a given conditions (other predicates).
 func HasInfoWith(preds ...predicate.RelationshipInfo) predicate.Relationship {
 	return predicate.Relationship(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, InfoColumn),
-			sqlgraph.To(InfoInverseTable, RelationshipInfoFieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, InfoTable, InfoColumn),
-		)
+		step := newInfoStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/edgeschema/ent/relationship_query.go
+++ b/entc/integration/edgeschema/ent/relationship_query.go
@@ -24,7 +24,7 @@ import (
 type RelationshipQuery struct {
 	config
 	ctx          *QueryContext
-	order        []OrderFunc
+	order        []relationship.Order
 	inters       []Interceptor
 	predicates   []predicate.Relationship
 	withUser     *UserQuery
@@ -61,7 +61,7 @@ func (rq *RelationshipQuery) Unique(unique bool) *RelationshipQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (rq *RelationshipQuery) Order(o ...OrderFunc) *RelationshipQuery {
+func (rq *RelationshipQuery) Order(o ...relationship.Order) *RelationshipQuery {
 	rq.order = append(rq.order, o...)
 	return rq
 }
@@ -249,7 +249,7 @@ func (rq *RelationshipQuery) Clone() *RelationshipQuery {
 	return &RelationshipQuery{
 		config:       rq.config,
 		ctx:          rq.ctx.Clone(),
-		order:        append([]OrderFunc{}, rq.order...),
+		order:        append([]relationship.Order{}, rq.order...),
 		inters:       append([]Interceptor{}, rq.inters...),
 		predicates:   append([]predicate.Relationship{}, rq.predicates...),
 		withUser:     rq.withUser.Clone(),

--- a/entc/integration/edgeschema/ent/relationshipinfo/relationshipinfo.go
+++ b/entc/integration/edgeschema/ent/relationshipinfo/relationshipinfo.go
@@ -6,6 +6,10 @@
 
 package relationshipinfo
 
+import (
+	"entgo.io/ent/dialect/sql"
+)
+
 const (
 	// Label holds the string label denoting the relationshipinfo type in the database.
 	Label = "relationship_info"
@@ -31,4 +35,17 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the RelationshipInfo queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByText orders the results by the text field.
+func ByText(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldText, opts...).ToFunc()
 }

--- a/entc/integration/edgeschema/ent/relationshipinfo_query.go
+++ b/entc/integration/edgeschema/ent/relationshipinfo_query.go
@@ -22,7 +22,7 @@ import (
 type RelationshipInfoQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []relationshipinfo.Order
 	inters     []Interceptor
 	predicates []predicate.RelationshipInfo
 	// intermediate query (i.e. traversal path).
@@ -56,7 +56,7 @@ func (riq *RelationshipInfoQuery) Unique(unique bool) *RelationshipInfoQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (riq *RelationshipInfoQuery) Order(o ...OrderFunc) *RelationshipInfoQuery {
+func (riq *RelationshipInfoQuery) Order(o ...relationshipinfo.Order) *RelationshipInfoQuery {
 	riq.order = append(riq.order, o...)
 	return riq
 }
@@ -250,7 +250,7 @@ func (riq *RelationshipInfoQuery) Clone() *RelationshipInfoQuery {
 	return &RelationshipInfoQuery{
 		config:     riq.config,
 		ctx:        riq.ctx.Clone(),
-		order:      append([]OrderFunc{}, riq.order...),
+		order:      append([]relationshipinfo.Order{}, riq.order...),
 		inters:     append([]Interceptor{}, riq.inters...),
 		predicates: append([]predicate.RelationshipInfo{}, riq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/edgeschema/ent/role/where.go
+++ b/entc/integration/edgeschema/ent/role/where.go
@@ -188,11 +188,7 @@ func HasUser() predicate.Role {
 // HasUserWith applies the HasEdge predicate on the "user" edge with a given conditions (other predicates).
 func HasUserWith(preds ...predicate.User) predicate.Role {
 	return predicate.Role(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(UserInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, true, UserTable, UserPrimaryKey...),
-		)
+		step := newUserStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -215,11 +211,7 @@ func HasRolesUsers() predicate.Role {
 // HasRolesUsersWith applies the HasEdge predicate on the "roles_users" edge with a given conditions (other predicates).
 func HasRolesUsersWith(preds ...predicate.RoleUser) predicate.Role {
 	return predicate.Role(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(RolesUsersInverseTable, RolesUsersColumn),
-			sqlgraph.Edge(sqlgraph.O2M, true, RolesUsersTable, RolesUsersColumn),
-		)
+		step := newRolesUsersStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/edgeschema/ent/role_query.go
+++ b/entc/integration/edgeschema/ent/role_query.go
@@ -25,7 +25,7 @@ import (
 type RoleQuery struct {
 	config
 	ctx            *QueryContext
-	order          []OrderFunc
+	order          []role.Order
 	inters         []Interceptor
 	predicates     []predicate.Role
 	withUser       *UserQuery
@@ -61,7 +61,7 @@ func (rq *RoleQuery) Unique(unique bool) *RoleQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (rq *RoleQuery) Order(o ...OrderFunc) *RoleQuery {
+func (rq *RoleQuery) Order(o ...role.Order) *RoleQuery {
 	rq.order = append(rq.order, o...)
 	return rq
 }
@@ -299,7 +299,7 @@ func (rq *RoleQuery) Clone() *RoleQuery {
 	return &RoleQuery{
 		config:         rq.config,
 		ctx:            rq.ctx.Clone(),
-		order:          append([]OrderFunc{}, rq.order...),
+		order:          append([]role.Order{}, rq.order...),
 		inters:         append([]Interceptor{}, rq.inters...),
 		predicates:     append([]predicate.Role{}, rq.predicates...),
 		withUser:       rq.withUser.Clone(),

--- a/entc/integration/edgeschema/ent/roleuser/roleuser.go
+++ b/entc/integration/edgeschema/ent/roleuser/roleuser.go
@@ -8,6 +8,9 @@ package roleuser
 
 import (
 	"time"
+
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
 )
 
 const (
@@ -66,3 +69,49 @@ var (
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time
 )
+
+// Order defines the ordering method for the RoleUser queries.
+type Order func(*sql.Selector)
+
+// ByCreatedAt orders the results by the created_at field.
+func ByCreatedAt(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldCreatedAt, opts...).ToFunc()
+}
+
+// ByRoleID orders the results by the role_id field.
+func ByRoleID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldRoleID, opts...).ToFunc()
+}
+
+// ByUserID orders the results by the user_id field.
+func ByUserID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldUserID, opts...).ToFunc()
+}
+
+// ByRoleField orders the results by role field.
+func ByRoleField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newRoleStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByUserField orders the results by user field.
+func ByUserField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newUserStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newRoleStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, RoleColumn),
+		sqlgraph.To(RoleInverseTable, RoleFieldID),
+		sqlgraph.Edge(sqlgraph.M2O, false, RoleTable, RoleColumn),
+	)
+}
+func newUserStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, UserColumn),
+		sqlgraph.To(UserInverseTable, UserFieldID),
+		sqlgraph.Edge(sqlgraph.M2O, false, UserTable, UserColumn),
+	)
+}

--- a/entc/integration/edgeschema/ent/roleuser/where.go
+++ b/entc/integration/edgeschema/ent/roleuser/where.go
@@ -123,11 +123,7 @@ func HasRole() predicate.RoleUser {
 // HasRoleWith applies the HasEdge predicate on the "role" edge with a given conditions (other predicates).
 func HasRoleWith(preds ...predicate.Role) predicate.RoleUser {
 	return predicate.RoleUser(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, RoleColumn),
-			sqlgraph.To(RoleInverseTable, RoleFieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, RoleTable, RoleColumn),
-		)
+		step := newRoleStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -150,11 +146,7 @@ func HasUser() predicate.RoleUser {
 // HasUserWith applies the HasEdge predicate on the "user" edge with a given conditions (other predicates).
 func HasUserWith(preds ...predicate.User) predicate.RoleUser {
 	return predicate.RoleUser(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, UserColumn),
-			sqlgraph.To(UserInverseTable, UserFieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, UserTable, UserColumn),
-		)
+		step := newUserStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/edgeschema/ent/roleuser_query.go
+++ b/entc/integration/edgeschema/ent/roleuser_query.go
@@ -23,7 +23,7 @@ import (
 type RoleUserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []roleuser.Order
 	inters     []Interceptor
 	predicates []predicate.RoleUser
 	withRole   *RoleQuery
@@ -59,7 +59,7 @@ func (ruq *RoleUserQuery) Unique(unique bool) *RoleUserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (ruq *RoleUserQuery) Order(o ...OrderFunc) *RoleUserQuery {
+func (ruq *RoleUserQuery) Order(o ...roleuser.Order) *RoleUserQuery {
 	ruq.order = append(ruq.order, o...)
 	return ruq
 }
@@ -225,7 +225,7 @@ func (ruq *RoleUserQuery) Clone() *RoleUserQuery {
 	return &RoleUserQuery{
 		config:     ruq.config,
 		ctx:        ruq.ctx.Clone(),
-		order:      append([]OrderFunc{}, ruq.order...),
+		order:      append([]roleuser.Order{}, ruq.order...),
 		inters:     append([]Interceptor{}, ruq.inters...),
 		predicates: append([]predicate.RoleUser{}, ruq.predicates...),
 		withRole:   ruq.withRole.Clone(),

--- a/entc/integration/edgeschema/ent/tag/tag.go
+++ b/entc/integration/edgeschema/ent/tag/tag.go
@@ -6,6 +6,11 @@
 
 package tag
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the tag type in the database.
 	Label = "tag"
@@ -72,4 +77,101 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Tag queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByValue orders the results by the value field.
+func ByValue(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldValue, opts...).ToFunc()
+}
+
+// ByTweetsCount orders the results by tweets count.
+func ByTweetsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newTweetsStep(), opts...)
+	}
+}
+
+// ByTweets orders the results by tweets terms.
+func ByTweets(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newTweetsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByGroupsCount orders the results by groups count.
+func ByGroupsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newGroupsStep(), opts...)
+	}
+}
+
+// ByGroups orders the results by groups terms.
+func ByGroups(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newGroupsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByTweetTagsCount orders the results by tweet_tags count.
+func ByTweetTagsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newTweetTagsStep(), opts...)
+	}
+}
+
+// ByTweetTags orders the results by tweet_tags terms.
+func ByTweetTags(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newTweetTagsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByGroupTagsCount orders the results by group_tags count.
+func ByGroupTagsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newGroupTagsStep(), opts...)
+	}
+}
+
+// ByGroupTags orders the results by group_tags terms.
+func ByGroupTags(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newGroupTagsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newTweetsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(TweetsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, TweetsTable, TweetsPrimaryKey...),
+	)
+}
+func newGroupsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(GroupsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, GroupsTable, GroupsPrimaryKey...),
+	)
+}
+func newTweetTagsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(TweetTagsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, true, TweetTagsTable, TweetTagsColumn),
+	)
+}
+func newGroupTagsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(GroupTagsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, true, GroupTagsTable, GroupTagsColumn),
+	)
 }

--- a/entc/integration/edgeschema/ent/tag/where.go
+++ b/entc/integration/edgeschema/ent/tag/where.go
@@ -141,11 +141,7 @@ func HasTweets() predicate.Tag {
 // HasTweetsWith applies the HasEdge predicate on the "tweets" edge with a given conditions (other predicates).
 func HasTweetsWith(preds ...predicate.Tweet) predicate.Tag {
 	return predicate.Tag(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(TweetsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, TweetsTable, TweetsPrimaryKey...),
-		)
+		step := newTweetsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -168,11 +164,7 @@ func HasGroups() predicate.Tag {
 // HasGroupsWith applies the HasEdge predicate on the "groups" edge with a given conditions (other predicates).
 func HasGroupsWith(preds ...predicate.Group) predicate.Tag {
 	return predicate.Tag(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(GroupsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, GroupsTable, GroupsPrimaryKey...),
-		)
+		step := newGroupsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -195,11 +187,7 @@ func HasTweetTags() predicate.Tag {
 // HasTweetTagsWith applies the HasEdge predicate on the "tweet_tags" edge with a given conditions (other predicates).
 func HasTweetTagsWith(preds ...predicate.TweetTag) predicate.Tag {
 	return predicate.Tag(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(TweetTagsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, true, TweetTagsTable, TweetTagsColumn),
-		)
+		step := newTweetTagsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -222,11 +210,7 @@ func HasGroupTags() predicate.Tag {
 // HasGroupTagsWith applies the HasEdge predicate on the "group_tags" edge with a given conditions (other predicates).
 func HasGroupTagsWith(preds ...predicate.GroupTag) predicate.Tag {
 	return predicate.Tag(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(GroupTagsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, true, GroupTagsTable, GroupTagsColumn),
-		)
+		step := newGroupTagsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/edgeschema/ent/tag_query.go
+++ b/entc/integration/edgeschema/ent/tag_query.go
@@ -27,7 +27,7 @@ import (
 type TagQuery struct {
 	config
 	ctx           *QueryContext
-	order         []OrderFunc
+	order         []tag.Order
 	inters        []Interceptor
 	predicates    []predicate.Tag
 	withTweets    *TweetQuery
@@ -65,7 +65,7 @@ func (tq *TagQuery) Unique(unique bool) *TagQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (tq *TagQuery) Order(o ...OrderFunc) *TagQuery {
+func (tq *TagQuery) Order(o ...tag.Order) *TagQuery {
 	tq.order = append(tq.order, o...)
 	return tq
 }
@@ -347,7 +347,7 @@ func (tq *TagQuery) Clone() *TagQuery {
 	return &TagQuery{
 		config:        tq.config,
 		ctx:           tq.ctx.Clone(),
-		order:         append([]OrderFunc{}, tq.order...),
+		order:         append([]tag.Order{}, tq.order...),
 		inters:        append([]Interceptor{}, tq.inters...),
 		predicates:    append([]predicate.Tag{}, tq.predicates...),
 		withTweets:    tq.withTweets.Clone(),

--- a/entc/integration/edgeschema/ent/tweet/tweet.go
+++ b/entc/integration/edgeschema/ent/tweet/tweet.go
@@ -6,6 +6,11 @@
 
 package tweet
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the tweet type in the database.
 	Label = "tweet"
@@ -91,4 +96,143 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Tweet queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByText orders the results by the text field.
+func ByText(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldText, opts...).ToFunc()
+}
+
+// ByLikedUsersCount orders the results by liked_users count.
+func ByLikedUsersCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newLikedUsersStep(), opts...)
+	}
+}
+
+// ByLikedUsers orders the results by liked_users terms.
+func ByLikedUsers(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newLikedUsersStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByUserCount orders the results by user count.
+func ByUserCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newUserStep(), opts...)
+	}
+}
+
+// ByUser orders the results by user terms.
+func ByUser(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newUserStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByTagsCount orders the results by tags count.
+func ByTagsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newTagsStep(), opts...)
+	}
+}
+
+// ByTags orders the results by tags terms.
+func ByTags(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newTagsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByLikesCount orders the results by likes count.
+func ByLikesCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newLikesStep(), opts...)
+	}
+}
+
+// ByLikes orders the results by likes terms.
+func ByLikes(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newLikesStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByTweetUserCount orders the results by tweet_user count.
+func ByTweetUserCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newTweetUserStep(), opts...)
+	}
+}
+
+// ByTweetUser orders the results by tweet_user terms.
+func ByTweetUser(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newTweetUserStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByTweetTagsCount orders the results by tweet_tags count.
+func ByTweetTagsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newTweetTagsStep(), opts...)
+	}
+}
+
+// ByTweetTags orders the results by tweet_tags terms.
+func ByTweetTags(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newTweetTagsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newLikedUsersStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(LikedUsersInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, true, LikedUsersTable, LikedUsersPrimaryKey...),
+	)
+}
+func newUserStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(UserInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, true, UserTable, UserPrimaryKey...),
+	)
+}
+func newTagsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(TagsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, true, TagsTable, TagsPrimaryKey...),
+	)
+}
+func newLikesStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(LikesInverseTable, LikesColumn),
+		sqlgraph.Edge(sqlgraph.O2M, true, LikesTable, LikesColumn),
+	)
+}
+func newTweetUserStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(TweetUserInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, true, TweetUserTable, TweetUserColumn),
+	)
+}
+func newTweetTagsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(TweetTagsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, true, TweetTagsTable, TweetTagsColumn),
+	)
 }

--- a/entc/integration/edgeschema/ent/tweet/where.go
+++ b/entc/integration/edgeschema/ent/tweet/where.go
@@ -141,11 +141,7 @@ func HasLikedUsers() predicate.Tweet {
 // HasLikedUsersWith applies the HasEdge predicate on the "liked_users" edge with a given conditions (other predicates).
 func HasLikedUsersWith(preds ...predicate.User) predicate.Tweet {
 	return predicate.Tweet(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(LikedUsersInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, true, LikedUsersTable, LikedUsersPrimaryKey...),
-		)
+		step := newLikedUsersStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -168,11 +164,7 @@ func HasUser() predicate.Tweet {
 // HasUserWith applies the HasEdge predicate on the "user" edge with a given conditions (other predicates).
 func HasUserWith(preds ...predicate.User) predicate.Tweet {
 	return predicate.Tweet(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(UserInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, true, UserTable, UserPrimaryKey...),
-		)
+		step := newUserStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -195,11 +187,7 @@ func HasTags() predicate.Tweet {
 // HasTagsWith applies the HasEdge predicate on the "tags" edge with a given conditions (other predicates).
 func HasTagsWith(preds ...predicate.Tag) predicate.Tweet {
 	return predicate.Tweet(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(TagsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, true, TagsTable, TagsPrimaryKey...),
-		)
+		step := newTagsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -222,11 +210,7 @@ func HasLikes() predicate.Tweet {
 // HasLikesWith applies the HasEdge predicate on the "likes" edge with a given conditions (other predicates).
 func HasLikesWith(preds ...predicate.TweetLike) predicate.Tweet {
 	return predicate.Tweet(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(LikesInverseTable, LikesColumn),
-			sqlgraph.Edge(sqlgraph.O2M, true, LikesTable, LikesColumn),
-		)
+		step := newLikesStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -249,11 +233,7 @@ func HasTweetUser() predicate.Tweet {
 // HasTweetUserWith applies the HasEdge predicate on the "tweet_user" edge with a given conditions (other predicates).
 func HasTweetUserWith(preds ...predicate.UserTweet) predicate.Tweet {
 	return predicate.Tweet(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(TweetUserInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, true, TweetUserTable, TweetUserColumn),
-		)
+		step := newTweetUserStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -276,11 +256,7 @@ func HasTweetTags() predicate.Tweet {
 // HasTweetTagsWith applies the HasEdge predicate on the "tweet_tags" edge with a given conditions (other predicates).
 func HasTweetTagsWith(preds ...predicate.TweetTag) predicate.Tweet {
 	return predicate.Tweet(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(TweetTagsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, true, TweetTagsTable, TweetTagsColumn),
-		)
+		step := newTweetTagsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/edgeschema/ent/tweet_query.go
+++ b/entc/integration/edgeschema/ent/tweet_query.go
@@ -28,7 +28,7 @@ import (
 type TweetQuery struct {
 	config
 	ctx            *QueryContext
-	order          []OrderFunc
+	order          []tweet.Order
 	inters         []Interceptor
 	predicates     []predicate.Tweet
 	withLikedUsers *UserQuery
@@ -68,7 +68,7 @@ func (tq *TweetQuery) Unique(unique bool) *TweetQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (tq *TweetQuery) Order(o ...OrderFunc) *TweetQuery {
+func (tq *TweetQuery) Order(o ...tweet.Order) *TweetQuery {
 	tq.order = append(tq.order, o...)
 	return tq
 }
@@ -394,7 +394,7 @@ func (tq *TweetQuery) Clone() *TweetQuery {
 	return &TweetQuery{
 		config:         tq.config,
 		ctx:            tq.ctx.Clone(),
-		order:          append([]OrderFunc{}, tq.order...),
+		order:          append([]tweet.Order{}, tq.order...),
 		inters:         append([]Interceptor{}, tq.inters...),
 		predicates:     append([]predicate.Tweet{}, tq.predicates...),
 		withLikedUsers: tq.withLikedUsers.Clone(),

--- a/entc/integration/edgeschema/ent/tweetlike/tweetlike.go
+++ b/entc/integration/edgeschema/ent/tweetlike/tweetlike.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"entgo.io/ent"
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
 )
 
 const (
@@ -75,3 +77,49 @@ var (
 	// DefaultLikedAt holds the default value on creation for the "liked_at" field.
 	DefaultLikedAt func() time.Time
 )
+
+// Order defines the ordering method for the TweetLike queries.
+type Order func(*sql.Selector)
+
+// ByLikedAt orders the results by the liked_at field.
+func ByLikedAt(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldLikedAt, opts...).ToFunc()
+}
+
+// ByUserID orders the results by the user_id field.
+func ByUserID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldUserID, opts...).ToFunc()
+}
+
+// ByTweetID orders the results by the tweet_id field.
+func ByTweetID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldTweetID, opts...).ToFunc()
+}
+
+// ByTweetField orders the results by tweet field.
+func ByTweetField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newTweetStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByUserField orders the results by user field.
+func ByUserField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newUserStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newTweetStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, TweetColumn),
+		sqlgraph.To(TweetInverseTable, TweetFieldID),
+		sqlgraph.Edge(sqlgraph.M2O, false, TweetTable, TweetColumn),
+	)
+}
+func newUserStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, UserColumn),
+		sqlgraph.To(UserInverseTable, UserFieldID),
+		sqlgraph.Edge(sqlgraph.M2O, false, UserTable, UserColumn),
+	)
+}

--- a/entc/integration/edgeschema/ent/tweetlike/where.go
+++ b/entc/integration/edgeschema/ent/tweetlike/where.go
@@ -123,11 +123,7 @@ func HasTweet() predicate.TweetLike {
 // HasTweetWith applies the HasEdge predicate on the "tweet" edge with a given conditions (other predicates).
 func HasTweetWith(preds ...predicate.Tweet) predicate.TweetLike {
 	return predicate.TweetLike(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, TweetColumn),
-			sqlgraph.To(TweetInverseTable, TweetFieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, TweetTable, TweetColumn),
-		)
+		step := newTweetStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -150,11 +146,7 @@ func HasUser() predicate.TweetLike {
 // HasUserWith applies the HasEdge predicate on the "user" edge with a given conditions (other predicates).
 func HasUserWith(preds ...predicate.User) predicate.TweetLike {
 	return predicate.TweetLike(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, UserColumn),
-			sqlgraph.To(UserInverseTable, UserFieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, UserTable, UserColumn),
-		)
+		step := newUserStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/edgeschema/ent/tweetlike_query.go
+++ b/entc/integration/edgeschema/ent/tweetlike_query.go
@@ -24,7 +24,7 @@ import (
 type TweetLikeQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []tweetlike.Order
 	inters     []Interceptor
 	predicates []predicate.TweetLike
 	withTweet  *TweetQuery
@@ -60,7 +60,7 @@ func (tlq *TweetLikeQuery) Unique(unique bool) *TweetLikeQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (tlq *TweetLikeQuery) Order(o ...OrderFunc) *TweetLikeQuery {
+func (tlq *TweetLikeQuery) Order(o ...tweetlike.Order) *TweetLikeQuery {
 	tlq.order = append(tlq.order, o...)
 	return tlq
 }
@@ -226,7 +226,7 @@ func (tlq *TweetLikeQuery) Clone() *TweetLikeQuery {
 	return &TweetLikeQuery{
 		config:     tlq.config,
 		ctx:        tlq.ctx.Clone(),
-		order:      append([]OrderFunc{}, tlq.order...),
+		order:      append([]tweetlike.Order{}, tlq.order...),
 		inters:     append([]Interceptor{}, tlq.inters...),
 		predicates: append([]predicate.TweetLike{}, tlq.predicates...),
 		withTweet:  tlq.withTweet.Clone(),

--- a/entc/integration/edgeschema/ent/tweettag/tweettag.go
+++ b/entc/integration/edgeschema/ent/tweettag/tweettag.go
@@ -9,6 +9,8 @@ package tweettag
 import (
 	"time"
 
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
 	"github.com/google/uuid"
 )
 
@@ -69,3 +71,54 @@ var (
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() uuid.UUID
 )
+
+// Order defines the ordering method for the TweetTag queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByAddedAt orders the results by the added_at field.
+func ByAddedAt(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldAddedAt, opts...).ToFunc()
+}
+
+// ByTagID orders the results by the tag_id field.
+func ByTagID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldTagID, opts...).ToFunc()
+}
+
+// ByTweetID orders the results by the tweet_id field.
+func ByTweetID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldTweetID, opts...).ToFunc()
+}
+
+// ByTagField orders the results by tag field.
+func ByTagField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newTagStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByTweetField orders the results by tweet field.
+func ByTweetField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newTweetStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newTagStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(TagInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, false, TagTable, TagColumn),
+	)
+}
+func newTweetStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(TweetInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, false, TweetTable, TweetColumn),
+	)
+}

--- a/entc/integration/edgeschema/ent/tweettag/where.go
+++ b/entc/integration/edgeschema/ent/tweettag/where.go
@@ -169,11 +169,7 @@ func HasTag() predicate.TweetTag {
 // HasTagWith applies the HasEdge predicate on the "tag" edge with a given conditions (other predicates).
 func HasTagWith(preds ...predicate.Tag) predicate.TweetTag {
 	return predicate.TweetTag(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(TagInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, TagTable, TagColumn),
-		)
+		step := newTagStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -196,11 +192,7 @@ func HasTweet() predicate.TweetTag {
 // HasTweetWith applies the HasEdge predicate on the "tweet" edge with a given conditions (other predicates).
 func HasTweetWith(preds ...predicate.Tweet) predicate.TweetTag {
 	return predicate.TweetTag(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(TweetInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, TweetTable, TweetColumn),
-		)
+		step := newTweetStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/edgeschema/ent/tweettag_query.go
+++ b/entc/integration/edgeschema/ent/tweettag_query.go
@@ -25,7 +25,7 @@ import (
 type TweetTagQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []tweettag.Order
 	inters     []Interceptor
 	predicates []predicate.TweetTag
 	withTag    *TagQuery
@@ -61,7 +61,7 @@ func (ttq *TweetTagQuery) Unique(unique bool) *TweetTagQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (ttq *TweetTagQuery) Order(o ...OrderFunc) *TweetTagQuery {
+func (ttq *TweetTagQuery) Order(o ...tweettag.Order) *TweetTagQuery {
 	ttq.order = append(ttq.order, o...)
 	return ttq
 }
@@ -299,7 +299,7 @@ func (ttq *TweetTagQuery) Clone() *TweetTagQuery {
 	return &TweetTagQuery{
 		config:     ttq.config,
 		ctx:        ttq.ctx.Clone(),
-		order:      append([]OrderFunc{}, ttq.order...),
+		order:      append([]tweettag.Order{}, ttq.order...),
 		inters:     append([]Interceptor{}, ttq.inters...),
 		predicates: append([]predicate.TweetTag{}, ttq.predicates...),
 		withTag:    ttq.withTag.Clone(),

--- a/entc/integration/edgeschema/ent/user/user.go
+++ b/entc/integration/edgeschema/ent/user/user.go
@@ -8,6 +8,8 @@ package user
 
 import (
 	"entgo.io/ent"
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
 )
 
 const (
@@ -159,3 +161,268 @@ var (
 	// DefaultName holds the default value on creation for the "name" field.
 	DefaultName string
 )
+
+// Order defines the ordering method for the User queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByGroupsCount orders the results by groups count.
+func ByGroupsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newGroupsStep(), opts...)
+	}
+}
+
+// ByGroups orders the results by groups terms.
+func ByGroups(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newGroupsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByFriendsCount orders the results by friends count.
+func ByFriendsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newFriendsStep(), opts...)
+	}
+}
+
+// ByFriends orders the results by friends terms.
+func ByFriends(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newFriendsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByRelativesCount orders the results by relatives count.
+func ByRelativesCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newRelativesStep(), opts...)
+	}
+}
+
+// ByRelatives orders the results by relatives terms.
+func ByRelatives(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newRelativesStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByLikedTweetsCount orders the results by liked_tweets count.
+func ByLikedTweetsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newLikedTweetsStep(), opts...)
+	}
+}
+
+// ByLikedTweets orders the results by liked_tweets terms.
+func ByLikedTweets(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newLikedTweetsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByTweetsCount orders the results by tweets count.
+func ByTweetsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newTweetsStep(), opts...)
+	}
+}
+
+// ByTweets orders the results by tweets terms.
+func ByTweets(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newTweetsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByRolesCount orders the results by roles count.
+func ByRolesCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newRolesStep(), opts...)
+	}
+}
+
+// ByRoles orders the results by roles terms.
+func ByRoles(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newRolesStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByJoinedGroupsCount orders the results by joined_groups count.
+func ByJoinedGroupsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newJoinedGroupsStep(), opts...)
+	}
+}
+
+// ByJoinedGroups orders the results by joined_groups terms.
+func ByJoinedGroups(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newJoinedGroupsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByFriendshipsCount orders the results by friendships count.
+func ByFriendshipsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newFriendshipsStep(), opts...)
+	}
+}
+
+// ByFriendships orders the results by friendships terms.
+func ByFriendships(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newFriendshipsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByRelationshipCount orders the results by relationship count.
+func ByRelationshipCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newRelationshipStep(), opts...)
+	}
+}
+
+// ByRelationship orders the results by relationship terms.
+func ByRelationship(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newRelationshipStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByLikesCount orders the results by likes count.
+func ByLikesCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newLikesStep(), opts...)
+	}
+}
+
+// ByLikes orders the results by likes terms.
+func ByLikes(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newLikesStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByUserTweetsCount orders the results by user_tweets count.
+func ByUserTweetsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newUserTweetsStep(), opts...)
+	}
+}
+
+// ByUserTweets orders the results by user_tweets terms.
+func ByUserTweets(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newUserTweetsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByRolesUsersCount orders the results by roles_users count.
+func ByRolesUsersCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newRolesUsersStep(), opts...)
+	}
+}
+
+// ByRolesUsers orders the results by roles_users terms.
+func ByRolesUsers(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newRolesUsersStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newGroupsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(GroupsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, GroupsTable, GroupsPrimaryKey...),
+	)
+}
+func newFriendsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, FriendsTable, FriendsPrimaryKey...),
+	)
+}
+func newRelativesStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, RelativesTable, RelativesPrimaryKey...),
+	)
+}
+func newLikedTweetsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(LikedTweetsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, LikedTweetsTable, LikedTweetsPrimaryKey...),
+	)
+}
+func newTweetsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(TweetsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, TweetsTable, TweetsPrimaryKey...),
+	)
+}
+func newRolesStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(RolesInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, RolesTable, RolesPrimaryKey...),
+	)
+}
+func newJoinedGroupsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(JoinedGroupsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, true, JoinedGroupsTable, JoinedGroupsColumn),
+	)
+}
+func newFriendshipsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(FriendshipsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, true, FriendshipsTable, FriendshipsColumn),
+	)
+}
+func newRelationshipStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(RelationshipInverseTable, RelationshipColumn),
+		sqlgraph.Edge(sqlgraph.O2M, true, RelationshipTable, RelationshipColumn),
+	)
+}
+func newLikesStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(LikesInverseTable, LikesColumn),
+		sqlgraph.Edge(sqlgraph.O2M, true, LikesTable, LikesColumn),
+	)
+}
+func newUserTweetsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(UserTweetsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, true, UserTweetsTable, UserTweetsColumn),
+	)
+}
+func newRolesUsersStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(RolesUsersInverseTable, RolesUsersColumn),
+		sqlgraph.Edge(sqlgraph.O2M, true, RolesUsersTable, RolesUsersColumn),
+	)
+}

--- a/entc/integration/edgeschema/ent/user/where.go
+++ b/entc/integration/edgeschema/ent/user/where.go
@@ -141,11 +141,7 @@ func HasGroups() predicate.User {
 // HasGroupsWith applies the HasEdge predicate on the "groups" edge with a given conditions (other predicates).
 func HasGroupsWith(preds ...predicate.Group) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(GroupsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, GroupsTable, GroupsPrimaryKey...),
-		)
+		step := newGroupsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -168,11 +164,7 @@ func HasFriends() predicate.User {
 // HasFriendsWith applies the HasEdge predicate on the "friends" edge with a given conditions (other predicates).
 func HasFriendsWith(preds ...predicate.User) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, FriendsTable, FriendsPrimaryKey...),
-		)
+		step := newFriendsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -195,11 +187,7 @@ func HasRelatives() predicate.User {
 // HasRelativesWith applies the HasEdge predicate on the "relatives" edge with a given conditions (other predicates).
 func HasRelativesWith(preds ...predicate.User) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, RelativesTable, RelativesPrimaryKey...),
-		)
+		step := newRelativesStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -222,11 +210,7 @@ func HasLikedTweets() predicate.User {
 // HasLikedTweetsWith applies the HasEdge predicate on the "liked_tweets" edge with a given conditions (other predicates).
 func HasLikedTweetsWith(preds ...predicate.Tweet) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(LikedTweetsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, LikedTweetsTable, LikedTweetsPrimaryKey...),
-		)
+		step := newLikedTweetsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -249,11 +233,7 @@ func HasTweets() predicate.User {
 // HasTweetsWith applies the HasEdge predicate on the "tweets" edge with a given conditions (other predicates).
 func HasTweetsWith(preds ...predicate.Tweet) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(TweetsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, TweetsTable, TweetsPrimaryKey...),
-		)
+		step := newTweetsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -276,11 +256,7 @@ func HasRoles() predicate.User {
 // HasRolesWith applies the HasEdge predicate on the "roles" edge with a given conditions (other predicates).
 func HasRolesWith(preds ...predicate.Role) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(RolesInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, RolesTable, RolesPrimaryKey...),
-		)
+		step := newRolesStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -303,11 +279,7 @@ func HasJoinedGroups() predicate.User {
 // HasJoinedGroupsWith applies the HasEdge predicate on the "joined_groups" edge with a given conditions (other predicates).
 func HasJoinedGroupsWith(preds ...predicate.UserGroup) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(JoinedGroupsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, true, JoinedGroupsTable, JoinedGroupsColumn),
-		)
+		step := newJoinedGroupsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -330,11 +302,7 @@ func HasFriendships() predicate.User {
 // HasFriendshipsWith applies the HasEdge predicate on the "friendships" edge with a given conditions (other predicates).
 func HasFriendshipsWith(preds ...predicate.Friendship) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(FriendshipsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, true, FriendshipsTable, FriendshipsColumn),
-		)
+		step := newFriendshipsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -357,11 +325,7 @@ func HasRelationship() predicate.User {
 // HasRelationshipWith applies the HasEdge predicate on the "relationship" edge with a given conditions (other predicates).
 func HasRelationshipWith(preds ...predicate.Relationship) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(RelationshipInverseTable, RelationshipColumn),
-			sqlgraph.Edge(sqlgraph.O2M, true, RelationshipTable, RelationshipColumn),
-		)
+		step := newRelationshipStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -384,11 +348,7 @@ func HasLikes() predicate.User {
 // HasLikesWith applies the HasEdge predicate on the "likes" edge with a given conditions (other predicates).
 func HasLikesWith(preds ...predicate.TweetLike) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(LikesInverseTable, LikesColumn),
-			sqlgraph.Edge(sqlgraph.O2M, true, LikesTable, LikesColumn),
-		)
+		step := newLikesStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -411,11 +371,7 @@ func HasUserTweets() predicate.User {
 // HasUserTweetsWith applies the HasEdge predicate on the "user_tweets" edge with a given conditions (other predicates).
 func HasUserTweetsWith(preds ...predicate.UserTweet) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(UserTweetsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, true, UserTweetsTable, UserTweetsColumn),
-		)
+		step := newUserTweetsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -438,11 +394,7 @@ func HasRolesUsers() predicate.User {
 // HasRolesUsersWith applies the HasEdge predicate on the "roles_users" edge with a given conditions (other predicates).
 func HasRolesUsersWith(preds ...predicate.RoleUser) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(RolesUsersInverseTable, RolesUsersColumn),
-			sqlgraph.Edge(sqlgraph.O2M, true, RolesUsersTable, RolesUsersColumn),
-		)
+		step := newRolesUsersStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/edgeschema/ent/user_query.go
+++ b/entc/integration/edgeschema/ent/user_query.go
@@ -33,7 +33,7 @@ import (
 type UserQuery struct {
 	config
 	ctx              *QueryContext
-	order            []OrderFunc
+	order            []user.Order
 	inters           []Interceptor
 	predicates       []predicate.User
 	withGroups       *GroupQuery
@@ -79,7 +79,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...OrderFunc) *UserQuery {
+func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -537,7 +537,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:           uq.config,
 		ctx:              uq.ctx.Clone(),
-		order:            append([]OrderFunc{}, uq.order...),
+		order:            append([]user.Order{}, uq.order...),
 		inters:           append([]Interceptor{}, uq.inters...),
 		predicates:       append([]predicate.User{}, uq.predicates...),
 		withGroups:       uq.withGroups.Clone(),

--- a/entc/integration/edgeschema/ent/usergroup/usergroup.go
+++ b/entc/integration/edgeschema/ent/usergroup/usergroup.go
@@ -8,6 +8,9 @@ package usergroup
 
 import (
 	"time"
+
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
 )
 
 const (
@@ -65,3 +68,54 @@ var (
 	// DefaultJoinedAt holds the default value on creation for the "joined_at" field.
 	DefaultJoinedAt func() time.Time
 )
+
+// Order defines the ordering method for the UserGroup queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByJoinedAt orders the results by the joined_at field.
+func ByJoinedAt(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldJoinedAt, opts...).ToFunc()
+}
+
+// ByUserID orders the results by the user_id field.
+func ByUserID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldUserID, opts...).ToFunc()
+}
+
+// ByGroupID orders the results by the group_id field.
+func ByGroupID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldGroupID, opts...).ToFunc()
+}
+
+// ByUserField orders the results by user field.
+func ByUserField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newUserStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByGroupField orders the results by group field.
+func ByGroupField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newGroupStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newUserStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(UserInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, false, UserTable, UserColumn),
+	)
+}
+func newGroupStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(GroupInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, false, GroupTable, GroupColumn),
+	)
+}

--- a/entc/integration/edgeschema/ent/usergroup/where.go
+++ b/entc/integration/edgeschema/ent/usergroup/where.go
@@ -168,11 +168,7 @@ func HasUser() predicate.UserGroup {
 // HasUserWith applies the HasEdge predicate on the "user" edge with a given conditions (other predicates).
 func HasUserWith(preds ...predicate.User) predicate.UserGroup {
 	return predicate.UserGroup(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(UserInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, UserTable, UserColumn),
-		)
+		step := newUserStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -195,11 +191,7 @@ func HasGroup() predicate.UserGroup {
 // HasGroupWith applies the HasEdge predicate on the "group" edge with a given conditions (other predicates).
 func HasGroupWith(preds ...predicate.Group) predicate.UserGroup {
 	return predicate.UserGroup(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(GroupInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, GroupTable, GroupColumn),
-		)
+		step := newGroupStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/edgeschema/ent/usergroup_query.go
+++ b/entc/integration/edgeschema/ent/usergroup_query.go
@@ -24,7 +24,7 @@ import (
 type UserGroupQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []usergroup.Order
 	inters     []Interceptor
 	predicates []predicate.UserGroup
 	withUser   *UserQuery
@@ -60,7 +60,7 @@ func (ugq *UserGroupQuery) Unique(unique bool) *UserGroupQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (ugq *UserGroupQuery) Order(o ...OrderFunc) *UserGroupQuery {
+func (ugq *UserGroupQuery) Order(o ...usergroup.Order) *UserGroupQuery {
 	ugq.order = append(ugq.order, o...)
 	return ugq
 }
@@ -298,7 +298,7 @@ func (ugq *UserGroupQuery) Clone() *UserGroupQuery {
 	return &UserGroupQuery{
 		config:     ugq.config,
 		ctx:        ugq.ctx.Clone(),
-		order:      append([]OrderFunc{}, ugq.order...),
+		order:      append([]usergroup.Order{}, ugq.order...),
 		inters:     append([]Interceptor{}, ugq.inters...),
 		predicates: append([]predicate.UserGroup{}, ugq.predicates...),
 		withUser:   ugq.withUser.Clone(),

--- a/entc/integration/edgeschema/ent/usertweet/usertweet.go
+++ b/entc/integration/edgeschema/ent/usertweet/usertweet.go
@@ -8,6 +8,9 @@ package usertweet
 
 import (
 	"time"
+
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
 )
 
 const (
@@ -65,3 +68,54 @@ var (
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time
 )
+
+// Order defines the ordering method for the UserTweet queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByCreatedAt orders the results by the created_at field.
+func ByCreatedAt(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldCreatedAt, opts...).ToFunc()
+}
+
+// ByUserID orders the results by the user_id field.
+func ByUserID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldUserID, opts...).ToFunc()
+}
+
+// ByTweetID orders the results by the tweet_id field.
+func ByTweetID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldTweetID, opts...).ToFunc()
+}
+
+// ByUserField orders the results by user field.
+func ByUserField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newUserStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByTweetField orders the results by tweet field.
+func ByTweetField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newTweetStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newUserStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(UserInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, false, UserTable, UserColumn),
+	)
+}
+func newTweetStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(TweetInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, false, TweetTable, TweetColumn),
+	)
+}

--- a/entc/integration/edgeschema/ent/usertweet/where.go
+++ b/entc/integration/edgeschema/ent/usertweet/where.go
@@ -168,11 +168,7 @@ func HasUser() predicate.UserTweet {
 // HasUserWith applies the HasEdge predicate on the "user" edge with a given conditions (other predicates).
 func HasUserWith(preds ...predicate.User) predicate.UserTweet {
 	return predicate.UserTweet(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(UserInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, UserTable, UserColumn),
-		)
+		step := newUserStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -195,11 +191,7 @@ func HasTweet() predicate.UserTweet {
 // HasTweetWith applies the HasEdge predicate on the "tweet" edge with a given conditions (other predicates).
 func HasTweetWith(preds ...predicate.Tweet) predicate.UserTweet {
 	return predicate.UserTweet(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(TweetInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, TweetTable, TweetColumn),
-		)
+		step := newTweetStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/edgeschema/ent/usertweet_query.go
+++ b/entc/integration/edgeschema/ent/usertweet_query.go
@@ -24,7 +24,7 @@ import (
 type UserTweetQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []usertweet.Order
 	inters     []Interceptor
 	predicates []predicate.UserTweet
 	withUser   *UserQuery
@@ -60,7 +60,7 @@ func (utq *UserTweetQuery) Unique(unique bool) *UserTweetQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (utq *UserTweetQuery) Order(o ...OrderFunc) *UserTweetQuery {
+func (utq *UserTweetQuery) Order(o ...usertweet.Order) *UserTweetQuery {
 	utq.order = append(utq.order, o...)
 	return utq
 }
@@ -298,7 +298,7 @@ func (utq *UserTweetQuery) Clone() *UserTweetQuery {
 	return &UserTweetQuery{
 		config:     utq.config,
 		ctx:        utq.ctx.Clone(),
-		order:      append([]OrderFunc{}, utq.order...),
+		order:      append([]usertweet.Order{}, utq.order...),
 		inters:     append([]Interceptor{}, utq.inters...),
 		predicates: append([]predicate.UserTweet{}, utq.predicates...),
 		withUser:   utq.withUser.Clone(),

--- a/entc/integration/ent/api/api.go
+++ b/entc/integration/ent/api/api.go
@@ -6,6 +6,10 @@
 
 package api
 
+import (
+	"entgo.io/ent/dialect/sql"
+)
+
 const (
 	// Label holds the string label denoting the api type in the database.
 	Label = "api"
@@ -28,6 +32,14 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Api queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // comment from another template.

--- a/entc/integration/ent/api_query.go
+++ b/entc/integration/ent/api_query.go
@@ -23,7 +23,7 @@ import (
 type APIQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []api.Order
 	inters     []Interceptor
 	predicates []predicate.Api
 	modifiers  []func(*sql.Selector)
@@ -58,7 +58,7 @@ func (aq *APIQuery) Unique(unique bool) *APIQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (aq *APIQuery) Order(o ...OrderFunc) *APIQuery {
+func (aq *APIQuery) Order(o ...api.Order) *APIQuery {
 	aq.order = append(aq.order, o...)
 	return aq
 }
@@ -252,7 +252,7 @@ func (aq *APIQuery) Clone() *APIQuery {
 	return &APIQuery{
 		config:     aq.config,
 		ctx:        aq.ctx.Clone(),
-		order:      append([]OrderFunc{}, aq.order...),
+		order:      append([]api.Order{}, aq.order...),
 		inters:     append([]Interceptor{}, aq.inters...),
 		predicates: append([]predicate.Api{}, aq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/ent/card/card.go
+++ b/entc/integration/ent/card/card.go
@@ -8,6 +8,9 @@ package card
 
 import (
 	"time"
+
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
 )
 
 const (
@@ -96,5 +99,73 @@ var (
 	// NameValidator is a validator for the "name" field. It is called by the builders before save.
 	NameValidator func(string) error
 )
+
+// Order defines the ordering method for the Card queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByCreateTime orders the results by the create_time field.
+func ByCreateTime(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldCreateTime, opts...).ToFunc()
+}
+
+// ByUpdateTime orders the results by the update_time field.
+func ByUpdateTime(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldUpdateTime, opts...).ToFunc()
+}
+
+// ByBalance orders the results by the balance field.
+func ByBalance(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldBalance, opts...).ToFunc()
+}
+
+// ByNumber orders the results by the number field.
+func ByNumber(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldNumber, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByOwnerField orders the results by owner field.
+func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// BySpecCount orders the results by spec count.
+func BySpecCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newSpecStep(), opts...)
+	}
+}
+
+// BySpec orders the results by spec terms.
+func BySpec(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newSpecStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newOwnerStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(OwnerInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2O, true, OwnerTable, OwnerColumn),
+	)
+}
+func newSpecStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(SpecInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, true, SpecTable, SpecPrimaryKey...),
+	)
+}
 
 // comment from another template.

--- a/entc/integration/ent/card/where.go
+++ b/entc/integration/ent/card/where.go
@@ -358,11 +358,7 @@ func HasOwner() predicate.Card {
 // HasOwnerWith applies the HasEdge predicate on the "owner" edge with a given conditions (other predicates).
 func HasOwnerWith(preds ...predicate.User) predicate.Card {
 	return predicate.Card(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(OwnerInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, true, OwnerTable, OwnerColumn),
-		)
+		step := newOwnerStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -385,11 +381,7 @@ func HasSpec() predicate.Card {
 // HasSpecWith applies the HasEdge predicate on the "spec" edge with a given conditions (other predicates).
 func HasSpecWith(preds ...predicate.Spec) predicate.Card {
 	return predicate.Card(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(SpecInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, true, SpecTable, SpecPrimaryKey...),
-		)
+		step := newSpecStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/ent/card_query.go
+++ b/entc/integration/ent/card_query.go
@@ -26,7 +26,7 @@ import (
 type CardQuery struct {
 	config
 	ctx           *QueryContext
-	order         []OrderFunc
+	order         []card.Order
 	inters        []Interceptor
 	predicates    []predicate.Card
 	withOwner     *UserQuery
@@ -65,7 +65,7 @@ func (cq *CardQuery) Unique(unique bool) *CardQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *CardQuery) Order(o ...OrderFunc) *CardQuery {
+func (cq *CardQuery) Order(o ...card.Order) *CardQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -303,7 +303,7 @@ func (cq *CardQuery) Clone() *CardQuery {
 	return &CardQuery{
 		config:     cq.config,
 		ctx:        cq.ctx.Clone(),
-		order:      append([]OrderFunc{}, cq.order...),
+		order:      append([]card.Order{}, cq.order...),
 		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Card{}, cq.predicates...),
 		withOwner:  cq.withOwner.Clone(),

--- a/entc/integration/ent/comment/comment.go
+++ b/entc/integration/ent/comment/comment.go
@@ -6,6 +6,10 @@
 
 package comment
 
+import (
+	"entgo.io/ent/dialect/sql"
+)
+
 const (
 	// Label holds the string label denoting the comment type in the database.
 	Label = "comment"
@@ -46,6 +50,39 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Comment queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByUniqueInt orders the results by the unique_int field.
+func ByUniqueInt(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldUniqueInt, opts...).ToFunc()
+}
+
+// ByUniqueFloat orders the results by the unique_float field.
+func ByUniqueFloat(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldUniqueFloat, opts...).ToFunc()
+}
+
+// ByNillableInt orders the results by the nillable_int field.
+func ByNillableInt(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldNillableInt, opts...).ToFunc()
+}
+
+// ByTable orders the results by the table field.
+func ByTable(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldTable, opts...).ToFunc()
+}
+
+// ByClient orders the results by the client field.
+func ByClient(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldClient, opts...).ToFunc()
 }
 
 // comment from another template.

--- a/entc/integration/ent/comment_query.go
+++ b/entc/integration/ent/comment_query.go
@@ -23,7 +23,7 @@ import (
 type CommentQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []comment.Order
 	inters     []Interceptor
 	predicates []predicate.Comment
 	modifiers  []func(*sql.Selector)
@@ -58,7 +58,7 @@ func (cq *CommentQuery) Unique(unique bool) *CommentQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *CommentQuery) Order(o ...OrderFunc) *CommentQuery {
+func (cq *CommentQuery) Order(o ...comment.Order) *CommentQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -252,7 +252,7 @@ func (cq *CommentQuery) Clone() *CommentQuery {
 	return &CommentQuery{
 		config:     cq.config,
 		ctx:        cq.ctx.Clone(),
-		order:      append([]OrderFunc{}, cq.order...),
+		order:      append([]comment.Order{}, cq.order...),
 		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Comment{}, cq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/ent/ent.go
+++ b/entc/integration/ent/ent.go
@@ -82,6 +82,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -116,7 +117,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -128,7 +129,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/entc/integration/ent/exvaluescan/exvaluescan.go
+++ b/entc/integration/ent/exvaluescan/exvaluescan.go
@@ -10,6 +10,7 @@ import (
 	"math/big"
 	"net/url"
 
+	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/schema/field"
 )
 
@@ -70,5 +71,48 @@ var (
 		CustomOptional field.TypeValueScanner[string]
 	}
 )
+
+// Order defines the ordering method for the ExValueScan queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByBinary orders the results by the binary field.
+func ByBinary(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldBinary, opts...).ToFunc()
+}
+
+// ByBinaryOptional orders the results by the binary_optional field.
+func ByBinaryOptional(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldBinaryOptional, opts...).ToFunc()
+}
+
+// ByText orders the results by the text field.
+func ByText(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldText, opts...).ToFunc()
+}
+
+// ByTextOptional orders the results by the text_optional field.
+func ByTextOptional(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldTextOptional, opts...).ToFunc()
+}
+
+// ByBase64 orders the results by the base64 field.
+func ByBase64(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldBase64, opts...).ToFunc()
+}
+
+// ByCustom orders the results by the custom field.
+func ByCustom(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldCustom, opts...).ToFunc()
+}
+
+// ByCustomOptional orders the results by the custom_optional field.
+func ByCustomOptional(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldCustomOptional, opts...).ToFunc()
+}
 
 // comment from another template.

--- a/entc/integration/ent/exvaluescan_query.go
+++ b/entc/integration/ent/exvaluescan_query.go
@@ -23,7 +23,7 @@ import (
 type ExValueScanQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []exvaluescan.Order
 	inters     []Interceptor
 	predicates []predicate.ExValueScan
 	modifiers  []func(*sql.Selector)
@@ -58,7 +58,7 @@ func (evsq *ExValueScanQuery) Unique(unique bool) *ExValueScanQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (evsq *ExValueScanQuery) Order(o ...OrderFunc) *ExValueScanQuery {
+func (evsq *ExValueScanQuery) Order(o ...exvaluescan.Order) *ExValueScanQuery {
 	evsq.order = append(evsq.order, o...)
 	return evsq
 }
@@ -252,7 +252,7 @@ func (evsq *ExValueScanQuery) Clone() *ExValueScanQuery {
 	return &ExValueScanQuery{
 		config:     evsq.config,
 		ctx:        evsq.ctx.Clone(),
-		order:      append([]OrderFunc{}, evsq.order...),
+		order:      append([]exvaluescan.Order{}, evsq.order...),
 		inters:     append([]Interceptor{}, evsq.inters...),
 		predicates: append([]predicate.ExValueScan{}, evsq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/ent/fieldtype/fieldtype.go
+++ b/entc/integration/ent/fieldtype/fieldtype.go
@@ -333,6 +333,309 @@ func PriorityValidator(pr role.Priority) error {
 	}
 }
 
+// Order defines the ordering method for the FieldType queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByInt orders the results by the int field.
+func ByInt(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldInt, opts...).ToFunc()
+}
+
+// ByInt8 orders the results by the int8 field.
+func ByInt8(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldInt8, opts...).ToFunc()
+}
+
+// ByInt16 orders the results by the int16 field.
+func ByInt16(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldInt16, opts...).ToFunc()
+}
+
+// ByInt32 orders the results by the int32 field.
+func ByInt32(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldInt32, opts...).ToFunc()
+}
+
+// ByInt64 orders the results by the int64 field.
+func ByInt64(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldInt64, opts...).ToFunc()
+}
+
+// ByOptionalInt orders the results by the optional_int field.
+func ByOptionalInt(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldOptionalInt, opts...).ToFunc()
+}
+
+// ByOptionalInt8 orders the results by the optional_int8 field.
+func ByOptionalInt8(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldOptionalInt8, opts...).ToFunc()
+}
+
+// ByOptionalInt16 orders the results by the optional_int16 field.
+func ByOptionalInt16(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldOptionalInt16, opts...).ToFunc()
+}
+
+// ByOptionalInt32 orders the results by the optional_int32 field.
+func ByOptionalInt32(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldOptionalInt32, opts...).ToFunc()
+}
+
+// ByOptionalInt64 orders the results by the optional_int64 field.
+func ByOptionalInt64(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldOptionalInt64, opts...).ToFunc()
+}
+
+// ByNillableInt orders the results by the nillable_int field.
+func ByNillableInt(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldNillableInt, opts...).ToFunc()
+}
+
+// ByNillableInt8 orders the results by the nillable_int8 field.
+func ByNillableInt8(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldNillableInt8, opts...).ToFunc()
+}
+
+// ByNillableInt16 orders the results by the nillable_int16 field.
+func ByNillableInt16(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldNillableInt16, opts...).ToFunc()
+}
+
+// ByNillableInt32 orders the results by the nillable_int32 field.
+func ByNillableInt32(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldNillableInt32, opts...).ToFunc()
+}
+
+// ByNillableInt64 orders the results by the nillable_int64 field.
+func ByNillableInt64(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldNillableInt64, opts...).ToFunc()
+}
+
+// ByValidateOptionalInt32 orders the results by the validate_optional_int32 field.
+func ByValidateOptionalInt32(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldValidateOptionalInt32, opts...).ToFunc()
+}
+
+// ByOptionalUint orders the results by the optional_uint field.
+func ByOptionalUint(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldOptionalUint, opts...).ToFunc()
+}
+
+// ByOptionalUint8 orders the results by the optional_uint8 field.
+func ByOptionalUint8(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldOptionalUint8, opts...).ToFunc()
+}
+
+// ByOptionalUint16 orders the results by the optional_uint16 field.
+func ByOptionalUint16(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldOptionalUint16, opts...).ToFunc()
+}
+
+// ByOptionalUint32 orders the results by the optional_uint32 field.
+func ByOptionalUint32(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldOptionalUint32, opts...).ToFunc()
+}
+
+// ByOptionalUint64 orders the results by the optional_uint64 field.
+func ByOptionalUint64(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldOptionalUint64, opts...).ToFunc()
+}
+
+// ByState orders the results by the state field.
+func ByState(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldState, opts...).ToFunc()
+}
+
+// ByOptionalFloat orders the results by the optional_float field.
+func ByOptionalFloat(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldOptionalFloat, opts...).ToFunc()
+}
+
+// ByOptionalFloat32 orders the results by the optional_float32 field.
+func ByOptionalFloat32(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldOptionalFloat32, opts...).ToFunc()
+}
+
+// ByText orders the results by the text field.
+func ByText(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldText, opts...).ToFunc()
+}
+
+// ByDatetime orders the results by the datetime field.
+func ByDatetime(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldDatetime, opts...).ToFunc()
+}
+
+// ByDecimal orders the results by the decimal field.
+func ByDecimal(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldDecimal, opts...).ToFunc()
+}
+
+// ByLinkOther orders the results by the link_other field.
+func ByLinkOther(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldLinkOther, opts...).ToFunc()
+}
+
+// ByLinkOtherFunc orders the results by the link_other_func field.
+func ByLinkOtherFunc(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldLinkOtherFunc, opts...).ToFunc()
+}
+
+// ByMAC orders the results by the mac field.
+func ByMAC(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldMAC, opts...).ToFunc()
+}
+
+// ByStringArray orders the results by the string_array field.
+func ByStringArray(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldStringArray, opts...).ToFunc()
+}
+
+// ByPassword orders the results by the password field.
+func ByPassword(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldPassword, opts...).ToFunc()
+}
+
+// ByStringScanner orders the results by the string_scanner field.
+func ByStringScanner(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldStringScanner, opts...).ToFunc()
+}
+
+// ByDuration orders the results by the duration field.
+func ByDuration(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldDuration, opts...).ToFunc()
+}
+
+// ByDir orders the results by the dir field.
+func ByDir(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldDir, opts...).ToFunc()
+}
+
+// ByNdir orders the results by the ndir field.
+func ByNdir(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldNdir, opts...).ToFunc()
+}
+
+// ByStr orders the results by the str field.
+func ByStr(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldStr, opts...).ToFunc()
+}
+
+// ByNullStr orders the results by the null_str field.
+func ByNullStr(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldNullStr, opts...).ToFunc()
+}
+
+// ByLink orders the results by the link field.
+func ByLink(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldLink, opts...).ToFunc()
+}
+
+// ByNullLink orders the results by the null_link field.
+func ByNullLink(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldNullLink, opts...).ToFunc()
+}
+
+// ByActive orders the results by the active field.
+func ByActive(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldActive, opts...).ToFunc()
+}
+
+// ByNullActive orders the results by the null_active field.
+func ByNullActive(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldNullActive, opts...).ToFunc()
+}
+
+// ByDeleted orders the results by the deleted field.
+func ByDeleted(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldDeleted, opts...).ToFunc()
+}
+
+// ByDeletedAt orders the results by the deleted_at field.
+func ByDeletedAt(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldDeletedAt, opts...).ToFunc()
+}
+
+// ByNullInt64 orders the results by the null_int64 field.
+func ByNullInt64(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldNullInt64, opts...).ToFunc()
+}
+
+// BySchemaInt orders the results by the schema_int field.
+func BySchemaInt(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldSchemaInt, opts...).ToFunc()
+}
+
+// BySchemaInt8 orders the results by the schema_int8 field.
+func BySchemaInt8(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldSchemaInt8, opts...).ToFunc()
+}
+
+// BySchemaInt64 orders the results by the schema_int64 field.
+func BySchemaInt64(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldSchemaInt64, opts...).ToFunc()
+}
+
+// BySchemaFloat orders the results by the schema_float field.
+func BySchemaFloat(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldSchemaFloat, opts...).ToFunc()
+}
+
+// BySchemaFloat32 orders the results by the schema_float32 field.
+func BySchemaFloat32(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldSchemaFloat32, opts...).ToFunc()
+}
+
+// ByNullFloat orders the results by the null_float field.
+func ByNullFloat(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldNullFloat, opts...).ToFunc()
+}
+
+// ByRole orders the results by the role field.
+func ByRole(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldRole, opts...).ToFunc()
+}
+
+// ByPriority orders the results by the priority field.
+func ByPriority(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldPriority, opts...).ToFunc()
+}
+
+// ByOptionalUUID orders the results by the optional_uuid field.
+func ByOptionalUUID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldOptionalUUID, opts...).ToFunc()
+}
+
+// ByNillableUUID orders the results by the nillable_uuid field.
+func ByNillableUUID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldNillableUUID, opts...).ToFunc()
+}
+
+// ByVstring orders the results by the vstring field.
+func ByVstring(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldVstring, opts...).ToFunc()
+}
+
+// ByTriple orders the results by the triple field.
+func ByTriple(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldTriple, opts...).ToFunc()
+}
+
+// ByBigInt orders the results by the big_int field.
+func ByBigInt(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldBigInt, opts...).ToFunc()
+}
+
+// ByPasswordOther orders the results by the password_other field.
+func ByPasswordOther(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldPasswordOther, opts...).ToFunc()
+}
+
 // Ptr returns a new pointer to the enum value.
 func (s State) Ptr() *State {
 	return &s

--- a/entc/integration/ent/fieldtype_query.go
+++ b/entc/integration/ent/fieldtype_query.go
@@ -23,7 +23,7 @@ import (
 type FieldTypeQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []fieldtype.Order
 	inters     []Interceptor
 	predicates []predicate.FieldType
 	withFKs    bool
@@ -59,7 +59,7 @@ func (ftq *FieldTypeQuery) Unique(unique bool) *FieldTypeQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (ftq *FieldTypeQuery) Order(o ...OrderFunc) *FieldTypeQuery {
+func (ftq *FieldTypeQuery) Order(o ...fieldtype.Order) *FieldTypeQuery {
 	ftq.order = append(ftq.order, o...)
 	return ftq
 }
@@ -253,7 +253,7 @@ func (ftq *FieldTypeQuery) Clone() *FieldTypeQuery {
 	return &FieldTypeQuery{
 		config:     ftq.config,
 		ctx:        ftq.ctx.Clone(),
-		order:      append([]OrderFunc{}, ftq.order...),
+		order:      append([]fieldtype.Order{}, ftq.order...),
 		inters:     append([]Interceptor{}, ftq.inters...),
 		predicates: append([]predicate.FieldType{}, ftq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/ent/file/file.go
+++ b/entc/integration/ent/file/file.go
@@ -6,6 +6,11 @@
 
 package file
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the file type in the database.
 	Label = "file"
@@ -94,5 +99,92 @@ var (
 	// SizeValidator is a validator for the "size" field. It is called by the builders before save.
 	SizeValidator func(int) error
 )
+
+// Order defines the ordering method for the File queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// BySize orders the results by the size field.
+func BySize(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldSize, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByUser orders the results by the user field.
+func ByUser(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldUser, opts...).ToFunc()
+}
+
+// ByGroup orders the results by the group field.
+func ByGroup(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldGroup, opts...).ToFunc()
+}
+
+// ByOp orders the results by the op field.
+func ByOp(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldOp, opts...).ToFunc()
+}
+
+// ByFieldID orders the results by the field_id field.
+func ByFieldID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldFieldID, opts...).ToFunc()
+}
+
+// ByOwnerField orders the results by owner field.
+func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByTypeField orders the results by type field.
+func ByTypeField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newTypeStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByFieldCount orders the results by field count.
+func ByFieldCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newFieldStep(), opts...)
+	}
+}
+
+// ByField orders the results by field terms.
+func ByField(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newFieldStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newOwnerStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(OwnerInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
+	)
+}
+func newTypeStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(TypeInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, TypeTable, TypeColumn),
+	)
+}
+func newFieldStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(FieldInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, FieldTable, FieldColumn),
+	)
+}
 
 // comment from another template.

--- a/entc/integration/ent/file/where.go
+++ b/entc/integration/ent/file/where.go
@@ -421,11 +421,7 @@ func HasOwner() predicate.File {
 // HasOwnerWith applies the HasEdge predicate on the "owner" edge with a given conditions (other predicates).
 func HasOwnerWith(preds ...predicate.User) predicate.File {
 	return predicate.File(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(OwnerInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
-		)
+		step := newOwnerStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -448,11 +444,7 @@ func HasType() predicate.File {
 // HasTypeWith applies the HasEdge predicate on the "type" edge with a given conditions (other predicates).
 func HasTypeWith(preds ...predicate.FileType) predicate.File {
 	return predicate.File(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(TypeInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, TypeTable, TypeColumn),
-		)
+		step := newTypeStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -475,11 +467,7 @@ func HasField() predicate.File {
 // HasFieldWith applies the HasEdge predicate on the "field" edge with a given conditions (other predicates).
 func HasFieldWith(preds ...predicate.FieldType) predicate.File {
 	return predicate.File(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(FieldInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, FieldTable, FieldColumn),
-		)
+		step := newFieldStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/ent/file_query.go
+++ b/entc/integration/ent/file_query.go
@@ -27,7 +27,7 @@ import (
 type FileQuery struct {
 	config
 	ctx            *QueryContext
-	order          []OrderFunc
+	order          []file.Order
 	inters         []Interceptor
 	predicates     []predicate.File
 	withOwner      *UserQuery
@@ -67,7 +67,7 @@ func (fq *FileQuery) Unique(unique bool) *FileQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (fq *FileQuery) Order(o ...OrderFunc) *FileQuery {
+func (fq *FileQuery) Order(o ...file.Order) *FileQuery {
 	fq.order = append(fq.order, o...)
 	return fq
 }
@@ -327,7 +327,7 @@ func (fq *FileQuery) Clone() *FileQuery {
 	return &FileQuery{
 		config:     fq.config,
 		ctx:        fq.ctx.Clone(),
-		order:      append([]OrderFunc{}, fq.order...),
+		order:      append([]file.Order{}, fq.order...),
 		inters:     append([]Interceptor{}, fq.inters...),
 		predicates: append([]predicate.File{}, fq.predicates...),
 		withOwner:  fq.withOwner.Clone(),

--- a/entc/integration/ent/filetype/filetype.go
+++ b/entc/integration/ent/filetype/filetype.go
@@ -8,6 +8,9 @@ package filetype
 
 import (
 	"fmt"
+
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
 )
 
 const (
@@ -103,6 +106,50 @@ func StateValidator(s State) error {
 	default:
 		return fmt.Errorf("filetype: invalid enum value for state field: %q", s)
 	}
+}
+
+// Order defines the ordering method for the FileType queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByType orders the results by the type field.
+func ByType(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldType, opts...).ToFunc()
+}
+
+// ByState orders the results by the state field.
+func ByState(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldState, opts...).ToFunc()
+}
+
+// ByFilesCount orders the results by files count.
+func ByFilesCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newFilesStep(), opts...)
+	}
+}
+
+// ByFiles orders the results by files terms.
+func ByFiles(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newFilesStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newFilesStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(FilesInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, FilesTable, FilesColumn),
+	)
 }
 
 // Ptr returns a new pointer to the enum value.

--- a/entc/integration/ent/filetype/where.go
+++ b/entc/integration/ent/filetype/where.go
@@ -181,11 +181,7 @@ func HasFiles() predicate.FileType {
 // HasFilesWith applies the HasEdge predicate on the "files" edge with a given conditions (other predicates).
 func HasFilesWith(preds ...predicate.File) predicate.FileType {
 	return predicate.FileType(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(FilesInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, FilesTable, FilesColumn),
-		)
+		step := newFilesStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/ent/filetype_query.go
+++ b/entc/integration/ent/filetype_query.go
@@ -25,7 +25,7 @@ import (
 type FileTypeQuery struct {
 	config
 	ctx            *QueryContext
-	order          []OrderFunc
+	order          []filetype.Order
 	inters         []Interceptor
 	predicates     []predicate.FileType
 	withFiles      *FileQuery
@@ -62,7 +62,7 @@ func (ftq *FileTypeQuery) Unique(unique bool) *FileTypeQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (ftq *FileTypeQuery) Order(o ...OrderFunc) *FileTypeQuery {
+func (ftq *FileTypeQuery) Order(o ...filetype.Order) *FileTypeQuery {
 	ftq.order = append(ftq.order, o...)
 	return ftq
 }
@@ -278,7 +278,7 @@ func (ftq *FileTypeQuery) Clone() *FileTypeQuery {
 	return &FileTypeQuery{
 		config:     ftq.config,
 		ctx:        ftq.ctx.Clone(),
-		order:      append([]OrderFunc{}, ftq.order...),
+		order:      append([]filetype.Order{}, ftq.order...),
 		inters:     append([]Interceptor{}, ftq.inters...),
 		predicates: append([]predicate.FileType{}, ftq.predicates...),
 		withFiles:  ftq.withFiles.Clone(),

--- a/entc/integration/ent/goods/goods.go
+++ b/entc/integration/ent/goods/goods.go
@@ -6,6 +6,10 @@
 
 package goods
 
+import (
+	"entgo.io/ent/dialect/sql"
+)
+
 const (
 	// Label holds the string label denoting the goods type in the database.
 	Label = "goods"
@@ -28,6 +32,14 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Goods queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // comment from another template.

--- a/entc/integration/ent/goods_query.go
+++ b/entc/integration/ent/goods_query.go
@@ -23,7 +23,7 @@ import (
 type GoodsQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []goods.Order
 	inters     []Interceptor
 	predicates []predicate.Goods
 	modifiers  []func(*sql.Selector)
@@ -58,7 +58,7 @@ func (gq *GoodsQuery) Unique(unique bool) *GoodsQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (gq *GoodsQuery) Order(o ...OrderFunc) *GoodsQuery {
+func (gq *GoodsQuery) Order(o ...goods.Order) *GoodsQuery {
 	gq.order = append(gq.order, o...)
 	return gq
 }
@@ -252,7 +252,7 @@ func (gq *GoodsQuery) Clone() *GoodsQuery {
 	return &GoodsQuery{
 		config:     gq.config,
 		ctx:        gq.ctx.Clone(),
-		order:      append([]OrderFunc{}, gq.order...),
+		order:      append([]goods.Order{}, gq.order...),
 		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Goods{}, gq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/ent/group/group.go
+++ b/entc/integration/ent/group/group.go
@@ -6,6 +6,11 @@
 
 package group
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the group type in the database.
 	Label = "group"
@@ -108,5 +113,115 @@ var (
 	// NameValidator is a validator for the "name" field. It is called by the builders before save.
 	NameValidator func(string) error
 )
+
+// Order defines the ordering method for the Group queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByActive orders the results by the active field.
+func ByActive(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldActive, opts...).ToFunc()
+}
+
+// ByExpire orders the results by the expire field.
+func ByExpire(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldExpire, opts...).ToFunc()
+}
+
+// ByType orders the results by the type field.
+func ByType(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldType, opts...).ToFunc()
+}
+
+// ByMaxUsers orders the results by the max_users field.
+func ByMaxUsers(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldMaxUsers, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByFilesCount orders the results by files count.
+func ByFilesCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newFilesStep(), opts...)
+	}
+}
+
+// ByFiles orders the results by files terms.
+func ByFiles(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newFilesStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByBlockedCount orders the results by blocked count.
+func ByBlockedCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newBlockedStep(), opts...)
+	}
+}
+
+// ByBlocked orders the results by blocked terms.
+func ByBlocked(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newBlockedStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByUsersCount orders the results by users count.
+func ByUsersCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newUsersStep(), opts...)
+	}
+}
+
+// ByUsers orders the results by users terms.
+func ByUsers(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newUsersStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByInfoField orders the results by info field.
+func ByInfoField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newInfoStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newFilesStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(FilesInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, FilesTable, FilesColumn),
+	)
+}
+func newBlockedStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(BlockedInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, BlockedTable, BlockedColumn),
+	)
+}
+func newUsersStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(UsersInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, true, UsersTable, UsersPrimaryKey...),
+	)
+}
+func newInfoStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(InfoInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, false, InfoTable, InfoColumn),
+	)
+}
 
 // comment from another template.

--- a/entc/integration/ent/group/where.go
+++ b/entc/integration/ent/group/where.go
@@ -338,11 +338,7 @@ func HasFiles() predicate.Group {
 // HasFilesWith applies the HasEdge predicate on the "files" edge with a given conditions (other predicates).
 func HasFilesWith(preds ...predicate.File) predicate.Group {
 	return predicate.Group(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(FilesInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, FilesTable, FilesColumn),
-		)
+		step := newFilesStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -365,11 +361,7 @@ func HasBlocked() predicate.Group {
 // HasBlockedWith applies the HasEdge predicate on the "blocked" edge with a given conditions (other predicates).
 func HasBlockedWith(preds ...predicate.User) predicate.Group {
 	return predicate.Group(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(BlockedInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, BlockedTable, BlockedColumn),
-		)
+		step := newBlockedStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -392,11 +384,7 @@ func HasUsers() predicate.Group {
 // HasUsersWith applies the HasEdge predicate on the "users" edge with a given conditions (other predicates).
 func HasUsersWith(preds ...predicate.User) predicate.Group {
 	return predicate.Group(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(UsersInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, true, UsersTable, UsersPrimaryKey...),
-		)
+		step := newUsersStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -419,11 +407,7 @@ func HasInfo() predicate.Group {
 // HasInfoWith applies the HasEdge predicate on the "info" edge with a given conditions (other predicates).
 func HasInfoWith(preds ...predicate.GroupInfo) predicate.Group {
 	return predicate.Group(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(InfoInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, InfoTable, InfoColumn),
-		)
+		step := newInfoStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/ent/group_query.go
+++ b/entc/integration/ent/group_query.go
@@ -27,7 +27,7 @@ import (
 type GroupQuery struct {
 	config
 	ctx              *QueryContext
-	order            []OrderFunc
+	order            []group.Order
 	inters           []Interceptor
 	predicates       []predicate.Group
 	withFiles        *FileQuery
@@ -70,7 +70,7 @@ func (gq *GroupQuery) Unique(unique bool) *GroupQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (gq *GroupQuery) Order(o ...OrderFunc) *GroupQuery {
+func (gq *GroupQuery) Order(o ...group.Order) *GroupQuery {
 	gq.order = append(gq.order, o...)
 	return gq
 }
@@ -352,7 +352,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 	return &GroupQuery{
 		config:      gq.config,
 		ctx:         gq.ctx.Clone(),
-		order:       append([]OrderFunc{}, gq.order...),
+		order:       append([]group.Order{}, gq.order...),
 		inters:      append([]Interceptor{}, gq.inters...),
 		predicates:  append([]predicate.Group{}, gq.predicates...),
 		withFiles:   gq.withFiles.Clone(),

--- a/entc/integration/ent/groupinfo/groupinfo.go
+++ b/entc/integration/ent/groupinfo/groupinfo.go
@@ -6,6 +6,11 @@
 
 package groupinfo
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the groupinfo type in the database.
 	Label = "group_info"
@@ -49,5 +54,44 @@ var (
 	// DefaultMaxUsers holds the default value on creation for the "max_users" field.
 	DefaultMaxUsers int
 )
+
+// Order defines the ordering method for the GroupInfo queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByDesc orders the results by the desc field.
+func ByDesc(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldDesc, opts...).ToFunc()
+}
+
+// ByMaxUsers orders the results by the max_users field.
+func ByMaxUsers(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldMaxUsers, opts...).ToFunc()
+}
+
+// ByGroupsCount orders the results by groups count.
+func ByGroupsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newGroupsStep(), opts...)
+	}
+}
+
+// ByGroups orders the results by groups terms.
+func ByGroups(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newGroupsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newGroupsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(GroupsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, true, GroupsTable, GroupsColumn),
+	)
+}
 
 // comment from another template.

--- a/entc/integration/ent/groupinfo/where.go
+++ b/entc/integration/ent/groupinfo/where.go
@@ -186,11 +186,7 @@ func HasGroups() predicate.GroupInfo {
 // HasGroupsWith applies the HasEdge predicate on the "groups" edge with a given conditions (other predicates).
 func HasGroupsWith(preds ...predicate.Group) predicate.GroupInfo {
 	return predicate.GroupInfo(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(GroupsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, true, GroupsTable, GroupsColumn),
-		)
+		step := newGroupsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/ent/groupinfo_query.go
+++ b/entc/integration/ent/groupinfo_query.go
@@ -25,7 +25,7 @@ import (
 type GroupInfoQuery struct {
 	config
 	ctx             *QueryContext
-	order           []OrderFunc
+	order           []groupinfo.Order
 	inters          []Interceptor
 	predicates      []predicate.GroupInfo
 	withGroups      *GroupQuery
@@ -62,7 +62,7 @@ func (giq *GroupInfoQuery) Unique(unique bool) *GroupInfoQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (giq *GroupInfoQuery) Order(o ...OrderFunc) *GroupInfoQuery {
+func (giq *GroupInfoQuery) Order(o ...groupinfo.Order) *GroupInfoQuery {
 	giq.order = append(giq.order, o...)
 	return giq
 }
@@ -278,7 +278,7 @@ func (giq *GroupInfoQuery) Clone() *GroupInfoQuery {
 	return &GroupInfoQuery{
 		config:     giq.config,
 		ctx:        giq.ctx.Clone(),
-		order:      append([]OrderFunc{}, giq.order...),
+		order:      append([]groupinfo.Order{}, giq.order...),
 		inters:     append([]Interceptor{}, giq.inters...),
 		predicates: append([]predicate.GroupInfo{}, giq.predicates...),
 		withGroups: giq.withGroups.Clone(),

--- a/entc/integration/ent/item/item.go
+++ b/entc/integration/ent/item/item.go
@@ -6,6 +6,10 @@
 
 package item
 
+import (
+	"entgo.io/ent/dialect/sql"
+)
+
 const (
 	// Label holds the string label denoting the item type in the database.
 	Label = "item"
@@ -41,5 +45,18 @@ var (
 	// IDValidator is a validator for the "id" field. It is called by the builders before save.
 	IDValidator func(string) error
 )
+
+// Order defines the ordering method for the Item queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByText orders the results by the text field.
+func ByText(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldText, opts...).ToFunc()
+}
 
 // comment from another template.

--- a/entc/integration/ent/item_query.go
+++ b/entc/integration/ent/item_query.go
@@ -23,7 +23,7 @@ import (
 type ItemQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []item.Order
 	inters     []Interceptor
 	predicates []predicate.Item
 	modifiers  []func(*sql.Selector)
@@ -58,7 +58,7 @@ func (iq *ItemQuery) Unique(unique bool) *ItemQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (iq *ItemQuery) Order(o ...OrderFunc) *ItemQuery {
+func (iq *ItemQuery) Order(o ...item.Order) *ItemQuery {
 	iq.order = append(iq.order, o...)
 	return iq
 }
@@ -252,7 +252,7 @@ func (iq *ItemQuery) Clone() *ItemQuery {
 	return &ItemQuery{
 		config:     iq.config,
 		ctx:        iq.ctx.Clone(),
-		order:      append([]OrderFunc{}, iq.order...),
+		order:      append([]item.Order{}, iq.order...),
 		inters:     append([]Interceptor{}, iq.inters...),
 		predicates: append([]predicate.Item{}, iq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/ent/license/license.go
+++ b/entc/integration/ent/license/license.go
@@ -8,6 +8,8 @@ package license
 
 import (
 	"time"
+
+	"entgo.io/ent/dialect/sql"
 )
 
 const (
@@ -48,5 +50,23 @@ var (
 	// UpdateDefaultUpdateTime holds the default value on update for the "update_time" field.
 	UpdateDefaultUpdateTime func() time.Time
 )
+
+// Order defines the ordering method for the License queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByCreateTime orders the results by the create_time field.
+func ByCreateTime(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldCreateTime, opts...).ToFunc()
+}
+
+// ByUpdateTime orders the results by the update_time field.
+func ByUpdateTime(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldUpdateTime, opts...).ToFunc()
+}
 
 // comment from another template.

--- a/entc/integration/ent/license_query.go
+++ b/entc/integration/ent/license_query.go
@@ -23,7 +23,7 @@ import (
 type LicenseQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []license.Order
 	inters     []Interceptor
 	predicates []predicate.License
 	modifiers  []func(*sql.Selector)
@@ -58,7 +58,7 @@ func (lq *LicenseQuery) Unique(unique bool) *LicenseQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (lq *LicenseQuery) Order(o ...OrderFunc) *LicenseQuery {
+func (lq *LicenseQuery) Order(o ...license.Order) *LicenseQuery {
 	lq.order = append(lq.order, o...)
 	return lq
 }
@@ -252,7 +252,7 @@ func (lq *LicenseQuery) Clone() *LicenseQuery {
 	return &LicenseQuery{
 		config:     lq.config,
 		ctx:        lq.ctx.Clone(),
-		order:      append([]OrderFunc{}, lq.order...),
+		order:      append([]license.Order{}, lq.order...),
 		inters:     append([]Interceptor{}, lq.inters...),
 		predicates: append([]predicate.License{}, lq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/ent/node/node.go
+++ b/entc/integration/ent/node/node.go
@@ -8,6 +8,9 @@ package node
 
 import (
 	"time"
+
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
 )
 
 const (
@@ -67,5 +70,51 @@ var (
 	// UpdateDefaultUpdatedAt holds the default value on update for the "updated_at" field.
 	UpdateDefaultUpdatedAt func() time.Time
 )
+
+// Order defines the ordering method for the Node queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByValue orders the results by the value field.
+func ByValue(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldValue, opts...).ToFunc()
+}
+
+// ByUpdatedAt orders the results by the updated_at field.
+func ByUpdatedAt(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldUpdatedAt, opts...).ToFunc()
+}
+
+// ByPrevField orders the results by prev field.
+func ByPrevField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newPrevStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByNextField orders the results by next field.
+func ByNextField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newNextStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newPrevStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.O2O, true, PrevTable, PrevColumn),
+	)
+}
+func newNextStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.O2O, false, NextTable, NextColumn),
+	)
+}
 
 // comment from another template.

--- a/entc/integration/ent/node/where.go
+++ b/entc/integration/ent/node/where.go
@@ -183,11 +183,7 @@ func HasPrev() predicate.Node {
 // HasPrevWith applies the HasEdge predicate on the "prev" edge with a given conditions (other predicates).
 func HasPrevWith(preds ...predicate.Node) predicate.Node {
 	return predicate.Node(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, true, PrevTable, PrevColumn),
-		)
+		step := newPrevStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -210,11 +206,7 @@ func HasNext() predicate.Node {
 // HasNextWith applies the HasEdge predicate on the "next" edge with a given conditions (other predicates).
 func HasNextWith(preds ...predicate.Node) predicate.Node {
 	return predicate.Node(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, false, NextTable, NextColumn),
-		)
+		step := newNextStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/ent/node_query.go
+++ b/entc/integration/ent/node_query.go
@@ -24,7 +24,7 @@ import (
 type NodeQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []node.Order
 	inters     []Interceptor
 	predicates []predicate.Node
 	withPrev   *NodeQuery
@@ -62,7 +62,7 @@ func (nq *NodeQuery) Unique(unique bool) *NodeQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (nq *NodeQuery) Order(o ...OrderFunc) *NodeQuery {
+func (nq *NodeQuery) Order(o ...node.Order) *NodeQuery {
 	nq.order = append(nq.order, o...)
 	return nq
 }
@@ -300,7 +300,7 @@ func (nq *NodeQuery) Clone() *NodeQuery {
 	return &NodeQuery{
 		config:     nq.config,
 		ctx:        nq.ctx.Clone(),
-		order:      append([]OrderFunc{}, nq.order...),
+		order:      append([]node.Order{}, nq.order...),
 		inters:     append([]Interceptor{}, nq.inters...),
 		predicates: append([]predicate.Node{}, nq.predicates...),
 		withPrev:   nq.withPrev.Clone(),

--- a/entc/integration/ent/pet/pet.go
+++ b/entc/integration/ent/pet/pet.go
@@ -6,6 +6,11 @@
 
 package pet
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the pet type in the database.
 	Label = "pet"
@@ -81,5 +86,66 @@ var (
 	// DefaultTrained holds the default value on creation for the "trained" field.
 	DefaultTrained bool
 )
+
+// Order defines the ordering method for the Pet queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByAge orders the results by the age field.
+func ByAge(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldAge, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByUUID orders the results by the uuid field.
+func ByUUID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldUUID, opts...).ToFunc()
+}
+
+// ByNickname orders the results by the nickname field.
+func ByNickname(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldNickname, opts...).ToFunc()
+}
+
+// ByTrained orders the results by the trained field.
+func ByTrained(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldTrained, opts...).ToFunc()
+}
+
+// ByTeamField orders the results by team field.
+func ByTeamField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newTeamStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByOwnerField orders the results by owner field.
+func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newTeamStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(TeamInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2O, true, TeamTable, TeamColumn),
+	)
+}
+func newOwnerStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(OwnerInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
+	)
+}
 
 // comment from another template.

--- a/entc/integration/ent/pet/where.go
+++ b/entc/integration/ent/pet/where.go
@@ -337,11 +337,7 @@ func HasTeam() predicate.Pet {
 // HasTeamWith applies the HasEdge predicate on the "team" edge with a given conditions (other predicates).
 func HasTeamWith(preds ...predicate.User) predicate.Pet {
 	return predicate.Pet(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(TeamInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, true, TeamTable, TeamColumn),
-		)
+		step := newTeamStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -364,11 +360,7 @@ func HasOwner() predicate.Pet {
 // HasOwnerWith applies the HasEdge predicate on the "owner" edge with a given conditions (other predicates).
 func HasOwnerWith(preds ...predicate.User) predicate.Pet {
 	return predicate.Pet(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(OwnerInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
-		)
+		step := newOwnerStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/ent/pet_query.go
+++ b/entc/integration/ent/pet_query.go
@@ -24,7 +24,7 @@ import (
 type PetQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []pet.Order
 	inters     []Interceptor
 	predicates []predicate.Pet
 	withTeam   *UserQuery
@@ -62,7 +62,7 @@ func (pq *PetQuery) Unique(unique bool) *PetQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (pq *PetQuery) Order(o ...OrderFunc) *PetQuery {
+func (pq *PetQuery) Order(o ...pet.Order) *PetQuery {
 	pq.order = append(pq.order, o...)
 	return pq
 }
@@ -300,7 +300,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 	return &PetQuery{
 		config:     pq.config,
 		ctx:        pq.ctx.Clone(),
-		order:      append([]OrderFunc{}, pq.order...),
+		order:      append([]pet.Order{}, pq.order...),
 		inters:     append([]Interceptor{}, pq.inters...),
 		predicates: append([]predicate.Pet{}, pq.predicates...),
 		withTeam:   pq.withTeam.Clone(),

--- a/entc/integration/ent/spec/where.go
+++ b/entc/integration/ent/spec/where.go
@@ -71,11 +71,7 @@ func HasCard() predicate.Spec {
 // HasCardWith applies the HasEdge predicate on the "card" edge with a given conditions (other predicates).
 func HasCardWith(preds ...predicate.Card) predicate.Spec {
 	return predicate.Spec(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(CardInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, CardTable, CardPrimaryKey...),
-		)
+		step := newCardStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/ent/spec_query.go
+++ b/entc/integration/ent/spec_query.go
@@ -25,7 +25,7 @@ import (
 type SpecQuery struct {
 	config
 	ctx           *QueryContext
-	order         []OrderFunc
+	order         []spec.Order
 	inters        []Interceptor
 	predicates    []predicate.Spec
 	withCard      *CardQuery
@@ -62,7 +62,7 @@ func (sq *SpecQuery) Unique(unique bool) *SpecQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (sq *SpecQuery) Order(o ...OrderFunc) *SpecQuery {
+func (sq *SpecQuery) Order(o ...spec.Order) *SpecQuery {
 	sq.order = append(sq.order, o...)
 	return sq
 }
@@ -278,7 +278,7 @@ func (sq *SpecQuery) Clone() *SpecQuery {
 	return &SpecQuery{
 		config:     sq.config,
 		ctx:        sq.ctx.Clone(),
-		order:      append([]OrderFunc{}, sq.order...),
+		order:      append([]spec.Order{}, sq.order...),
 		inters:     append([]Interceptor{}, sq.inters...),
 		predicates: append([]predicate.Spec{}, sq.predicates...),
 		withCard:   sq.withCard.Clone(),

--- a/entc/integration/ent/task/task.go
+++ b/entc/integration/ent/task/task.go
@@ -9,6 +9,7 @@ package enttask
 import (
 	"time"
 
+	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/entc/integration/ent/schema/task"
 )
 
@@ -57,5 +58,33 @@ var (
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time
 )
+
+// Order defines the ordering method for the Task queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByPriority orders the results by the priority field.
+func ByPriority(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldPriority, opts...).ToFunc()
+}
+
+// ByCreatedAt orders the results by the created_at field.
+func ByCreatedAt(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldCreatedAt, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByOwner orders the results by the owner field.
+func ByOwner(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldOwner, opts...).ToFunc()
+}
 
 // comment from another template.

--- a/entc/integration/ent/task_query.go
+++ b/entc/integration/ent/task_query.go
@@ -23,7 +23,7 @@ import (
 type TaskQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []enttask.Order
 	inters     []Interceptor
 	predicates []predicate.Task
 	modifiers  []func(*sql.Selector)
@@ -58,7 +58,7 @@ func (tq *TaskQuery) Unique(unique bool) *TaskQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (tq *TaskQuery) Order(o ...OrderFunc) *TaskQuery {
+func (tq *TaskQuery) Order(o ...enttask.Order) *TaskQuery {
 	tq.order = append(tq.order, o...)
 	return tq
 }
@@ -252,7 +252,7 @@ func (tq *TaskQuery) Clone() *TaskQuery {
 	return &TaskQuery{
 		config:     tq.config,
 		ctx:        tq.ctx.Clone(),
-		order:      append([]OrderFunc{}, tq.order...),
+		order:      append([]enttask.Order{}, tq.order...),
 		inters:     append([]Interceptor{}, tq.inters...),
 		predicates: append([]predicate.Task{}, tq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/ent/user/user.go
+++ b/entc/integration/ent/user/user.go
@@ -8,6 +8,9 @@ package user
 
 import (
 	"fmt"
+
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
 )
 
 const (
@@ -230,6 +233,272 @@ func EmploymentValidator(e Employment) error {
 	default:
 		return fmt.Errorf("user: invalid enum value for employment field: %q", e)
 	}
+}
+
+// Order defines the ordering method for the User queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByOptionalInt orders the results by the optional_int field.
+func ByOptionalInt(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldOptionalInt, opts...).ToFunc()
+}
+
+// ByAge orders the results by the age field.
+func ByAge(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldAge, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByLast orders the results by the last field.
+func ByLast(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldLast, opts...).ToFunc()
+}
+
+// ByNickname orders the results by the nickname field.
+func ByNickname(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldNickname, opts...).ToFunc()
+}
+
+// ByAddress orders the results by the address field.
+func ByAddress(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldAddress, opts...).ToFunc()
+}
+
+// ByPhone orders the results by the phone field.
+func ByPhone(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldPhone, opts...).ToFunc()
+}
+
+// ByPassword orders the results by the password field.
+func ByPassword(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldPassword, opts...).ToFunc()
+}
+
+// ByRole orders the results by the role field.
+func ByRole(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldRole, opts...).ToFunc()
+}
+
+// ByEmployment orders the results by the employment field.
+func ByEmployment(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldEmployment, opts...).ToFunc()
+}
+
+// BySSOCert orders the results by the SSOCert field.
+func BySSOCert(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldSSOCert, opts...).ToFunc()
+}
+
+// ByCardField orders the results by card field.
+func ByCardField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newCardStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByPetsCount orders the results by pets count.
+func ByPetsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newPetsStep(), opts...)
+	}
+}
+
+// ByPets orders the results by pets terms.
+func ByPets(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newPetsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByFilesCount orders the results by files count.
+func ByFilesCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newFilesStep(), opts...)
+	}
+}
+
+// ByFiles orders the results by files terms.
+func ByFiles(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newFilesStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByGroupsCount orders the results by groups count.
+func ByGroupsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newGroupsStep(), opts...)
+	}
+}
+
+// ByGroups orders the results by groups terms.
+func ByGroups(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newGroupsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByFriendsCount orders the results by friends count.
+func ByFriendsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newFriendsStep(), opts...)
+	}
+}
+
+// ByFriends orders the results by friends terms.
+func ByFriends(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newFriendsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByFollowersCount orders the results by followers count.
+func ByFollowersCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newFollowersStep(), opts...)
+	}
+}
+
+// ByFollowers orders the results by followers terms.
+func ByFollowers(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newFollowersStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByFollowingCount orders the results by following count.
+func ByFollowingCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newFollowingStep(), opts...)
+	}
+}
+
+// ByFollowing orders the results by following terms.
+func ByFollowing(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newFollowingStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByTeamField orders the results by team field.
+func ByTeamField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newTeamStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// BySpouseField orders the results by spouse field.
+func BySpouseField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newSpouseStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByChildrenCount orders the results by children count.
+func ByChildrenCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newChildrenStep(), opts...)
+	}
+}
+
+// ByChildren orders the results by children terms.
+func ByChildren(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newChildrenStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByParentField orders the results by parent field.
+func ByParentField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newParentStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newCardStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(CardInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2O, false, CardTable, CardColumn),
+	)
+}
+func newPetsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(PetsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, PetsTable, PetsColumn),
+	)
+}
+func newFilesStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(FilesInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, FilesTable, FilesColumn),
+	)
+}
+func newGroupsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(GroupsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, GroupsTable, GroupsPrimaryKey...),
+	)
+}
+func newFriendsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, FriendsTable, FriendsPrimaryKey...),
+	)
+}
+func newFollowersStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, true, FollowersTable, FollowersPrimaryKey...),
+	)
+}
+func newFollowingStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, FollowingTable, FollowingPrimaryKey...),
+	)
+}
+func newTeamStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(TeamInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2O, false, TeamTable, TeamColumn),
+	)
+}
+func newSpouseStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.O2O, false, SpouseTable, SpouseColumn),
+	)
+}
+func newChildrenStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, true, ChildrenTable, ChildrenColumn),
+	)
+}
+func newParentStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, false, ParentTable, ParentColumn),
+	)
 }
 
 // Ptr returns a new pointer to the enum value.

--- a/entc/integration/ent/user/where.go
+++ b/entc/integration/ent/user/where.go
@@ -751,11 +751,7 @@ func HasCard() predicate.User {
 // HasCardWith applies the HasEdge predicate on the "card" edge with a given conditions (other predicates).
 func HasCardWith(preds ...predicate.Card) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(CardInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, false, CardTable, CardColumn),
-		)
+		step := newCardStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -778,11 +774,7 @@ func HasPets() predicate.User {
 // HasPetsWith applies the HasEdge predicate on the "pets" edge with a given conditions (other predicates).
 func HasPetsWith(preds ...predicate.Pet) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(PetsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, PetsTable, PetsColumn),
-		)
+		step := newPetsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -805,11 +797,7 @@ func HasFiles() predicate.User {
 // HasFilesWith applies the HasEdge predicate on the "files" edge with a given conditions (other predicates).
 func HasFilesWith(preds ...predicate.File) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(FilesInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, FilesTable, FilesColumn),
-		)
+		step := newFilesStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -832,11 +820,7 @@ func HasGroups() predicate.User {
 // HasGroupsWith applies the HasEdge predicate on the "groups" edge with a given conditions (other predicates).
 func HasGroupsWith(preds ...predicate.Group) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(GroupsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, GroupsTable, GroupsPrimaryKey...),
-		)
+		step := newGroupsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -859,11 +843,7 @@ func HasFriends() predicate.User {
 // HasFriendsWith applies the HasEdge predicate on the "friends" edge with a given conditions (other predicates).
 func HasFriendsWith(preds ...predicate.User) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, FriendsTable, FriendsPrimaryKey...),
-		)
+		step := newFriendsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -886,11 +866,7 @@ func HasFollowers() predicate.User {
 // HasFollowersWith applies the HasEdge predicate on the "followers" edge with a given conditions (other predicates).
 func HasFollowersWith(preds ...predicate.User) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, true, FollowersTable, FollowersPrimaryKey...),
-		)
+		step := newFollowersStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -913,11 +889,7 @@ func HasFollowing() predicate.User {
 // HasFollowingWith applies the HasEdge predicate on the "following" edge with a given conditions (other predicates).
 func HasFollowingWith(preds ...predicate.User) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, FollowingTable, FollowingPrimaryKey...),
-		)
+		step := newFollowingStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -940,11 +912,7 @@ func HasTeam() predicate.User {
 // HasTeamWith applies the HasEdge predicate on the "team" edge with a given conditions (other predicates).
 func HasTeamWith(preds ...predicate.Pet) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(TeamInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, false, TeamTable, TeamColumn),
-		)
+		step := newTeamStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -967,11 +935,7 @@ func HasSpouse() predicate.User {
 // HasSpouseWith applies the HasEdge predicate on the "spouse" edge with a given conditions (other predicates).
 func HasSpouseWith(preds ...predicate.User) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, false, SpouseTable, SpouseColumn),
-		)
+		step := newSpouseStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -994,11 +958,7 @@ func HasChildren() predicate.User {
 // HasChildrenWith applies the HasEdge predicate on the "children" edge with a given conditions (other predicates).
 func HasChildrenWith(preds ...predicate.User) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, true, ChildrenTable, ChildrenColumn),
-		)
+		step := newChildrenStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -1021,11 +981,7 @@ func HasParent() predicate.User {
 // HasParentWith applies the HasEdge predicate on the "parent" edge with a given conditions (other predicates).
 func HasParentWith(preds ...predicate.User) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, ParentTable, ParentColumn),
-		)
+		step := newParentStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/ent/user_query.go
+++ b/entc/integration/ent/user_query.go
@@ -28,7 +28,7 @@ import (
 type UserQuery struct {
 	config
 	ctx                *QueryContext
-	order              []OrderFunc
+	order              []user.Order
 	inters             []Interceptor
 	predicates         []predicate.User
 	withCard           *CardQuery
@@ -82,7 +82,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...OrderFunc) *UserQuery {
+func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -518,7 +518,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:        uq.config,
 		ctx:           uq.ctx.Clone(),
-		order:         append([]OrderFunc{}, uq.order...),
+		order:         append([]user.Order{}, uq.order...),
 		inters:        append([]Interceptor{}, uq.inters...),
 		predicates:    append([]predicate.User{}, uq.predicates...),
 		withCard:      uq.withCard.Clone(),

--- a/entc/integration/gremlin/ent/api/api.go
+++ b/entc/integration/gremlin/ent/api/api.go
@@ -6,11 +6,18 @@
 
 package api
 
+import (
+	"entgo.io/ent/dialect/gremlin/graph/dsl"
+)
+
 const (
 	// Label holds the string label denoting the api type in the database.
 	Label = "api"
 	// FieldID holds the string denoting the id field in the database.
 	FieldID = "id"
 )
+
+// Order defines the ordering method for the Api queries.
+type Order func(*dsl.Traversal)
 
 // comment from another template.

--- a/entc/integration/gremlin/ent/api_query.go
+++ b/entc/integration/gremlin/ent/api_query.go
@@ -23,7 +23,7 @@ import (
 type APIQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []api.Order
 	inters     []Interceptor
 	predicates []predicate.Api
 	// intermediate query (i.e. traversal path).
@@ -57,7 +57,7 @@ func (aq *APIQuery) Unique(unique bool) *APIQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (aq *APIQuery) Order(o ...OrderFunc) *APIQuery {
+func (aq *APIQuery) Order(o ...api.Order) *APIQuery {
 	aq.order = append(aq.order, o...)
 	return aq
 }
@@ -251,7 +251,7 @@ func (aq *APIQuery) Clone() *APIQuery {
 	return &APIQuery{
 		config:     aq.config,
 		ctx:        aq.ctx.Clone(),
-		order:      append([]OrderFunc{}, aq.order...),
+		order:      append([]api.Order{}, aq.order...),
 		inters:     append([]Interceptor{}, aq.inters...),
 		predicates: append([]predicate.Api{}, aq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/gremlin/ent/card/card.go
+++ b/entc/integration/gremlin/ent/card/card.go
@@ -8,6 +8,8 @@ package card
 
 import (
 	"time"
+
+	"entgo.io/ent/dialect/gremlin/graph/dsl"
 )
 
 const (
@@ -49,5 +51,8 @@ var (
 	// NameValidator is a validator for the "name" field. It is called by the builders before save.
 	NameValidator func(string) error
 )
+
+// Order defines the ordering method for the Card queries.
+type Order func(*dsl.Traversal)
 
 // comment from another template.

--- a/entc/integration/gremlin/ent/card_query.go
+++ b/entc/integration/gremlin/ent/card_query.go
@@ -25,7 +25,7 @@ import (
 type CardQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []card.Order
 	inters     []Interceptor
 	predicates []predicate.Card
 	withOwner  *UserQuery
@@ -61,7 +61,7 @@ func (cq *CardQuery) Unique(unique bool) *CardQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *CardQuery) Order(o ...OrderFunc) *CardQuery {
+func (cq *CardQuery) Order(o ...card.Order) *CardQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -283,7 +283,7 @@ func (cq *CardQuery) Clone() *CardQuery {
 	return &CardQuery{
 		config:     cq.config,
 		ctx:        cq.ctx.Clone(),
-		order:      append([]OrderFunc{}, cq.order...),
+		order:      append([]card.Order{}, cq.order...),
 		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Card{}, cq.predicates...),
 		withOwner:  cq.withOwner.Clone(),

--- a/entc/integration/gremlin/ent/comment/comment.go
+++ b/entc/integration/gremlin/ent/comment/comment.go
@@ -6,6 +6,10 @@
 
 package comment
 
+import (
+	"entgo.io/ent/dialect/gremlin/graph/dsl"
+)
+
 const (
 	// Label holds the string label denoting the comment type in the database.
 	Label = "comment"
@@ -24,5 +28,8 @@ const (
 	// FieldClient holds the string denoting the client field in the database.
 	FieldClient = "client"
 )
+
+// Order defines the ordering method for the Comment queries.
+type Order func(*dsl.Traversal)
 
 // comment from another template.

--- a/entc/integration/gremlin/ent/comment_query.go
+++ b/entc/integration/gremlin/ent/comment_query.go
@@ -23,7 +23,7 @@ import (
 type CommentQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []comment.Order
 	inters     []Interceptor
 	predicates []predicate.Comment
 	// intermediate query (i.e. traversal path).
@@ -57,7 +57,7 @@ func (cq *CommentQuery) Unique(unique bool) *CommentQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *CommentQuery) Order(o ...OrderFunc) *CommentQuery {
+func (cq *CommentQuery) Order(o ...comment.Order) *CommentQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -251,7 +251,7 @@ func (cq *CommentQuery) Clone() *CommentQuery {
 	return &CommentQuery{
 		config:     cq.config,
 		ctx:        cq.ctx.Clone(),
-		order:      append([]OrderFunc{}, cq.order...),
+		order:      append([]comment.Order{}, cq.order...),
 		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Comment{}, cq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/gremlin/ent/ent.go
+++ b/entc/integration/gremlin/ent/ent.go
@@ -70,7 +70,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 type OrderFunc func(*dsl.Traversal)
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*dsl.Traversal) {
 	return func(tr *dsl.Traversal) {
 		for _, f := range fields {
 			tr.By(f, dsl.Incr)
@@ -79,7 +79,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*dsl.Traversal) {
 	return func(tr *dsl.Traversal) {
 		for _, f := range fields {
 			tr.By(f, dsl.Decr)

--- a/entc/integration/gremlin/ent/exvaluescan/exvaluescan.go
+++ b/entc/integration/gremlin/ent/exvaluescan/exvaluescan.go
@@ -10,6 +10,7 @@ import (
 	"math/big"
 	"net/url"
 
+	"entgo.io/ent/dialect/gremlin/graph/dsl"
 	"entgo.io/ent/schema/field"
 )
 
@@ -46,5 +47,8 @@ var (
 		CustomOptional field.TypeValueScanner[string]
 	}
 )
+
+// Order defines the ordering method for the ExValueScan queries.
+type Order func(*dsl.Traversal)
 
 // comment from another template.

--- a/entc/integration/gremlin/ent/exvaluescan_query.go
+++ b/entc/integration/gremlin/ent/exvaluescan_query.go
@@ -23,7 +23,7 @@ import (
 type ExValueScanQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []exvaluescan.Order
 	inters     []Interceptor
 	predicates []predicate.ExValueScan
 	// intermediate query (i.e. traversal path).
@@ -57,7 +57,7 @@ func (evsq *ExValueScanQuery) Unique(unique bool) *ExValueScanQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (evsq *ExValueScanQuery) Order(o ...OrderFunc) *ExValueScanQuery {
+func (evsq *ExValueScanQuery) Order(o ...exvaluescan.Order) *ExValueScanQuery {
 	evsq.order = append(evsq.order, o...)
 	return evsq
 }
@@ -251,7 +251,7 @@ func (evsq *ExValueScanQuery) Clone() *ExValueScanQuery {
 	return &ExValueScanQuery{
 		config:     evsq.config,
 		ctx:        evsq.ctx.Clone(),
-		order:      append([]OrderFunc{}, evsq.order...),
+		order:      append([]exvaluescan.Order{}, evsq.order...),
 		inters:     append([]Interceptor{}, evsq.inters...),
 		predicates: append([]predicate.ExValueScan{}, evsq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/gremlin/ent/fieldtype/fieldtype.go
+++ b/entc/integration/gremlin/ent/fieldtype/fieldtype.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"time"
 
+	"entgo.io/ent/dialect/gremlin/graph/dsl"
 	"entgo.io/ent/entc/integration/ent/role"
 	"entgo.io/ent/entc/integration/ent/schema"
 )
@@ -239,6 +240,9 @@ func PriorityValidator(pr role.Priority) error {
 		return fmt.Errorf("fieldtype: invalid enum value for priority field: %q", pr)
 	}
 }
+
+// Order defines the ordering method for the FieldType queries.
+type Order func(*dsl.Traversal)
 
 // Ptr returns a new pointer to the enum value.
 func (s State) Ptr() *State {

--- a/entc/integration/gremlin/ent/fieldtype_query.go
+++ b/entc/integration/gremlin/ent/fieldtype_query.go
@@ -23,7 +23,7 @@ import (
 type FieldTypeQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []fieldtype.Order
 	inters     []Interceptor
 	predicates []predicate.FieldType
 	// intermediate query (i.e. traversal path).
@@ -57,7 +57,7 @@ func (ftq *FieldTypeQuery) Unique(unique bool) *FieldTypeQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (ftq *FieldTypeQuery) Order(o ...OrderFunc) *FieldTypeQuery {
+func (ftq *FieldTypeQuery) Order(o ...fieldtype.Order) *FieldTypeQuery {
 	ftq.order = append(ftq.order, o...)
 	return ftq
 }
@@ -251,7 +251,7 @@ func (ftq *FieldTypeQuery) Clone() *FieldTypeQuery {
 	return &FieldTypeQuery{
 		config:     ftq.config,
 		ctx:        ftq.ctx.Clone(),
-		order:      append([]OrderFunc{}, ftq.order...),
+		order:      append([]fieldtype.Order{}, ftq.order...),
 		inters:     append([]Interceptor{}, ftq.inters...),
 		predicates: append([]predicate.FieldType{}, ftq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/gremlin/ent/file/file.go
+++ b/entc/integration/gremlin/ent/file/file.go
@@ -6,6 +6,10 @@
 
 package file
 
+import (
+	"entgo.io/ent/dialect/gremlin/graph/dsl"
+)
+
 const (
 	// Label holds the string label denoting the file type in the database.
 	Label = "file"
@@ -43,5 +47,8 @@ var (
 	// SizeValidator is a validator for the "size" field. It is called by the builders before save.
 	SizeValidator func(int) error
 )
+
+// Order defines the ordering method for the File queries.
+type Order func(*dsl.Traversal)
 
 // comment from another template.

--- a/entc/integration/gremlin/ent/file_query.go
+++ b/entc/integration/gremlin/ent/file_query.go
@@ -25,7 +25,7 @@ import (
 type FileQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []file.Order
 	inters     []Interceptor
 	predicates []predicate.File
 	withOwner  *UserQuery
@@ -62,7 +62,7 @@ func (fq *FileQuery) Unique(unique bool) *FileQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (fq *FileQuery) Order(o ...OrderFunc) *FileQuery {
+func (fq *FileQuery) Order(o ...file.Order) *FileQuery {
 	fq.order = append(fq.order, o...)
 	return fq
 }
@@ -298,7 +298,7 @@ func (fq *FileQuery) Clone() *FileQuery {
 	return &FileQuery{
 		config:     fq.config,
 		ctx:        fq.ctx.Clone(),
-		order:      append([]OrderFunc{}, fq.order...),
+		order:      append([]file.Order{}, fq.order...),
 		inters:     append([]Interceptor{}, fq.inters...),
 		predicates: append([]predicate.File{}, fq.predicates...),
 		withOwner:  fq.withOwner.Clone(),

--- a/entc/integration/gremlin/ent/filetype/filetype.go
+++ b/entc/integration/gremlin/ent/filetype/filetype.go
@@ -8,6 +8,8 @@ package filetype
 
 import (
 	"fmt"
+
+	"entgo.io/ent/dialect/gremlin/graph/dsl"
 )
 
 const (
@@ -79,6 +81,9 @@ func StateValidator(s State) error {
 		return fmt.Errorf("filetype: invalid enum value for state field: %q", s)
 	}
 }
+
+// Order defines the ordering method for the FileType queries.
+type Order func(*dsl.Traversal)
 
 // Ptr returns a new pointer to the enum value.
 func (_type Type) Ptr() *Type {

--- a/entc/integration/gremlin/ent/filetype_query.go
+++ b/entc/integration/gremlin/ent/filetype_query.go
@@ -23,7 +23,7 @@ import (
 type FileTypeQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []filetype.Order
 	inters     []Interceptor
 	predicates []predicate.FileType
 	withFiles  *FileQuery
@@ -58,7 +58,7 @@ func (ftq *FileTypeQuery) Unique(unique bool) *FileTypeQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (ftq *FileTypeQuery) Order(o ...OrderFunc) *FileTypeQuery {
+func (ftq *FileTypeQuery) Order(o ...filetype.Order) *FileTypeQuery {
 	ftq.order = append(ftq.order, o...)
 	return ftq
 }
@@ -266,7 +266,7 @@ func (ftq *FileTypeQuery) Clone() *FileTypeQuery {
 	return &FileTypeQuery{
 		config:     ftq.config,
 		ctx:        ftq.ctx.Clone(),
-		order:      append([]OrderFunc{}, ftq.order...),
+		order:      append([]filetype.Order{}, ftq.order...),
 		inters:     append([]Interceptor{}, ftq.inters...),
 		predicates: append([]predicate.FileType{}, ftq.predicates...),
 		withFiles:  ftq.withFiles.Clone(),

--- a/entc/integration/gremlin/ent/goods/goods.go
+++ b/entc/integration/gremlin/ent/goods/goods.go
@@ -6,11 +6,18 @@
 
 package goods
 
+import (
+	"entgo.io/ent/dialect/gremlin/graph/dsl"
+)
+
 const (
 	// Label holds the string label denoting the goods type in the database.
 	Label = "goods"
 	// FieldID holds the string denoting the id field in the database.
 	FieldID = "id"
 )
+
+// Order defines the ordering method for the Goods queries.
+type Order func(*dsl.Traversal)
 
 // comment from another template.

--- a/entc/integration/gremlin/ent/goods_query.go
+++ b/entc/integration/gremlin/ent/goods_query.go
@@ -23,7 +23,7 @@ import (
 type GoodsQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []goods.Order
 	inters     []Interceptor
 	predicates []predicate.Goods
 	// intermediate query (i.e. traversal path).
@@ -57,7 +57,7 @@ func (gq *GoodsQuery) Unique(unique bool) *GoodsQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (gq *GoodsQuery) Order(o ...OrderFunc) *GoodsQuery {
+func (gq *GoodsQuery) Order(o ...goods.Order) *GoodsQuery {
 	gq.order = append(gq.order, o...)
 	return gq
 }
@@ -251,7 +251,7 @@ func (gq *GoodsQuery) Clone() *GoodsQuery {
 	return &GoodsQuery{
 		config:     gq.config,
 		ctx:        gq.ctx.Clone(),
-		order:      append([]OrderFunc{}, gq.order...),
+		order:      append([]goods.Order{}, gq.order...),
 		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Goods{}, gq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/gremlin/ent/group/group.go
+++ b/entc/integration/gremlin/ent/group/group.go
@@ -6,6 +6,10 @@
 
 package group
 
+import (
+	"entgo.io/ent/dialect/gremlin/graph/dsl"
+)
+
 const (
 	// Label holds the string label denoting the group type in the database.
 	Label = "group"
@@ -51,5 +55,8 @@ var (
 	// NameValidator is a validator for the "name" field. It is called by the builders before save.
 	NameValidator func(string) error
 )
+
+// Order defines the ordering method for the Group queries.
+type Order func(*dsl.Traversal)
 
 // comment from another template.

--- a/entc/integration/gremlin/ent/group_query.go
+++ b/entc/integration/gremlin/ent/group_query.go
@@ -24,7 +24,7 @@ import (
 type GroupQuery struct {
 	config
 	ctx         *QueryContext
-	order       []OrderFunc
+	order       []group.Order
 	inters      []Interceptor
 	predicates  []predicate.Group
 	withFiles   *FileQuery
@@ -62,7 +62,7 @@ func (gq *GroupQuery) Unique(unique bool) *GroupQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (gq *GroupQuery) Order(o ...OrderFunc) *GroupQuery {
+func (gq *GroupQuery) Order(o ...group.Order) *GroupQuery {
 	gq.order = append(gq.order, o...)
 	return gq
 }
@@ -312,7 +312,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 	return &GroupQuery{
 		config:      gq.config,
 		ctx:         gq.ctx.Clone(),
-		order:       append([]OrderFunc{}, gq.order...),
+		order:       append([]group.Order{}, gq.order...),
 		inters:      append([]Interceptor{}, gq.inters...),
 		predicates:  append([]predicate.Group{}, gq.predicates...),
 		withFiles:   gq.withFiles.Clone(),

--- a/entc/integration/gremlin/ent/groupinfo/groupinfo.go
+++ b/entc/integration/gremlin/ent/groupinfo/groupinfo.go
@@ -6,6 +6,10 @@
 
 package groupinfo
 
+import (
+	"entgo.io/ent/dialect/gremlin/graph/dsl"
+)
+
 const (
 	// Label holds the string label denoting the groupinfo type in the database.
 	Label = "group_info"
@@ -25,5 +29,8 @@ var (
 	// DefaultMaxUsers holds the default value on creation for the "max_users" field.
 	DefaultMaxUsers int
 )
+
+// Order defines the ordering method for the GroupInfo queries.
+type Order func(*dsl.Traversal)
 
 // comment from another template.

--- a/entc/integration/gremlin/ent/groupinfo_query.go
+++ b/entc/integration/gremlin/ent/groupinfo_query.go
@@ -24,7 +24,7 @@ import (
 type GroupInfoQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []groupinfo.Order
 	inters     []Interceptor
 	predicates []predicate.GroupInfo
 	withGroups *GroupQuery
@@ -59,7 +59,7 @@ func (giq *GroupInfoQuery) Unique(unique bool) *GroupInfoQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (giq *GroupInfoQuery) Order(o ...OrderFunc) *GroupInfoQuery {
+func (giq *GroupInfoQuery) Order(o ...groupinfo.Order) *GroupInfoQuery {
 	giq.order = append(giq.order, o...)
 	return giq
 }
@@ -267,7 +267,7 @@ func (giq *GroupInfoQuery) Clone() *GroupInfoQuery {
 	return &GroupInfoQuery{
 		config:     giq.config,
 		ctx:        giq.ctx.Clone(),
-		order:      append([]OrderFunc{}, giq.order...),
+		order:      append([]groupinfo.Order{}, giq.order...),
 		inters:     append([]Interceptor{}, giq.inters...),
 		predicates: append([]predicate.GroupInfo{}, giq.predicates...),
 		withGroups: giq.withGroups.Clone(),

--- a/entc/integration/gremlin/ent/item/item.go
+++ b/entc/integration/gremlin/ent/item/item.go
@@ -6,6 +6,10 @@
 
 package item
 
+import (
+	"entgo.io/ent/dialect/gremlin/graph/dsl"
+)
+
 const (
 	// Label holds the string label denoting the item type in the database.
 	Label = "item"
@@ -23,5 +27,8 @@ var (
 	// IDValidator is a validator for the "id" field. It is called by the builders before save.
 	IDValidator func(string) error
 )
+
+// Order defines the ordering method for the Item queries.
+type Order func(*dsl.Traversal)
 
 // comment from another template.

--- a/entc/integration/gremlin/ent/item_query.go
+++ b/entc/integration/gremlin/ent/item_query.go
@@ -23,7 +23,7 @@ import (
 type ItemQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []item.Order
 	inters     []Interceptor
 	predicates []predicate.Item
 	// intermediate query (i.e. traversal path).
@@ -57,7 +57,7 @@ func (iq *ItemQuery) Unique(unique bool) *ItemQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (iq *ItemQuery) Order(o ...OrderFunc) *ItemQuery {
+func (iq *ItemQuery) Order(o ...item.Order) *ItemQuery {
 	iq.order = append(iq.order, o...)
 	return iq
 }
@@ -251,7 +251,7 @@ func (iq *ItemQuery) Clone() *ItemQuery {
 	return &ItemQuery{
 		config:     iq.config,
 		ctx:        iq.ctx.Clone(),
-		order:      append([]OrderFunc{}, iq.order...),
+		order:      append([]item.Order{}, iq.order...),
 		inters:     append([]Interceptor{}, iq.inters...),
 		predicates: append([]predicate.Item{}, iq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/gremlin/ent/license/license.go
+++ b/entc/integration/gremlin/ent/license/license.go
@@ -8,6 +8,8 @@ package license
 
 import (
 	"time"
+
+	"entgo.io/ent/dialect/gremlin/graph/dsl"
 )
 
 const (
@@ -29,5 +31,8 @@ var (
 	// UpdateDefaultUpdateTime holds the default value on update for the "update_time" field.
 	UpdateDefaultUpdateTime func() time.Time
 )
+
+// Order defines the ordering method for the License queries.
+type Order func(*dsl.Traversal)
 
 // comment from another template.

--- a/entc/integration/gremlin/ent/license_query.go
+++ b/entc/integration/gremlin/ent/license_query.go
@@ -23,7 +23,7 @@ import (
 type LicenseQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []license.Order
 	inters     []Interceptor
 	predicates []predicate.License
 	// intermediate query (i.e. traversal path).
@@ -57,7 +57,7 @@ func (lq *LicenseQuery) Unique(unique bool) *LicenseQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (lq *LicenseQuery) Order(o ...OrderFunc) *LicenseQuery {
+func (lq *LicenseQuery) Order(o ...license.Order) *LicenseQuery {
 	lq.order = append(lq.order, o...)
 	return lq
 }
@@ -251,7 +251,7 @@ func (lq *LicenseQuery) Clone() *LicenseQuery {
 	return &LicenseQuery{
 		config:     lq.config,
 		ctx:        lq.ctx.Clone(),
-		order:      append([]OrderFunc{}, lq.order...),
+		order:      append([]license.Order{}, lq.order...),
 		inters:     append([]Interceptor{}, lq.inters...),
 		predicates: append([]predicate.License{}, lq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/gremlin/ent/node/node.go
+++ b/entc/integration/gremlin/ent/node/node.go
@@ -8,6 +8,8 @@ package node
 
 import (
 	"time"
+
+	"entgo.io/ent/dialect/gremlin/graph/dsl"
 )
 
 const (
@@ -33,5 +35,8 @@ var (
 	// UpdateDefaultUpdatedAt holds the default value on update for the "updated_at" field.
 	UpdateDefaultUpdatedAt func() time.Time
 )
+
+// Order defines the ordering method for the Node queries.
+type Order func(*dsl.Traversal)
 
 // comment from another template.

--- a/entc/integration/gremlin/ent/node_query.go
+++ b/entc/integration/gremlin/ent/node_query.go
@@ -23,7 +23,7 @@ import (
 type NodeQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []node.Order
 	inters     []Interceptor
 	predicates []predicate.Node
 	withPrev   *NodeQuery
@@ -59,7 +59,7 @@ func (nq *NodeQuery) Unique(unique bool) *NodeQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (nq *NodeQuery) Order(o ...OrderFunc) *NodeQuery {
+func (nq *NodeQuery) Order(o ...node.Order) *NodeQuery {
 	nq.order = append(nq.order, o...)
 	return nq
 }
@@ -281,7 +281,7 @@ func (nq *NodeQuery) Clone() *NodeQuery {
 	return &NodeQuery{
 		config:     nq.config,
 		ctx:        nq.ctx.Clone(),
-		order:      append([]OrderFunc{}, nq.order...),
+		order:      append([]node.Order{}, nq.order...),
 		inters:     append([]Interceptor{}, nq.inters...),
 		predicates: append([]predicate.Node{}, nq.predicates...),
 		withPrev:   nq.withPrev.Clone(),

--- a/entc/integration/gremlin/ent/pet/pet.go
+++ b/entc/integration/gremlin/ent/pet/pet.go
@@ -6,6 +6,10 @@
 
 package pet
 
+import (
+	"entgo.io/ent/dialect/gremlin/graph/dsl"
+)
+
 const (
 	// Label holds the string label denoting the pet type in the database.
 	Label = "pet"
@@ -37,5 +41,8 @@ var (
 	// DefaultTrained holds the default value on creation for the "trained" field.
 	DefaultTrained bool
 )
+
+// Order defines the ordering method for the Pet queries.
+type Order func(*dsl.Traversal)
 
 // comment from another template.

--- a/entc/integration/gremlin/ent/pet_query.go
+++ b/entc/integration/gremlin/ent/pet_query.go
@@ -24,7 +24,7 @@ import (
 type PetQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []pet.Order
 	inters     []Interceptor
 	predicates []predicate.Pet
 	withTeam   *UserQuery
@@ -60,7 +60,7 @@ func (pq *PetQuery) Unique(unique bool) *PetQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (pq *PetQuery) Order(o ...OrderFunc) *PetQuery {
+func (pq *PetQuery) Order(o ...pet.Order) *PetQuery {
 	pq.order = append(pq.order, o...)
 	return pq
 }
@@ -282,7 +282,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 	return &PetQuery{
 		config:     pq.config,
 		ctx:        pq.ctx.Clone(),
-		order:      append([]OrderFunc{}, pq.order...),
+		order:      append([]pet.Order{}, pq.order...),
 		inters:     append([]Interceptor{}, pq.inters...),
 		predicates: append([]predicate.Pet{}, pq.predicates...),
 		withTeam:   pq.withTeam.Clone(),

--- a/entc/integration/gremlin/ent/spec/spec.go
+++ b/entc/integration/gremlin/ent/spec/spec.go
@@ -6,6 +6,10 @@
 
 package spec
 
+import (
+	"entgo.io/ent/dialect/gremlin/graph/dsl"
+)
+
 const (
 	// Label holds the string label denoting the spec type in the database.
 	Label = "spec"
@@ -16,5 +20,8 @@ const (
 	// CardLabel holds the string label denoting the card edge type in the database.
 	CardLabel = "spec_card"
 )
+
+// Order defines the ordering method for the Spec queries.
+type Order func(*dsl.Traversal)
 
 // comment from another template.

--- a/entc/integration/gremlin/ent/spec_query.go
+++ b/entc/integration/gremlin/ent/spec_query.go
@@ -23,7 +23,7 @@ import (
 type SpecQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []spec.Order
 	inters     []Interceptor
 	predicates []predicate.Spec
 	withCard   *CardQuery
@@ -58,7 +58,7 @@ func (sq *SpecQuery) Unique(unique bool) *SpecQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (sq *SpecQuery) Order(o ...OrderFunc) *SpecQuery {
+func (sq *SpecQuery) Order(o ...spec.Order) *SpecQuery {
 	sq.order = append(sq.order, o...)
 	return sq
 }
@@ -266,7 +266,7 @@ func (sq *SpecQuery) Clone() *SpecQuery {
 	return &SpecQuery{
 		config:     sq.config,
 		ctx:        sq.ctx.Clone(),
-		order:      append([]OrderFunc{}, sq.order...),
+		order:      append([]spec.Order{}, sq.order...),
 		inters:     append([]Interceptor{}, sq.inters...),
 		predicates: append([]predicate.Spec{}, sq.predicates...),
 		withCard:   sq.withCard.Clone(),

--- a/entc/integration/gremlin/ent/task/task.go
+++ b/entc/integration/gremlin/ent/task/task.go
@@ -9,6 +9,7 @@ package enttask
 import (
 	"time"
 
+	"entgo.io/ent/dialect/gremlin/graph/dsl"
 	"entgo.io/ent/entc/integration/ent/schema/task"
 )
 
@@ -35,5 +36,8 @@ var (
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time
 )
+
+// Order defines the ordering method for the Task queries.
+type Order func(*dsl.Traversal)
 
 // comment from another template.

--- a/entc/integration/gremlin/ent/task_query.go
+++ b/entc/integration/gremlin/ent/task_query.go
@@ -23,7 +23,7 @@ import (
 type TaskQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []enttask.Order
 	inters     []Interceptor
 	predicates []predicate.Task
 	// intermediate query (i.e. traversal path).
@@ -57,7 +57,7 @@ func (tq *TaskQuery) Unique(unique bool) *TaskQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (tq *TaskQuery) Order(o ...OrderFunc) *TaskQuery {
+func (tq *TaskQuery) Order(o ...enttask.Order) *TaskQuery {
 	tq.order = append(tq.order, o...)
 	return tq
 }
@@ -251,7 +251,7 @@ func (tq *TaskQuery) Clone() *TaskQuery {
 	return &TaskQuery{
 		config:     tq.config,
 		ctx:        tq.ctx.Clone(),
-		order:      append([]OrderFunc{}, tq.order...),
+		order:      append([]enttask.Order{}, tq.order...),
 		inters:     append([]Interceptor{}, tq.inters...),
 		predicates: append([]predicate.Task{}, tq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/gremlin/ent/user/user.go
+++ b/entc/integration/gremlin/ent/user/user.go
@@ -8,6 +8,8 @@ package user
 
 import (
 	"fmt"
+
+	"entgo.io/ent/dialect/gremlin/graph/dsl"
 )
 
 const (
@@ -146,6 +148,9 @@ func EmploymentValidator(e Employment) error {
 		return fmt.Errorf("user: invalid enum value for employment field: %q", e)
 	}
 }
+
+// Order defines the ordering method for the User queries.
+type Order func(*dsl.Traversal)
 
 // Ptr returns a new pointer to the enum value.
 func (r Role) Ptr() *Role {

--- a/entc/integration/gremlin/ent/user_query.go
+++ b/entc/integration/gremlin/ent/user_query.go
@@ -23,7 +23,7 @@ import (
 type UserQuery struct {
 	config
 	ctx           *QueryContext
-	order         []OrderFunc
+	order         []user.Order
 	inters        []Interceptor
 	predicates    []predicate.User
 	withCard      *CardQuery
@@ -68,7 +68,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...OrderFunc) *UserQuery {
+func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -416,7 +416,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:        uq.config,
 		ctx:           uq.ctx.Clone(),
-		order:         append([]OrderFunc{}, uq.order...),
+		order:         append([]user.Order{}, uq.order...),
 		inters:        append([]Interceptor{}, uq.inters...),
 		predicates:    append([]predicate.User{}, uq.predicates...),
 		withCard:      uq.withCard.Clone(),

--- a/entc/integration/hooks/ent/card/card.go
+++ b/entc/integration/hooks/ent/card/card.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"entgo.io/ent"
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
 )
 
 const (
@@ -86,3 +88,50 @@ var (
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time
 )
+
+// Order defines the ordering method for the Card queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByNumber orders the results by the number field.
+func ByNumber(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldNumber, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByCreatedAt orders the results by the created_at field.
+func ByCreatedAt(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldCreatedAt, opts...).ToFunc()
+}
+
+// ByInHook orders the results by the in_hook field.
+func ByInHook(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldInHook, opts...).ToFunc()
+}
+
+// ByExpiredAt orders the results by the expired_at field.
+func ByExpiredAt(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldExpiredAt, opts...).ToFunc()
+}
+
+// ByOwnerField orders the results by owner field.
+func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newOwnerStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(OwnerInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
+	)
+}

--- a/entc/integration/hooks/ent/card/where.go
+++ b/entc/integration/hooks/ent/card/where.go
@@ -393,11 +393,7 @@ func HasOwner() predicate.Card {
 // HasOwnerWith applies the HasEdge predicate on the "owner" edge with a given conditions (other predicates).
 func HasOwnerWith(preds ...predicate.User) predicate.Card {
 	return predicate.Card(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(OwnerInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
-		)
+		step := newOwnerStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/hooks/ent/card_query.go
+++ b/entc/integration/hooks/ent/card_query.go
@@ -23,7 +23,7 @@ import (
 type CardQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []card.Order
 	inters     []Interceptor
 	predicates []predicate.Card
 	withOwner  *UserQuery
@@ -59,7 +59,7 @@ func (cq *CardQuery) Unique(unique bool) *CardQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *CardQuery) Order(o ...OrderFunc) *CardQuery {
+func (cq *CardQuery) Order(o ...card.Order) *CardQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -275,7 +275,7 @@ func (cq *CardQuery) Clone() *CardQuery {
 	return &CardQuery{
 		config:     cq.config,
 		ctx:        cq.ctx.Clone(),
-		order:      append([]OrderFunc{}, cq.order...),
+		order:      append([]card.Order{}, cq.order...),
 		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Card{}, cq.predicates...),
 		withOwner:  cq.withOwner.Clone(),

--- a/entc/integration/hooks/ent/ent.go
+++ b/entc/integration/hooks/ent/ent.go
@@ -67,6 +67,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -87,7 +88,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -99,7 +100,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/entc/integration/hooks/ent/intercept/intercept.go
+++ b/entc/integration/hooks/ent/intercept/intercept.go
@@ -12,7 +12,10 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/entc/integration/hooks/ent"
+	"entgo.io/ent/entc/integration/hooks/ent/card"
+	"entgo.io/ent/entc/integration/hooks/ent/pet"
 	"entgo.io/ent/entc/integration/hooks/ent/predicate"
+	"entgo.io/ent/entc/integration/hooks/ent/user"
 )
 
 // The Query interface represents an operation that queries a graph.
@@ -28,7 +31,7 @@ type Query interface {
 	// Unique configures the query builder to filter duplicate records.
 	Unique(bool)
 	// Order specifies how the records should be ordered.
-	Order(...ent.OrderFunc)
+	Order(...func(*sql.Selector))
 	// WhereP appends storage-level predicates to the query builder. Using this method, users
 	// can use type-assertion to append predicates that do not depend on any generated package.
 	WhereP(...func(*sql.Selector))
@@ -156,48 +159,52 @@ func (f TraverseUser) Traverse(ctx context.Context, q ent.Query) error {
 func NewQuery(q ent.Query) (Query, error) {
 	switch q := q.(type) {
 	case *ent.CardQuery:
-		return &query[*ent.CardQuery, predicate.Card]{typ: ent.TypeCard, tq: q}, nil
+		return &query[*ent.CardQuery, predicate.Card, card.Order]{typ: ent.TypeCard, tq: q}, nil
 	case *ent.PetQuery:
-		return &query[*ent.PetQuery, predicate.Pet]{typ: ent.TypePet, tq: q}, nil
+		return &query[*ent.PetQuery, predicate.Pet, pet.Order]{typ: ent.TypePet, tq: q}, nil
 	case *ent.UserQuery:
-		return &query[*ent.UserQuery, predicate.User]{typ: ent.TypeUser, tq: q}, nil
+		return &query[*ent.UserQuery, predicate.User, user.Order]{typ: ent.TypeUser, tq: q}, nil
 	default:
 		return nil, fmt.Errorf("unknown query type %T", q)
 	}
 }
 
-type query[T any, P ~func(*sql.Selector)] struct {
+type query[T any, P ~func(*sql.Selector), R ~func(*sql.Selector)] struct {
 	typ string
 	tq  interface {
 		Limit(int) T
 		Offset(int) T
 		Unique(bool) T
-		Order(...ent.OrderFunc) T
+		Order(...R) T
 		Where(...P) T
 	}
 }
 
-func (q query[T, P]) Type() string {
+func (q query[T, P, R]) Type() string {
 	return q.typ
 }
 
-func (q query[T, P]) Limit(limit int) {
+func (q query[T, P, R]) Limit(limit int) {
 	q.tq.Limit(limit)
 }
 
-func (q query[T, P]) Offset(offset int) {
+func (q query[T, P, R]) Offset(offset int) {
 	q.tq.Offset(offset)
 }
 
-func (q query[T, P]) Unique(unique bool) {
+func (q query[T, P, R]) Unique(unique bool) {
 	q.tq.Unique(unique)
 }
 
-func (q query[T, P]) Order(orders ...ent.OrderFunc) {
-	q.tq.Order(orders...)
+func (q query[T, P, R]) Order(orders ...func(*sql.Selector)) {
+	rs := make([]R, len(orders))
+	for i := range orders {
+		rs[i] = orders[i]
+	}
+	q.tq.Order(rs...)
 }
 
-func (q query[T, P]) WhereP(ps ...func(*sql.Selector)) {
+func (q query[T, P, R]) WhereP(ps ...func(*sql.Selector)) {
 	p := make([]P, len(ps))
 	for i := range ps {
 		p[i] = ps[i]

--- a/entc/integration/hooks/ent/pet/pet.go
+++ b/entc/integration/hooks/ent/pet/pet.go
@@ -8,6 +8,8 @@ package pet
 
 import (
 	"entgo.io/ent"
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
 )
 
 const (
@@ -69,3 +71,35 @@ var (
 	Hooks        [1]ent.Hook
 	Interceptors [1]ent.Interceptor
 )
+
+// Order defines the ordering method for the Pet queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByDeleteTime orders the results by the delete_time field.
+func ByDeleteTime(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldDeleteTime, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByOwnerField orders the results by owner field.
+func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newOwnerStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(OwnerInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
+	)
+}

--- a/entc/integration/hooks/ent/pet/where.go
+++ b/entc/integration/hooks/ent/pet/where.go
@@ -208,11 +208,7 @@ func HasOwner() predicate.Pet {
 // HasOwnerWith applies the HasEdge predicate on the "owner" edge with a given conditions (other predicates).
 func HasOwnerWith(preds ...predicate.User) predicate.Pet {
 	return predicate.Pet(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(OwnerInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
-		)
+		step := newOwnerStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/hooks/ent/pet_query.go
+++ b/entc/integration/hooks/ent/pet_query.go
@@ -23,7 +23,7 @@ import (
 type PetQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []pet.Order
 	inters     []Interceptor
 	predicates []predicate.Pet
 	withOwner  *UserQuery
@@ -59,7 +59,7 @@ func (pq *PetQuery) Unique(unique bool) *PetQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (pq *PetQuery) Order(o ...OrderFunc) *PetQuery {
+func (pq *PetQuery) Order(o ...pet.Order) *PetQuery {
 	pq.order = append(pq.order, o...)
 	return pq
 }
@@ -275,7 +275,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 	return &PetQuery{
 		config:     pq.config,
 		ctx:        pq.ctx.Clone(),
-		order:      append([]OrderFunc{}, pq.order...),
+		order:      append([]pet.Order{}, pq.order...),
 		inters:     append([]Interceptor{}, pq.inters...),
 		predicates: append([]predicate.Pet{}, pq.predicates...),
 		withOwner:  pq.withOwner.Clone(),

--- a/entc/integration/hooks/ent/user/user.go
+++ b/entc/integration/hooks/ent/user/user.go
@@ -8,6 +8,8 @@ package user
 
 import (
 	"entgo.io/ent"
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
 )
 
 const (
@@ -106,3 +108,113 @@ var (
 	// DefaultActive holds the default value on creation for the "active" field.
 	DefaultActive bool
 )
+
+// Order defines the ordering method for the User queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByVersion orders the results by the version field.
+func ByVersion(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldVersion, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByWorth orders the results by the worth field.
+func ByWorth(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldWorth, opts...).ToFunc()
+}
+
+// ByPassword orders the results by the password field.
+func ByPassword(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldPassword, opts...).ToFunc()
+}
+
+// ByActive orders the results by the active field.
+func ByActive(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldActive, opts...).ToFunc()
+}
+
+// ByCardsCount orders the results by cards count.
+func ByCardsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newCardsStep(), opts...)
+	}
+}
+
+// ByCards orders the results by cards terms.
+func ByCards(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newCardsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByPetsCount orders the results by pets count.
+func ByPetsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newPetsStep(), opts...)
+	}
+}
+
+// ByPets orders the results by pets terms.
+func ByPets(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newPetsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByFriendsCount orders the results by friends count.
+func ByFriendsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newFriendsStep(), opts...)
+	}
+}
+
+// ByFriends orders the results by friends terms.
+func ByFriends(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newFriendsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByBestFriendField orders the results by best_friend field.
+func ByBestFriendField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newBestFriendStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newCardsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(CardsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, CardsTable, CardsColumn),
+	)
+}
+func newPetsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(PetsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, PetsTable, PetsColumn),
+	)
+}
+func newFriendsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, FriendsTable, FriendsPrimaryKey...),
+	)
+}
+func newBestFriendStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.O2O, false, BestFriendTable, BestFriendColumn),
+	)
+}

--- a/entc/integration/hooks/ent/user/where.go
+++ b/entc/integration/hooks/ent/user/where.go
@@ -336,11 +336,7 @@ func HasCards() predicate.User {
 // HasCardsWith applies the HasEdge predicate on the "cards" edge with a given conditions (other predicates).
 func HasCardsWith(preds ...predicate.Card) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(CardsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, CardsTable, CardsColumn),
-		)
+		step := newCardsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -363,11 +359,7 @@ func HasPets() predicate.User {
 // HasPetsWith applies the HasEdge predicate on the "pets" edge with a given conditions (other predicates).
 func HasPetsWith(preds ...predicate.Pet) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(PetsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, PetsTable, PetsColumn),
-		)
+		step := newPetsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -390,11 +382,7 @@ func HasFriends() predicate.User {
 // HasFriendsWith applies the HasEdge predicate on the "friends" edge with a given conditions (other predicates).
 func HasFriendsWith(preds ...predicate.User) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, FriendsTable, FriendsPrimaryKey...),
-		)
+		step := newFriendsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -417,11 +405,7 @@ func HasBestFriend() predicate.User {
 // HasBestFriendWith applies the HasEdge predicate on the "best_friend" edge with a given conditions (other predicates).
 func HasBestFriendWith(preds ...predicate.User) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, false, BestFriendTable, BestFriendColumn),
-		)
+		step := newBestFriendStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/hooks/ent/user_query.go
+++ b/entc/integration/hooks/ent/user_query.go
@@ -25,7 +25,7 @@ import (
 type UserQuery struct {
 	config
 	ctx            *QueryContext
-	order          []OrderFunc
+	order          []user.Order
 	inters         []Interceptor
 	predicates     []predicate.User
 	withCards      *CardQuery
@@ -64,7 +64,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...OrderFunc) *UserQuery {
+func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -346,7 +346,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:         uq.config,
 		ctx:            uq.ctx.Clone(),
-		order:          append([]OrderFunc{}, uq.order...),
+		order:          append([]user.Order{}, uq.order...),
 		inters:         append([]Interceptor{}, uq.inters...),
 		predicates:     append([]predicate.User{}, uq.predicates...),
 		withCards:      uq.withCards.Clone(),

--- a/entc/integration/idtype/ent/ent.go
+++ b/entc/integration/idtype/ent/ent.go
@@ -65,6 +65,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -83,7 +84,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -95,7 +96,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/entc/integration/idtype/ent/user/user.go
+++ b/entc/integration/idtype/ent/user/user.go
@@ -6,6 +6,11 @@
 
 package user
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the user type in the database.
 	Label = "user"
@@ -65,4 +70,73 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the User queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// BySpouseField orders the results by spouse field.
+func BySpouseField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newSpouseStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByFollowersCount orders the results by followers count.
+func ByFollowersCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newFollowersStep(), opts...)
+	}
+}
+
+// ByFollowers orders the results by followers terms.
+func ByFollowers(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newFollowersStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByFollowingCount orders the results by following count.
+func ByFollowingCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newFollowingStep(), opts...)
+	}
+}
+
+// ByFollowing orders the results by following terms.
+func ByFollowing(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newFollowingStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newSpouseStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.O2O, false, SpouseTable, SpouseColumn),
+	)
+}
+func newFollowersStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, true, FollowersTable, FollowersPrimaryKey...),
+	)
+}
+func newFollowingStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, FollowingTable, FollowingPrimaryKey...),
+	)
 }

--- a/entc/integration/idtype/ent/user/where.go
+++ b/entc/integration/idtype/ent/user/where.go
@@ -141,11 +141,7 @@ func HasSpouse() predicate.User {
 // HasSpouseWith applies the HasEdge predicate on the "spouse" edge with a given conditions (other predicates).
 func HasSpouseWith(preds ...predicate.User) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, false, SpouseTable, SpouseColumn),
-		)
+		step := newSpouseStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -168,11 +164,7 @@ func HasFollowers() predicate.User {
 // HasFollowersWith applies the HasEdge predicate on the "followers" edge with a given conditions (other predicates).
 func HasFollowersWith(preds ...predicate.User) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, true, FollowersTable, FollowersPrimaryKey...),
-		)
+		step := newFollowersStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -195,11 +187,7 @@ func HasFollowing() predicate.User {
 // HasFollowingWith applies the HasEdge predicate on the "following" edge with a given conditions (other predicates).
 func HasFollowingWith(preds ...predicate.User) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, FollowingTable, FollowingPrimaryKey...),
-		)
+		step := newFollowingStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/idtype/ent/user_query.go
+++ b/entc/integration/idtype/ent/user_query.go
@@ -23,7 +23,7 @@ import (
 type UserQuery struct {
 	config
 	ctx           *QueryContext
-	order         []OrderFunc
+	order         []user.Order
 	inters        []Interceptor
 	predicates    []predicate.User
 	withSpouse    *UserQuery
@@ -61,7 +61,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...OrderFunc) *UserQuery {
+func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -321,7 +321,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:        uq.config,
 		ctx:           uq.ctx.Clone(),
-		order:         append([]OrderFunc{}, uq.order...),
+		order:         append([]user.Order{}, uq.order...),
 		inters:        append([]Interceptor{}, uq.inters...),
 		predicates:    append([]predicate.User{}, uq.predicates...),
 		withSpouse:    uq.withSpouse.Clone(),

--- a/entc/integration/json/ent/ent.go
+++ b/entc/integration/json/ent/ent.go
@@ -65,6 +65,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -83,7 +84,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -95,7 +96,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/entc/integration/json/ent/user/user.go
+++ b/entc/integration/json/ent/user/user.go
@@ -8,6 +8,8 @@ package user
 
 import (
 	"net/http"
+
+	"entgo.io/ent/dialect/sql"
 )
 
 const (
@@ -70,3 +72,11 @@ var (
 	// DefaultInts holds the default value on creation for the "ints" field.
 	DefaultInts []int
 )
+
+// Order defines the ordering method for the User queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}

--- a/entc/integration/json/ent/user_query.go
+++ b/entc/integration/json/ent/user_query.go
@@ -22,7 +22,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []user.Order
 	inters     []Interceptor
 	predicates []predicate.User
 	modifiers  []func(*sql.Selector)
@@ -57,7 +57,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...OrderFunc) *UserQuery {
+func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -251,7 +251,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]OrderFunc{}, uq.order...),
+		order:      append([]user.Order{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/migrate/entv1/car/car.go
+++ b/entc/integration/migrate/entv1/car/car.go
@@ -6,6 +6,11 @@
 
 package car
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the car type in the database.
 	Label = "car"
@@ -50,4 +55,26 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Car queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByOwnerField orders the results by owner field.
+func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newOwnerStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(OwnerInverseTable, UserFieldID),
+		sqlgraph.Edge(sqlgraph.O2O, true, OwnerTable, OwnerColumn),
+	)
 }

--- a/entc/integration/migrate/entv1/car/where.go
+++ b/entc/integration/migrate/entv1/car/where.go
@@ -71,11 +71,7 @@ func HasOwner() predicate.Car {
 // HasOwnerWith applies the HasEdge predicate on the "owner" edge with a given conditions (other predicates).
 func HasOwnerWith(preds ...predicate.User) predicate.Car {
 	return predicate.Car(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(OwnerInverseTable, UserFieldID),
-			sqlgraph.Edge(sqlgraph.O2O, true, OwnerTable, OwnerColumn),
-		)
+		step := newOwnerStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/migrate/entv1/car_query.go
+++ b/entc/integration/migrate/entv1/car_query.go
@@ -23,7 +23,7 @@ import (
 type CarQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []car.Order
 	inters     []Interceptor
 	predicates []predicate.Car
 	withOwner  *UserQuery
@@ -59,7 +59,7 @@ func (cq *CarQuery) Unique(unique bool) *CarQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *CarQuery) Order(o ...OrderFunc) *CarQuery {
+func (cq *CarQuery) Order(o ...car.Order) *CarQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -275,7 +275,7 @@ func (cq *CarQuery) Clone() *CarQuery {
 	return &CarQuery{
 		config:     cq.config,
 		ctx:        cq.ctx.Clone(),
-		order:      append([]OrderFunc{}, cq.order...),
+		order:      append([]car.Order{}, cq.order...),
 		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Car{}, cq.predicates...),
 		withOwner:  cq.withOwner.Clone(),

--- a/entc/integration/migrate/entv1/conversion/conversion.go
+++ b/entc/integration/migrate/entv1/conversion/conversion.go
@@ -6,6 +6,10 @@
 
 package conversion
 
+import (
+	"entgo.io/ent/dialect/sql"
+)
+
 const (
 	// Label holds the string label denoting the conversion type in the database.
 	Label = "conversion"
@@ -55,4 +59,57 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Conversion queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByInt8ToString orders the results by the int8_to_string field.
+func ByInt8ToString(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldInt8ToString, opts...).ToFunc()
+}
+
+// ByUint8ToString orders the results by the uint8_to_string field.
+func ByUint8ToString(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldUint8ToString, opts...).ToFunc()
+}
+
+// ByInt16ToString orders the results by the int16_to_string field.
+func ByInt16ToString(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldInt16ToString, opts...).ToFunc()
+}
+
+// ByUint16ToString orders the results by the uint16_to_string field.
+func ByUint16ToString(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldUint16ToString, opts...).ToFunc()
+}
+
+// ByInt32ToString orders the results by the int32_to_string field.
+func ByInt32ToString(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldInt32ToString, opts...).ToFunc()
+}
+
+// ByUint32ToString orders the results by the uint32_to_string field.
+func ByUint32ToString(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldUint32ToString, opts...).ToFunc()
+}
+
+// ByInt64ToString orders the results by the int64_to_string field.
+func ByInt64ToString(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldInt64ToString, opts...).ToFunc()
+}
+
+// ByUint64ToString orders the results by the uint64_to_string field.
+func ByUint64ToString(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldUint64ToString, opts...).ToFunc()
 }

--- a/entc/integration/migrate/entv1/conversion_query.go
+++ b/entc/integration/migrate/entv1/conversion_query.go
@@ -22,7 +22,7 @@ import (
 type ConversionQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []conversion.Order
 	inters     []Interceptor
 	predicates []predicate.Conversion
 	// intermediate query (i.e. traversal path).
@@ -56,7 +56,7 @@ func (cq *ConversionQuery) Unique(unique bool) *ConversionQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *ConversionQuery) Order(o ...OrderFunc) *ConversionQuery {
+func (cq *ConversionQuery) Order(o ...conversion.Order) *ConversionQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -250,7 +250,7 @@ func (cq *ConversionQuery) Clone() *ConversionQuery {
 	return &ConversionQuery{
 		config:     cq.config,
 		ctx:        cq.ctx.Clone(),
-		order:      append([]OrderFunc{}, cq.order...),
+		order:      append([]conversion.Order{}, cq.order...),
 		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Conversion{}, cq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/migrate/entv1/customtype/customtype.go
+++ b/entc/integration/migrate/entv1/customtype/customtype.go
@@ -6,6 +6,10 @@
 
 package customtype
 
+import (
+	"entgo.io/ent/dialect/sql"
+)
+
 const (
 	// Label holds the string label denoting the customtype type in the database.
 	Label = "custom_type"
@@ -31,4 +35,17 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the CustomType queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByCustom orders the results by the custom field.
+func ByCustom(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldCustom, opts...).ToFunc()
 }

--- a/entc/integration/migrate/entv1/customtype_query.go
+++ b/entc/integration/migrate/entv1/customtype_query.go
@@ -22,7 +22,7 @@ import (
 type CustomTypeQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []customtype.Order
 	inters     []Interceptor
 	predicates []predicate.CustomType
 	// intermediate query (i.e. traversal path).
@@ -56,7 +56,7 @@ func (ctq *CustomTypeQuery) Unique(unique bool) *CustomTypeQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (ctq *CustomTypeQuery) Order(o ...OrderFunc) *CustomTypeQuery {
+func (ctq *CustomTypeQuery) Order(o ...customtype.Order) *CustomTypeQuery {
 	ctq.order = append(ctq.order, o...)
 	return ctq
 }
@@ -250,7 +250,7 @@ func (ctq *CustomTypeQuery) Clone() *CustomTypeQuery {
 	return &CustomTypeQuery{
 		config:     ctq.config,
 		ctx:        ctq.ctx.Clone(),
-		order:      append([]OrderFunc{}, ctq.order...),
+		order:      append([]customtype.Order{}, ctq.order...),
 		inters:     append([]Interceptor{}, ctq.inters...),
 		predicates: append([]predicate.CustomType{}, ctq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/migrate/entv1/ent.go
+++ b/entc/integration/migrate/entv1/ent.go
@@ -68,6 +68,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -89,7 +90,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -101,7 +102,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/entc/integration/migrate/entv1/user/user.go
+++ b/entc/integration/migrate/entv1/user/user.go
@@ -8,6 +8,9 @@ package user
 
 import (
 	"fmt"
+
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
 )
 
 const (
@@ -146,4 +149,130 @@ func StateValidator(s State) error {
 	default:
 		return fmt.Errorf("user: invalid enum value for state field: %q", s)
 	}
+}
+
+// Order defines the ordering method for the User queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByAge orders the results by the age field.
+func ByAge(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldAge, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByDescription orders the results by the description field.
+func ByDescription(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldDescription, opts...).ToFunc()
+}
+
+// ByNickname orders the results by the nickname field.
+func ByNickname(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldNickname, opts...).ToFunc()
+}
+
+// ByAddress orders the results by the address field.
+func ByAddress(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldAddress, opts...).ToFunc()
+}
+
+// ByRenamed orders the results by the renamed field.
+func ByRenamed(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldRenamed, opts...).ToFunc()
+}
+
+// ByOldToken orders the results by the old_token field.
+func ByOldToken(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldOldToken, opts...).ToFunc()
+}
+
+// ByState orders the results by the state field.
+func ByState(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldState, opts...).ToFunc()
+}
+
+// ByStatus orders the results by the status field.
+func ByStatus(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldStatus, opts...).ToFunc()
+}
+
+// ByWorkplace orders the results by the workplace field.
+func ByWorkplace(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldWorkplace, opts...).ToFunc()
+}
+
+// ByDropOptional orders the results by the drop_optional field.
+func ByDropOptional(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldDropOptional, opts...).ToFunc()
+}
+
+// ByParentField orders the results by parent field.
+func ByParentField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newParentStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByChildrenCount orders the results by children count.
+func ByChildrenCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newChildrenStep(), opts...)
+	}
+}
+
+// ByChildren orders the results by children terms.
+func ByChildren(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newChildrenStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// BySpouseField orders the results by spouse field.
+func BySpouseField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newSpouseStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByCarField orders the results by car field.
+func ByCarField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newCarStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newParentStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, ParentTable, ParentColumn),
+	)
+}
+func newChildrenStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, ChildrenTable, ChildrenColumn),
+	)
+}
+func newSpouseStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.O2O, false, SpouseTable, SpouseColumn),
+	)
+}
+func newCarStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(CarInverseTable, CarFieldID),
+		sqlgraph.Edge(sqlgraph.O2O, false, CarTable, CarColumn),
+	)
 }

--- a/entc/integration/migrate/entv1/user/where.go
+++ b/entc/integration/migrate/entv1/user/where.go
@@ -891,11 +891,7 @@ func HasParent() predicate.User {
 // HasParentWith applies the HasEdge predicate on the "parent" edge with a given conditions (other predicates).
 func HasParentWith(preds ...predicate.User) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, ParentTable, ParentColumn),
-		)
+		step := newParentStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -918,11 +914,7 @@ func HasChildren() predicate.User {
 // HasChildrenWith applies the HasEdge predicate on the "children" edge with a given conditions (other predicates).
 func HasChildrenWith(preds ...predicate.User) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, ChildrenTable, ChildrenColumn),
-		)
+		step := newChildrenStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -945,11 +937,7 @@ func HasSpouse() predicate.User {
 // HasSpouseWith applies the HasEdge predicate on the "spouse" edge with a given conditions (other predicates).
 func HasSpouseWith(preds ...predicate.User) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, false, SpouseTable, SpouseColumn),
-		)
+		step := newSpouseStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -972,11 +960,7 @@ func HasCar() predicate.User {
 // HasCarWith applies the HasEdge predicate on the "car" edge with a given conditions (other predicates).
 func HasCarWith(preds ...predicate.Car) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(CarInverseTable, CarFieldID),
-			sqlgraph.Edge(sqlgraph.O2O, false, CarTable, CarColumn),
-		)
+		step := newCarStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/migrate/entv1/user_query.go
+++ b/entc/integration/migrate/entv1/user_query.go
@@ -24,7 +24,7 @@ import (
 type UserQuery struct {
 	config
 	ctx          *QueryContext
-	order        []OrderFunc
+	order        []user.Order
 	inters       []Interceptor
 	predicates   []predicate.User
 	withParent   *UserQuery
@@ -63,7 +63,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...OrderFunc) *UserQuery {
+func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -345,7 +345,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:       uq.config,
 		ctx:          uq.ctx.Clone(),
-		order:        append([]OrderFunc{}, uq.order...),
+		order:        append([]user.Order{}, uq.order...),
 		inters:       append([]Interceptor{}, uq.inters...),
 		predicates:   append([]predicate.User{}, uq.predicates...),
 		withParent:   uq.withParent.Clone(),

--- a/entc/integration/migrate/entv2/blog/blog.go
+++ b/entc/integration/migrate/entv2/blog/blog.go
@@ -6,6 +6,11 @@
 
 package blog
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the blog type in the database.
 	Label = "blog"
@@ -42,4 +47,38 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Blog queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByOid orders the results by the oid field.
+func ByOid(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldOid, opts...).ToFunc()
+}
+
+// ByAdminsCount orders the results by admins count.
+func ByAdminsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newAdminsStep(), opts...)
+	}
+}
+
+// ByAdmins orders the results by admins terms.
+func ByAdmins(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newAdminsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newAdminsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(AdminsInverseTable, UserFieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, AdminsTable, AdminsColumn),
+	)
 }

--- a/entc/integration/migrate/entv2/blog/where.go
+++ b/entc/integration/migrate/entv2/blog/where.go
@@ -116,11 +116,7 @@ func HasAdmins() predicate.Blog {
 // HasAdminsWith applies the HasEdge predicate on the "admins" edge with a given conditions (other predicates).
 func HasAdminsWith(preds ...predicate.User) predicate.Blog {
 	return predicate.Blog(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(AdminsInverseTable, UserFieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, AdminsTable, AdminsColumn),
-		)
+		step := newAdminsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/migrate/entv2/blog_query.go
+++ b/entc/integration/migrate/entv2/blog_query.go
@@ -24,7 +24,7 @@ import (
 type BlogQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []blog.Order
 	inters     []Interceptor
 	predicates []predicate.Blog
 	withAdmins *UserQuery
@@ -59,7 +59,7 @@ func (bq *BlogQuery) Unique(unique bool) *BlogQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (bq *BlogQuery) Order(o ...OrderFunc) *BlogQuery {
+func (bq *BlogQuery) Order(o ...blog.Order) *BlogQuery {
 	bq.order = append(bq.order, o...)
 	return bq
 }
@@ -275,7 +275,7 @@ func (bq *BlogQuery) Clone() *BlogQuery {
 	return &BlogQuery{
 		config:     bq.config,
 		ctx:        bq.ctx.Clone(),
-		order:      append([]OrderFunc{}, bq.order...),
+		order:      append([]blog.Order{}, bq.order...),
 		inters:     append([]Interceptor{}, bq.inters...),
 		predicates: append([]predicate.Blog{}, bq.predicates...),
 		withAdmins: bq.withAdmins.Clone(),

--- a/entc/integration/migrate/entv2/car/car.go
+++ b/entc/integration/migrate/entv2/car/car.go
@@ -6,6 +6,11 @@
 
 package car
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the car type in the database.
 	Label = "car"
@@ -53,4 +58,31 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Car queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByOwnerField orders the results by owner field.
+func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newOwnerStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(OwnerInverseTable, UserFieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
+	)
 }

--- a/entc/integration/migrate/entv2/car/where.go
+++ b/entc/integration/migrate/entv2/car/where.go
@@ -151,11 +151,7 @@ func HasOwner() predicate.Car {
 // HasOwnerWith applies the HasEdge predicate on the "owner" edge with a given conditions (other predicates).
 func HasOwnerWith(preds ...predicate.User) predicate.Car {
 	return predicate.Car(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(OwnerInverseTable, UserFieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
-		)
+		step := newOwnerStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/migrate/entv2/car_query.go
+++ b/entc/integration/migrate/entv2/car_query.go
@@ -23,7 +23,7 @@ import (
 type CarQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []car.Order
 	inters     []Interceptor
 	predicates []predicate.Car
 	withOwner  *UserQuery
@@ -59,7 +59,7 @@ func (cq *CarQuery) Unique(unique bool) *CarQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *CarQuery) Order(o ...OrderFunc) *CarQuery {
+func (cq *CarQuery) Order(o ...car.Order) *CarQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -275,7 +275,7 @@ func (cq *CarQuery) Clone() *CarQuery {
 	return &CarQuery{
 		config:     cq.config,
 		ctx:        cq.ctx.Clone(),
-		order:      append([]OrderFunc{}, cq.order...),
+		order:      append([]car.Order{}, cq.order...),
 		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Car{}, cq.predicates...),
 		withOwner:  cq.withOwner.Clone(),

--- a/entc/integration/migrate/entv2/conversion/conversion.go
+++ b/entc/integration/migrate/entv2/conversion/conversion.go
@@ -6,6 +6,10 @@
 
 package conversion
 
+import (
+	"entgo.io/ent/dialect/sql"
+)
+
 const (
 	// Label holds the string label denoting the conversion type in the database.
 	Label = "conversion"
@@ -55,4 +59,57 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Conversion queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByInt8ToString orders the results by the int8_to_string field.
+func ByInt8ToString(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldInt8ToString, opts...).ToFunc()
+}
+
+// ByUint8ToString orders the results by the uint8_to_string field.
+func ByUint8ToString(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldUint8ToString, opts...).ToFunc()
+}
+
+// ByInt16ToString orders the results by the int16_to_string field.
+func ByInt16ToString(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldInt16ToString, opts...).ToFunc()
+}
+
+// ByUint16ToString orders the results by the uint16_to_string field.
+func ByUint16ToString(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldUint16ToString, opts...).ToFunc()
+}
+
+// ByInt32ToString orders the results by the int32_to_string field.
+func ByInt32ToString(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldInt32ToString, opts...).ToFunc()
+}
+
+// ByUint32ToString orders the results by the uint32_to_string field.
+func ByUint32ToString(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldUint32ToString, opts...).ToFunc()
+}
+
+// ByInt64ToString orders the results by the int64_to_string field.
+func ByInt64ToString(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldInt64ToString, opts...).ToFunc()
+}
+
+// ByUint64ToString orders the results by the uint64_to_string field.
+func ByUint64ToString(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldUint64ToString, opts...).ToFunc()
 }

--- a/entc/integration/migrate/entv2/conversion_query.go
+++ b/entc/integration/migrate/entv2/conversion_query.go
@@ -22,7 +22,7 @@ import (
 type ConversionQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []conversion.Order
 	inters     []Interceptor
 	predicates []predicate.Conversion
 	// intermediate query (i.e. traversal path).
@@ -56,7 +56,7 @@ func (cq *ConversionQuery) Unique(unique bool) *ConversionQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *ConversionQuery) Order(o ...OrderFunc) *ConversionQuery {
+func (cq *ConversionQuery) Order(o ...conversion.Order) *ConversionQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -250,7 +250,7 @@ func (cq *ConversionQuery) Clone() *ConversionQuery {
 	return &ConversionQuery{
 		config:     cq.config,
 		ctx:        cq.ctx.Clone(),
-		order:      append([]OrderFunc{}, cq.order...),
+		order:      append([]conversion.Order{}, cq.order...),
 		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Conversion{}, cq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/migrate/entv2/customtype/customtype.go
+++ b/entc/integration/migrate/entv2/customtype/customtype.go
@@ -6,6 +6,10 @@
 
 package customtype
 
+import (
+	"entgo.io/ent/dialect/sql"
+)
+
 const (
 	// Label holds the string label denoting the customtype type in the database.
 	Label = "custom_type"
@@ -37,4 +41,27 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the CustomType queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByCustom orders the results by the custom field.
+func ByCustom(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldCustom, opts...).ToFunc()
+}
+
+// ByTz0 orders the results by the tz0 field.
+func ByTz0(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldTz0, opts...).ToFunc()
+}
+
+// ByTz3 orders the results by the tz3 field.
+func ByTz3(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldTz3, opts...).ToFunc()
 }

--- a/entc/integration/migrate/entv2/customtype_query.go
+++ b/entc/integration/migrate/entv2/customtype_query.go
@@ -22,7 +22,7 @@ import (
 type CustomTypeQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []customtype.Order
 	inters     []Interceptor
 	predicates []predicate.CustomType
 	// intermediate query (i.e. traversal path).
@@ -56,7 +56,7 @@ func (ctq *CustomTypeQuery) Unique(unique bool) *CustomTypeQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (ctq *CustomTypeQuery) Order(o ...OrderFunc) *CustomTypeQuery {
+func (ctq *CustomTypeQuery) Order(o ...customtype.Order) *CustomTypeQuery {
 	ctq.order = append(ctq.order, o...)
 	return ctq
 }
@@ -250,7 +250,7 @@ func (ctq *CustomTypeQuery) Clone() *CustomTypeQuery {
 	return &CustomTypeQuery{
 		config:     ctq.config,
 		ctx:        ctq.ctx.Clone(),
-		order:      append([]OrderFunc{}, ctq.order...),
+		order:      append([]customtype.Order{}, ctq.order...),
 		inters:     append([]Interceptor{}, ctq.inters...),
 		predicates: append([]predicate.CustomType{}, ctq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/migrate/entv2/ent.go
+++ b/entc/integration/migrate/entv2/ent.go
@@ -73,6 +73,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -99,7 +100,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -111,7 +112,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/entc/integration/migrate/entv2/group/group.go
+++ b/entc/integration/migrate/entv2/group/group.go
@@ -6,6 +6,10 @@
 
 package group
 
+import (
+	"entgo.io/ent/dialect/sql"
+)
+
 const (
 	// Label holds the string label denoting the group type in the database.
 	Label = "group"
@@ -28,4 +32,12 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Group queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
 }

--- a/entc/integration/migrate/entv2/group_query.go
+++ b/entc/integration/migrate/entv2/group_query.go
@@ -22,7 +22,7 @@ import (
 type GroupQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []group.Order
 	inters     []Interceptor
 	predicates []predicate.Group
 	// intermediate query (i.e. traversal path).
@@ -56,7 +56,7 @@ func (gq *GroupQuery) Unique(unique bool) *GroupQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (gq *GroupQuery) Order(o ...OrderFunc) *GroupQuery {
+func (gq *GroupQuery) Order(o ...group.Order) *GroupQuery {
 	gq.order = append(gq.order, o...)
 	return gq
 }
@@ -250,7 +250,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 	return &GroupQuery{
 		config:     gq.config,
 		ctx:        gq.ctx.Clone(),
-		order:      append([]OrderFunc{}, gq.order...),
+		order:      append([]group.Order{}, gq.order...),
 		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Group{}, gq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/migrate/entv2/media/media.go
+++ b/entc/integration/migrate/entv2/media/media.go
@@ -6,6 +6,10 @@
 
 package media
 
+import (
+	"entgo.io/ent/dialect/sql"
+)
+
 const (
 	// Label holds the string label denoting the media type in the database.
 	Label = "media"
@@ -37,4 +41,27 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Media queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// BySource orders the results by the source field.
+func BySource(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldSource, opts...).ToFunc()
+}
+
+// BySourceURI orders the results by the source_uri field.
+func BySourceURI(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldSourceURI, opts...).ToFunc()
+}
+
+// ByText orders the results by the text field.
+func ByText(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldText, opts...).ToFunc()
 }

--- a/entc/integration/migrate/entv2/media_query.go
+++ b/entc/integration/migrate/entv2/media_query.go
@@ -22,7 +22,7 @@ import (
 type MediaQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []media.Order
 	inters     []Interceptor
 	predicates []predicate.Media
 	// intermediate query (i.e. traversal path).
@@ -56,7 +56,7 @@ func (mq *MediaQuery) Unique(unique bool) *MediaQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (mq *MediaQuery) Order(o ...OrderFunc) *MediaQuery {
+func (mq *MediaQuery) Order(o ...media.Order) *MediaQuery {
 	mq.order = append(mq.order, o...)
 	return mq
 }
@@ -250,7 +250,7 @@ func (mq *MediaQuery) Clone() *MediaQuery {
 	return &MediaQuery{
 		config:     mq.config,
 		ctx:        mq.ctx.Clone(),
-		order:      append([]OrderFunc{}, mq.order...),
+		order:      append([]media.Order{}, mq.order...),
 		inters:     append([]Interceptor{}, mq.inters...),
 		predicates: append([]predicate.Media{}, mq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/migrate/entv2/pet/pet.go
+++ b/entc/integration/migrate/entv2/pet/pet.go
@@ -6,6 +6,11 @@
 
 package pet
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the pet type in the database.
 	Label = "pet"
@@ -53,4 +58,31 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Pet queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByOwnerField orders the results by owner field.
+func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newOwnerStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(OwnerInverseTable, UserFieldID),
+		sqlgraph.Edge(sqlgraph.O2O, true, OwnerTable, OwnerColumn),
+	)
 }

--- a/entc/integration/migrate/entv2/pet/where.go
+++ b/entc/integration/migrate/entv2/pet/where.go
@@ -151,11 +151,7 @@ func HasOwner() predicate.Pet {
 // HasOwnerWith applies the HasEdge predicate on the "owner" edge with a given conditions (other predicates).
 func HasOwnerWith(preds ...predicate.User) predicate.Pet {
 	return predicate.Pet(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(OwnerInverseTable, UserFieldID),
-			sqlgraph.Edge(sqlgraph.O2O, true, OwnerTable, OwnerColumn),
-		)
+		step := newOwnerStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/migrate/entv2/pet_query.go
+++ b/entc/integration/migrate/entv2/pet_query.go
@@ -23,7 +23,7 @@ import (
 type PetQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []pet.Order
 	inters     []Interceptor
 	predicates []predicate.Pet
 	withOwner  *UserQuery
@@ -59,7 +59,7 @@ func (pq *PetQuery) Unique(unique bool) *PetQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (pq *PetQuery) Order(o ...OrderFunc) *PetQuery {
+func (pq *PetQuery) Order(o ...pet.Order) *PetQuery {
 	pq.order = append(pq.order, o...)
 	return pq
 }
@@ -275,7 +275,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 	return &PetQuery{
 		config:     pq.config,
 		ctx:        pq.ctx.Clone(),
-		order:      append([]OrderFunc{}, pq.order...),
+		order:      append([]pet.Order{}, pq.order...),
 		inters:     append([]Interceptor{}, pq.inters...),
 		predicates: append([]predicate.Pet{}, pq.predicates...),
 		withOwner:  pq.withOwner.Clone(),

--- a/entc/integration/migrate/entv2/user/user.go
+++ b/entc/integration/migrate/entv2/user/user.go
@@ -9,6 +9,9 @@ package user
 import (
 	"fmt"
 	"time"
+
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
 )
 
 const (
@@ -238,4 +241,158 @@ func StatusValidator(s Status) error {
 	default:
 		return fmt.Errorf("user: invalid enum value for status field: %q", s)
 	}
+}
+
+// Order defines the ordering method for the User queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByMixedString orders the results by the mixed_string field.
+func ByMixedString(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldMixedString, opts...).ToFunc()
+}
+
+// ByMixedEnum orders the results by the mixed_enum field.
+func ByMixedEnum(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldMixedEnum, opts...).ToFunc()
+}
+
+// ByActive orders the results by the active field.
+func ByActive(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldActive, opts...).ToFunc()
+}
+
+// ByAge orders the results by the age field.
+func ByAge(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldAge, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByDescription orders the results by the description field.
+func ByDescription(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldDescription, opts...).ToFunc()
+}
+
+// ByNickname orders the results by the nickname field.
+func ByNickname(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldNickname, opts...).ToFunc()
+}
+
+// ByPhone orders the results by the phone field.
+func ByPhone(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldPhone, opts...).ToFunc()
+}
+
+// ByTitle orders the results by the title field.
+func ByTitle(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldTitle, opts...).ToFunc()
+}
+
+// ByNewName orders the results by the new_name field.
+func ByNewName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldNewName, opts...).ToFunc()
+}
+
+// ByNewToken orders the results by the new_token field.
+func ByNewToken(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldNewToken, opts...).ToFunc()
+}
+
+// ByState orders the results by the state field.
+func ByState(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldState, opts...).ToFunc()
+}
+
+// ByStatus orders the results by the status field.
+func ByStatus(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldStatus, opts...).ToFunc()
+}
+
+// ByWorkplace orders the results by the workplace field.
+func ByWorkplace(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldWorkplace, opts...).ToFunc()
+}
+
+// ByDefaultExpr orders the results by the default_expr field.
+func ByDefaultExpr(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldDefaultExpr, opts...).ToFunc()
+}
+
+// ByDefaultExprs orders the results by the default_exprs field.
+func ByDefaultExprs(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldDefaultExprs, opts...).ToFunc()
+}
+
+// ByCreatedAt orders the results by the created_at field.
+func ByCreatedAt(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldCreatedAt, opts...).ToFunc()
+}
+
+// ByDropOptional orders the results by the drop_optional field.
+func ByDropOptional(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldDropOptional, opts...).ToFunc()
+}
+
+// ByCarCount orders the results by car count.
+func ByCarCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newCarStep(), opts...)
+	}
+}
+
+// ByCar orders the results by car terms.
+func ByCar(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newCarStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByPetsField orders the results by pets field.
+func ByPetsField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newPetsStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByFriendsCount orders the results by friends count.
+func ByFriendsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newFriendsStep(), opts...)
+	}
+}
+
+// ByFriends orders the results by friends terms.
+func ByFriends(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newFriendsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newCarStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(CarInverseTable, CarFieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, CarTable, CarColumn),
+	)
+}
+func newPetsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(PetsInverseTable, PetFieldID),
+		sqlgraph.Edge(sqlgraph.O2O, false, PetsTable, PetsColumn),
+	)
+}
+func newFriendsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, FriendsTable, FriendsPrimaryKey...),
+	)
 }

--- a/entc/integration/migrate/entv2/user/where.go
+++ b/entc/integration/migrate/entv2/user/where.go
@@ -1268,11 +1268,7 @@ func HasCar() predicate.User {
 // HasCarWith applies the HasEdge predicate on the "car" edge with a given conditions (other predicates).
 func HasCarWith(preds ...predicate.Car) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(CarInverseTable, CarFieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, CarTable, CarColumn),
-		)
+		step := newCarStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -1295,11 +1291,7 @@ func HasPets() predicate.User {
 // HasPetsWith applies the HasEdge predicate on the "pets" edge with a given conditions (other predicates).
 func HasPetsWith(preds ...predicate.Pet) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(PetsInverseTable, PetFieldID),
-			sqlgraph.Edge(sqlgraph.O2O, false, PetsTable, PetsColumn),
-		)
+		step := newPetsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -1322,11 +1314,7 @@ func HasFriends() predicate.User {
 // HasFriendsWith applies the HasEdge predicate on the "friends" edge with a given conditions (other predicates).
 func HasFriendsWith(preds ...predicate.User) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, FriendsTable, FriendsPrimaryKey...),
-		)
+		step := newFriendsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/migrate/entv2/user_query.go
+++ b/entc/integration/migrate/entv2/user_query.go
@@ -25,7 +25,7 @@ import (
 type UserQuery struct {
 	config
 	ctx         *QueryContext
-	order       []OrderFunc
+	order       []user.Order
 	inters      []Interceptor
 	predicates  []predicate.User
 	withCar     *CarQuery
@@ -63,7 +63,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...OrderFunc) *UserQuery {
+func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -323,7 +323,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:      uq.config,
 		ctx:         uq.ctx.Clone(),
-		order:       append([]OrderFunc{}, uq.order...),
+		order:       append([]user.Order{}, uq.order...),
 		inters:      append([]Interceptor{}, uq.inters...),
 		predicates:  append([]predicate.User{}, uq.predicates...),
 		withCar:     uq.withCar.Clone(),

--- a/entc/integration/migrate/entv2/zoo/zoo.go
+++ b/entc/integration/migrate/entv2/zoo/zoo.go
@@ -6,6 +6,10 @@
 
 package zoo
 
+import (
+	"entgo.io/ent/dialect/sql"
+)
+
 const (
 	// Label holds the string label denoting the zoo type in the database.
 	Label = "zoo"
@@ -28,4 +32,12 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Zoo queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
 }

--- a/entc/integration/migrate/entv2/zoo_query.go
+++ b/entc/integration/migrate/entv2/zoo_query.go
@@ -22,7 +22,7 @@ import (
 type ZooQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []zoo.Order
 	inters     []Interceptor
 	predicates []predicate.Zoo
 	// intermediate query (i.e. traversal path).
@@ -56,7 +56,7 @@ func (zq *ZooQuery) Unique(unique bool) *ZooQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (zq *ZooQuery) Order(o ...OrderFunc) *ZooQuery {
+func (zq *ZooQuery) Order(o ...zoo.Order) *ZooQuery {
 	zq.order = append(zq.order, o...)
 	return zq
 }
@@ -250,7 +250,7 @@ func (zq *ZooQuery) Clone() *ZooQuery {
 	return &ZooQuery{
 		config:     zq.config,
 		ctx:        zq.ctx.Clone(),
-		order:      append([]OrderFunc{}, zq.order...),
+		order:      append([]zoo.Order{}, zq.order...),
 		inters:     append([]Interceptor{}, zq.inters...),
 		predicates: append([]predicate.Zoo{}, zq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/migrate/versioned/ent.go
+++ b/entc/integration/migrate/versioned/ent.go
@@ -66,6 +66,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -85,7 +86,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -97,7 +98,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/entc/integration/migrate/versioned/group/group.go
+++ b/entc/integration/migrate/versioned/group/group.go
@@ -6,6 +6,10 @@
 
 package group
 
+import (
+	"entgo.io/ent/dialect/sql"
+)
+
 const (
 	// Label holds the string label denoting the group type in the database.
 	Label = "group"
@@ -31,4 +35,17 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Group queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
 }

--- a/entc/integration/migrate/versioned/group_query.go
+++ b/entc/integration/migrate/versioned/group_query.go
@@ -22,7 +22,7 @@ import (
 type GroupQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []group.Order
 	inters     []Interceptor
 	predicates []predicate.Group
 	// intermediate query (i.e. traversal path).
@@ -56,7 +56,7 @@ func (gq *GroupQuery) Unique(unique bool) *GroupQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (gq *GroupQuery) Order(o ...OrderFunc) *GroupQuery {
+func (gq *GroupQuery) Order(o ...group.Order) *GroupQuery {
 	gq.order = append(gq.order, o...)
 	return gq
 }
@@ -250,7 +250,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 	return &GroupQuery{
 		config:     gq.config,
 		ctx:        gq.ctx.Clone(),
-		order:      append([]OrderFunc{}, gq.order...),
+		order:      append([]group.Order{}, gq.order...),
 		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Group{}, gq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/migrate/versioned/user/user.go
+++ b/entc/integration/migrate/versioned/user/user.go
@@ -6,6 +6,10 @@
 
 package user
 
+import (
+	"entgo.io/ent/dialect/sql"
+)
+
 const (
 	// Label holds the string label denoting the user type in the database.
 	Label = "user"
@@ -43,3 +47,26 @@ var (
 	// NameValidator is a validator for the "name" field. It is called by the builders before save.
 	NameValidator func(string) error
 )
+
+// Order defines the ordering method for the User queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByAge orders the results by the age field.
+func ByAge(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldAge, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByAddress orders the results by the address field.
+func ByAddress(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldAddress, opts...).ToFunc()
+}

--- a/entc/integration/migrate/versioned/user_query.go
+++ b/entc/integration/migrate/versioned/user_query.go
@@ -22,7 +22,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []user.Order
 	inters     []Interceptor
 	predicates []predicate.User
 	// intermediate query (i.e. traversal path).
@@ -56,7 +56,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...OrderFunc) *UserQuery {
+func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -250,7 +250,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]OrderFunc{}, uq.order...),
+		order:      append([]user.Order{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/multischema/ent/ent.go
+++ b/entc/integration/multischema/ent/ent.go
@@ -68,6 +68,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -89,7 +90,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -101,7 +102,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/entc/integration/multischema/ent/friendship/friendship.go
+++ b/entc/integration/multischema/ent/friendship/friendship.go
@@ -8,6 +8,9 @@ package friendship
 
 import (
 	"time"
+
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
 )
 
 const (
@@ -70,3 +73,59 @@ var (
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time
 )
+
+// Order defines the ordering method for the Friendship queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByWeight orders the results by the weight field.
+func ByWeight(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldWeight, opts...).ToFunc()
+}
+
+// ByCreatedAt orders the results by the created_at field.
+func ByCreatedAt(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldCreatedAt, opts...).ToFunc()
+}
+
+// ByUserID orders the results by the user_id field.
+func ByUserID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldUserID, opts...).ToFunc()
+}
+
+// ByFriendID orders the results by the friend_id field.
+func ByFriendID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldFriendID, opts...).ToFunc()
+}
+
+// ByUserField orders the results by user field.
+func ByUserField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newUserStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByFriendField orders the results by friend field.
+func ByFriendField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newFriendStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newUserStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(UserInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, false, UserTable, UserColumn),
+	)
+}
+func newFriendStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(FriendInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, false, FriendTable, FriendColumn),
+	)
+}

--- a/entc/integration/multischema/ent/friendship/where.go
+++ b/entc/integration/multischema/ent/friendship/where.go
@@ -217,11 +217,7 @@ func HasUser() predicate.Friendship {
 // HasUserWith applies the HasEdge predicate on the "user" edge with a given conditions (other predicates).
 func HasUserWith(preds ...predicate.User) predicate.Friendship {
 	return predicate.Friendship(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(UserInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, UserTable, UserColumn),
-		)
+		step := newUserStep()
 		schemaConfig := internal.SchemaConfigFromContext(s.Context())
 		step.To.Schema = schemaConfig.User
 		step.Edge.Schema = schemaConfig.Friendship
@@ -250,11 +246,7 @@ func HasFriend() predicate.Friendship {
 // HasFriendWith applies the HasEdge predicate on the "friend" edge with a given conditions (other predicates).
 func HasFriendWith(preds ...predicate.User) predicate.Friendship {
 	return predicate.Friendship(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(FriendInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, FriendTable, FriendColumn),
-		)
+		step := newFriendStep()
 		schemaConfig := internal.SchemaConfigFromContext(s.Context())
 		step.To.Schema = schemaConfig.User
 		step.Edge.Schema = schemaConfig.Friendship

--- a/entc/integration/multischema/ent/friendship_query.go
+++ b/entc/integration/multischema/ent/friendship_query.go
@@ -24,7 +24,7 @@ import (
 type FriendshipQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []friendship.Order
 	inters     []Interceptor
 	predicates []predicate.Friendship
 	withUser   *UserQuery
@@ -61,7 +61,7 @@ func (fq *FriendshipQuery) Unique(unique bool) *FriendshipQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (fq *FriendshipQuery) Order(o ...OrderFunc) *FriendshipQuery {
+func (fq *FriendshipQuery) Order(o ...friendship.Order) *FriendshipQuery {
 	fq.order = append(fq.order, o...)
 	return fq
 }
@@ -305,7 +305,7 @@ func (fq *FriendshipQuery) Clone() *FriendshipQuery {
 	return &FriendshipQuery{
 		config:     fq.config,
 		ctx:        fq.ctx.Clone(),
-		order:      append([]OrderFunc{}, fq.order...),
+		order:      append([]friendship.Order{}, fq.order...),
 		inters:     append([]Interceptor{}, fq.inters...),
 		predicates: append([]predicate.Friendship{}, fq.predicates...),
 		withUser:   fq.withUser.Clone(),

--- a/entc/integration/multischema/ent/group/where.go
+++ b/entc/integration/multischema/ent/group/where.go
@@ -145,11 +145,7 @@ func HasUsers() predicate.Group {
 // HasUsersWith applies the HasEdge predicate on the "users" edge with a given conditions (other predicates).
 func HasUsersWith(preds ...predicate.User) predicate.Group {
 	return predicate.Group(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(UsersInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, UsersTable, UsersPrimaryKey...),
-		)
+		step := newUsersStep()
 		schemaConfig := internal.SchemaConfigFromContext(s.Context())
 		step.To.Schema = schemaConfig.User
 		step.Edge.Schema = schemaConfig.GroupUsers

--- a/entc/integration/multischema/ent/group_query.go
+++ b/entc/integration/multischema/ent/group_query.go
@@ -25,7 +25,7 @@ import (
 type GroupQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []group.Order
 	inters     []Interceptor
 	predicates []predicate.Group
 	withUsers  *UserQuery
@@ -61,7 +61,7 @@ func (gq *GroupQuery) Unique(unique bool) *GroupQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (gq *GroupQuery) Order(o ...OrderFunc) *GroupQuery {
+func (gq *GroupQuery) Order(o ...group.Order) *GroupQuery {
 	gq.order = append(gq.order, o...)
 	return gq
 }
@@ -280,7 +280,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 	return &GroupQuery{
 		config:     gq.config,
 		ctx:        gq.ctx.Clone(),
-		order:      append([]OrderFunc{}, gq.order...),
+		order:      append([]group.Order{}, gq.order...),
 		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Group{}, gq.predicates...),
 		withUsers:  gq.withUsers.Clone(),

--- a/entc/integration/multischema/ent/pet/pet.go
+++ b/entc/integration/multischema/ent/pet/pet.go
@@ -6,6 +6,11 @@
 
 package pet
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the pet type in the database.
 	Label = "pet"
@@ -49,3 +54,35 @@ var (
 	// DefaultName holds the default value on creation for the "name" field.
 	DefaultName string
 )
+
+// Order defines the ordering method for the Pet queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByOwnerID orders the results by the owner_id field.
+func ByOwnerID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldOwnerID, opts...).ToFunc()
+}
+
+// ByOwnerField orders the results by owner field.
+func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newOwnerStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(OwnerInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
+	)
+}

--- a/entc/integration/multischema/ent/pet/where.go
+++ b/entc/integration/multischema/ent/pet/where.go
@@ -180,11 +180,7 @@ func HasOwner() predicate.Pet {
 // HasOwnerWith applies the HasEdge predicate on the "owner" edge with a given conditions (other predicates).
 func HasOwnerWith(preds ...predicate.User) predicate.Pet {
 	return predicate.Pet(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(OwnerInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
-		)
+		step := newOwnerStep()
 		schemaConfig := internal.SchemaConfigFromContext(s.Context())
 		step.To.Schema = schemaConfig.User
 		step.Edge.Schema = schemaConfig.Pet

--- a/entc/integration/multischema/ent/pet_query.go
+++ b/entc/integration/multischema/ent/pet_query.go
@@ -24,7 +24,7 @@ import (
 type PetQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []pet.Order
 	inters     []Interceptor
 	predicates []predicate.Pet
 	withOwner  *UserQuery
@@ -60,7 +60,7 @@ func (pq *PetQuery) Unique(unique bool) *PetQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (pq *PetQuery) Order(o ...OrderFunc) *PetQuery {
+func (pq *PetQuery) Order(o ...pet.Order) *PetQuery {
 	pq.order = append(pq.order, o...)
 	return pq
 }
@@ -279,7 +279,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 	return &PetQuery{
 		config:     pq.config,
 		ctx:        pq.ctx.Clone(),
-		order:      append([]OrderFunc{}, pq.order...),
+		order:      append([]pet.Order{}, pq.order...),
 		inters:     append([]Interceptor{}, pq.inters...),
 		predicates: append([]predicate.Pet{}, pq.predicates...),
 		withOwner:  pq.withOwner.Clone(),

--- a/entc/integration/multischema/ent/user/user.go
+++ b/entc/integration/multischema/ent/user/user.go
@@ -6,6 +6,11 @@
 
 package user
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the user type in the database.
 	Label = "user"
@@ -75,3 +80,100 @@ var (
 	// DefaultName holds the default value on creation for the "name" field.
 	DefaultName string
 )
+
+// Order defines the ordering method for the User queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByPetsCount orders the results by pets count.
+func ByPetsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newPetsStep(), opts...)
+	}
+}
+
+// ByPets orders the results by pets terms.
+func ByPets(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newPetsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByGroupsCount orders the results by groups count.
+func ByGroupsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newGroupsStep(), opts...)
+	}
+}
+
+// ByGroups orders the results by groups terms.
+func ByGroups(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newGroupsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByFriendsCount orders the results by friends count.
+func ByFriendsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newFriendsStep(), opts...)
+	}
+}
+
+// ByFriends orders the results by friends terms.
+func ByFriends(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newFriendsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByFriendshipsCount orders the results by friendships count.
+func ByFriendshipsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newFriendshipsStep(), opts...)
+	}
+}
+
+// ByFriendships orders the results by friendships terms.
+func ByFriendships(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newFriendshipsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newPetsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(PetsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, PetsTable, PetsColumn),
+	)
+}
+func newGroupsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(GroupsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, true, GroupsTable, GroupsPrimaryKey...),
+	)
+}
+func newFriendsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, FriendsTable, FriendsPrimaryKey...),
+	)
+}
+func newFriendshipsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(FriendshipsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, true, FriendshipsTable, FriendshipsColumn),
+	)
+}

--- a/entc/integration/multischema/ent/user/where.go
+++ b/entc/integration/multischema/ent/user/where.go
@@ -145,11 +145,7 @@ func HasPets() predicate.User {
 // HasPetsWith applies the HasEdge predicate on the "pets" edge with a given conditions (other predicates).
 func HasPetsWith(preds ...predicate.Pet) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(PetsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, PetsTable, PetsColumn),
-		)
+		step := newPetsStep()
 		schemaConfig := internal.SchemaConfigFromContext(s.Context())
 		step.To.Schema = schemaConfig.Pet
 		step.Edge.Schema = schemaConfig.Pet
@@ -178,11 +174,7 @@ func HasGroups() predicate.User {
 // HasGroupsWith applies the HasEdge predicate on the "groups" edge with a given conditions (other predicates).
 func HasGroupsWith(preds ...predicate.Group) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(GroupsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, true, GroupsTable, GroupsPrimaryKey...),
-		)
+		step := newGroupsStep()
 		schemaConfig := internal.SchemaConfigFromContext(s.Context())
 		step.To.Schema = schemaConfig.Group
 		step.Edge.Schema = schemaConfig.GroupUsers
@@ -211,11 +203,7 @@ func HasFriends() predicate.User {
 // HasFriendsWith applies the HasEdge predicate on the "friends" edge with a given conditions (other predicates).
 func HasFriendsWith(preds ...predicate.User) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, FriendsTable, FriendsPrimaryKey...),
-		)
+		step := newFriendsStep()
 		schemaConfig := internal.SchemaConfigFromContext(s.Context())
 		step.To.Schema = schemaConfig.User
 		step.Edge.Schema = schemaConfig.Friendship
@@ -244,11 +232,7 @@ func HasFriendships() predicate.User {
 // HasFriendshipsWith applies the HasEdge predicate on the "friendships" edge with a given conditions (other predicates).
 func HasFriendshipsWith(preds ...predicate.Friendship) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(FriendshipsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, true, FriendshipsTable, FriendshipsColumn),
-		)
+		step := newFriendshipsStep()
 		schemaConfig := internal.SchemaConfigFromContext(s.Context())
 		step.To.Schema = schemaConfig.Friendship
 		step.Edge.Schema = schemaConfig.Friendship

--- a/entc/integration/multischema/ent/user_query.go
+++ b/entc/integration/multischema/ent/user_query.go
@@ -27,7 +27,7 @@ import (
 type UserQuery struct {
 	config
 	ctx             *QueryContext
-	order           []OrderFunc
+	order           []user.Order
 	inters          []Interceptor
 	predicates      []predicate.User
 	withPets        *PetQuery
@@ -66,7 +66,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...OrderFunc) *UserQuery {
+func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -360,7 +360,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:          uq.config,
 		ctx:             uq.ctx.Clone(),
-		order:           append([]OrderFunc{}, uq.order...),
+		order:           append([]user.Order{}, uq.order...),
 		inters:          append([]Interceptor{}, uq.inters...),
 		predicates:      append([]predicate.User{}, uq.predicates...),
 		withPets:        uq.withPets.Clone(),

--- a/entc/integration/privacy/ent/ent.go
+++ b/entc/integration/privacy/ent/ent.go
@@ -67,6 +67,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -87,7 +88,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -99,7 +100,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/entc/integration/privacy/ent/task/where.go
+++ b/entc/integration/privacy/ent/task/where.go
@@ -297,11 +297,7 @@ func HasTeams() predicate.Task {
 // HasTeamsWith applies the HasEdge predicate on the "teams" edge with a given conditions (other predicates).
 func HasTeamsWith(preds ...predicate.Team) predicate.Task {
 	return predicate.Task(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(TeamsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, TeamsTable, TeamsPrimaryKey...),
-		)
+		step := newTeamsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -324,11 +320,7 @@ func HasOwner() predicate.Task {
 // HasOwnerWith applies the HasEdge predicate on the "owner" edge with a given conditions (other predicates).
 func HasOwnerWith(preds ...predicate.User) predicate.Task {
 	return predicate.Task(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(OwnerInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
-		)
+		step := newOwnerStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/privacy/ent/task_query.go
+++ b/entc/integration/privacy/ent/task_query.go
@@ -26,7 +26,7 @@ import (
 type TaskQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []task.Order
 	inters     []Interceptor
 	predicates []predicate.Task
 	withTeams  *TeamQuery
@@ -63,7 +63,7 @@ func (tq *TaskQuery) Unique(unique bool) *TaskQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (tq *TaskQuery) Order(o ...OrderFunc) *TaskQuery {
+func (tq *TaskQuery) Order(o ...task.Order) *TaskQuery {
 	tq.order = append(tq.order, o...)
 	return tq
 }
@@ -301,7 +301,7 @@ func (tq *TaskQuery) Clone() *TaskQuery {
 	return &TaskQuery{
 		config:     tq.config,
 		ctx:        tq.ctx.Clone(),
-		order:      append([]OrderFunc{}, tq.order...),
+		order:      append([]task.Order{}, tq.order...),
 		inters:     append([]Interceptor{}, tq.inters...),
 		predicates: append([]predicate.Task{}, tq.predicates...),
 		withTeams:  tq.withTeams.Clone(),

--- a/entc/integration/privacy/ent/team/where.go
+++ b/entc/integration/privacy/ent/team/where.go
@@ -141,11 +141,7 @@ func HasTasks() predicate.Team {
 // HasTasksWith applies the HasEdge predicate on the "tasks" edge with a given conditions (other predicates).
 func HasTasksWith(preds ...predicate.Task) predicate.Team {
 	return predicate.Team(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(TasksInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, true, TasksTable, TasksPrimaryKey...),
-		)
+		step := newTasksStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -168,11 +164,7 @@ func HasUsers() predicate.Team {
 // HasUsersWith applies the HasEdge predicate on the "users" edge with a given conditions (other predicates).
 func HasUsersWith(preds ...predicate.User) predicate.Team {
 	return predicate.Team(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(UsersInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, true, UsersTable, UsersPrimaryKey...),
-		)
+		step := newUsersStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/privacy/ent/team_query.go
+++ b/entc/integration/privacy/ent/team_query.go
@@ -26,7 +26,7 @@ import (
 type TeamQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []team.Order
 	inters     []Interceptor
 	predicates []predicate.Team
 	withTasks  *TaskQuery
@@ -62,7 +62,7 @@ func (tq *TeamQuery) Unique(unique bool) *TeamQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (tq *TeamQuery) Order(o ...OrderFunc) *TeamQuery {
+func (tq *TeamQuery) Order(o ...team.Order) *TeamQuery {
 	tq.order = append(tq.order, o...)
 	return tq
 }
@@ -300,7 +300,7 @@ func (tq *TeamQuery) Clone() *TeamQuery {
 	return &TeamQuery{
 		config:     tq.config,
 		ctx:        tq.ctx.Clone(),
-		order:      append([]OrderFunc{}, tq.order...),
+		order:      append([]team.Order{}, tq.order...),
 		inters:     append([]Interceptor{}, tq.inters...),
 		predicates: append([]predicate.Team{}, tq.predicates...),
 		withTasks:  tq.withTasks.Clone(),

--- a/entc/integration/privacy/ent/user/user.go
+++ b/entc/integration/privacy/ent/user/user.go
@@ -8,6 +8,8 @@ package user
 
 import (
 	"entgo.io/ent"
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
 )
 
 const (
@@ -73,3 +75,63 @@ var (
 	// NameValidator is a validator for the "name" field. It is called by the builders before save.
 	NameValidator func(string) error
 )
+
+// Order defines the ordering method for the User queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByAge orders the results by the age field.
+func ByAge(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldAge, opts...).ToFunc()
+}
+
+// ByTeamsCount orders the results by teams count.
+func ByTeamsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newTeamsStep(), opts...)
+	}
+}
+
+// ByTeams orders the results by teams terms.
+func ByTeams(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newTeamsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByTasksCount orders the results by tasks count.
+func ByTasksCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newTasksStep(), opts...)
+	}
+}
+
+// ByTasks orders the results by tasks terms.
+func ByTasks(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newTasksStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newTeamsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(TeamsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, TeamsTable, TeamsPrimaryKey...),
+	)
+}
+func newTasksStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(TasksInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, TasksTable, TasksColumn),
+	)
+}

--- a/entc/integration/privacy/ent/user/where.go
+++ b/entc/integration/privacy/ent/user/where.go
@@ -196,11 +196,7 @@ func HasTeams() predicate.User {
 // HasTeamsWith applies the HasEdge predicate on the "teams" edge with a given conditions (other predicates).
 func HasTeamsWith(preds ...predicate.Team) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(TeamsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, TeamsTable, TeamsPrimaryKey...),
-		)
+		step := newTeamsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -223,11 +219,7 @@ func HasTasks() predicate.User {
 // HasTasksWith applies the HasEdge predicate on the "tasks" edge with a given conditions (other predicates).
 func HasTasksWith(preds ...predicate.Task) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(TasksInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, TasksTable, TasksColumn),
-		)
+		step := newTasksStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/privacy/ent/user_query.go
+++ b/entc/integration/privacy/ent/user_query.go
@@ -26,7 +26,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []user.Order
 	inters     []Interceptor
 	predicates []predicate.User
 	withTeams  *TeamQuery
@@ -62,7 +62,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...OrderFunc) *UserQuery {
+func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -300,7 +300,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]OrderFunc{}, uq.order...),
+		order:      append([]user.Order{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		withTeams:  uq.withTeams.Clone(),

--- a/entc/integration/template/ent/ent.go
+++ b/entc/integration/template/ent/ent.go
@@ -67,6 +67,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -87,7 +88,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -99,7 +100,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/entc/integration/template/ent/group/group.go
+++ b/entc/integration/template/ent/group/group.go
@@ -6,6 +6,10 @@
 
 package group
 
+import (
+	"entgo.io/ent/dialect/sql"
+)
+
 const (
 	// Label holds the string label denoting the group type in the database.
 	Label = "group"
@@ -31,4 +35,17 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Group queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByMaxUsers orders the results by the max_users field.
+func ByMaxUsers(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldMaxUsers, opts...).ToFunc()
 }

--- a/entc/integration/template/ent/group_query.go
+++ b/entc/integration/template/ent/group_query.go
@@ -22,7 +22,7 @@ import (
 type GroupQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []group.Order
 	inters     []Interceptor
 	predicates []predicate.Group
 	// additional query fields.
@@ -59,7 +59,7 @@ func (gq *GroupQuery) Unique(unique bool) *GroupQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (gq *GroupQuery) Order(o ...OrderFunc) *GroupQuery {
+func (gq *GroupQuery) Order(o ...group.Order) *GroupQuery {
 	gq.order = append(gq.order, o...)
 	return gq
 }
@@ -253,7 +253,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 	return &GroupQuery{
 		config:     gq.config,
 		ctx:        gq.ctx.Clone(),
-		order:      append([]OrderFunc{}, gq.order...),
+		order:      append([]group.Order{}, gq.order...),
 		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Group{}, gq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/template/ent/pet/pet.go
+++ b/entc/integration/template/ent/pet/pet.go
@@ -6,6 +6,11 @@
 
 package pet
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the pet type in the database.
 	Label = "pet"
@@ -54,4 +59,36 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Pet queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByAge orders the results by the age field.
+func ByAge(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldAge, opts...).ToFunc()
+}
+
+// ByLicensedAt orders the results by the licensed_at field.
+func ByLicensedAt(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldLicensedAt, opts...).ToFunc()
+}
+
+// ByOwnerField orders the results by owner field.
+func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newOwnerStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(OwnerInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
+	)
 }

--- a/entc/integration/template/ent/pet/where.go
+++ b/entc/integration/template/ent/pet/where.go
@@ -173,11 +173,7 @@ func HasOwner() predicate.Pet {
 // HasOwnerWith applies the HasEdge predicate on the "owner" edge with a given conditions (other predicates).
 func HasOwnerWith(preds ...predicate.User) predicate.Pet {
 	return predicate.Pet(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(OwnerInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
-		)
+		step := newOwnerStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/template/ent/pet_query.go
+++ b/entc/integration/template/ent/pet_query.go
@@ -23,7 +23,7 @@ import (
 type PetQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []pet.Order
 	inters     []Interceptor
 	predicates []predicate.Pet
 	withOwner  *UserQuery
@@ -62,7 +62,7 @@ func (pq *PetQuery) Unique(unique bool) *PetQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (pq *PetQuery) Order(o ...OrderFunc) *PetQuery {
+func (pq *PetQuery) Order(o ...pet.Order) *PetQuery {
 	pq.order = append(pq.order, o...)
 	return pq
 }
@@ -278,7 +278,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 	return &PetQuery{
 		config:     pq.config,
 		ctx:        pq.ctx.Clone(),
-		order:      append([]OrderFunc{}, pq.order...),
+		order:      append([]pet.Order{}, pq.order...),
 		inters:     append([]Interceptor{}, pq.inters...),
 		predicates: append([]predicate.Pet{}, pq.predicates...),
 		withOwner:  pq.withOwner.Clone(),

--- a/entc/integration/template/ent/user/user.go
+++ b/entc/integration/template/ent/user/user.go
@@ -6,6 +6,11 @@
 
 package user
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the user type in the database.
 	Label = "user"
@@ -50,4 +55,59 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the User queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByPetsCount orders the results by pets count.
+func ByPetsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newPetsStep(), opts...)
+	}
+}
+
+// ByPets orders the results by pets terms.
+func ByPets(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newPetsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByFriendsCount orders the results by friends count.
+func ByFriendsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newFriendsStep(), opts...)
+	}
+}
+
+// ByFriends orders the results by friends terms.
+func ByFriends(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newFriendsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newPetsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(PetsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, PetsTable, PetsColumn),
+	)
+}
+func newFriendsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, FriendsTable, FriendsPrimaryKey...),
+	)
 }

--- a/entc/integration/template/ent/user/where.go
+++ b/entc/integration/template/ent/user/where.go
@@ -141,11 +141,7 @@ func HasPets() predicate.User {
 // HasPetsWith applies the HasEdge predicate on the "pets" edge with a given conditions (other predicates).
 func HasPetsWith(preds ...predicate.Pet) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(PetsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, PetsTable, PetsColumn),
-		)
+		step := newPetsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -168,11 +164,7 @@ func HasFriends() predicate.User {
 // HasFriendsWith applies the HasEdge predicate on the "friends" edge with a given conditions (other predicates).
 func HasFriendsWith(preds ...predicate.User) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, FriendsTable, FriendsPrimaryKey...),
-		)
+		step := newFriendsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/entc/integration/template/ent/user_query.go
+++ b/entc/integration/template/ent/user_query.go
@@ -24,7 +24,7 @@ import (
 type UserQuery struct {
 	config
 	ctx         *QueryContext
-	order       []OrderFunc
+	order       []user.Order
 	inters      []Interceptor
 	predicates  []predicate.User
 	withPets    *PetQuery
@@ -63,7 +63,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...OrderFunc) *UserQuery {
+func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -301,7 +301,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:      uq.config,
 		ctx:         uq.ctx.Clone(),
-		order:       append([]OrderFunc{}, uq.order...),
+		order:       append([]user.Order{}, uq.order...),
 		inters:      append([]Interceptor{}, uq.inters...),
 		predicates:  append([]predicate.User{}, uq.predicates...),
 		withPets:    uq.withPets.Clone(),

--- a/examples/edgeindex/ent/city/where.go
+++ b/examples/edgeindex/ent/city/where.go
@@ -141,11 +141,7 @@ func HasStreets() predicate.City {
 // HasStreetsWith applies the HasEdge predicate on the "streets" edge with a given conditions (other predicates).
 func HasStreetsWith(preds ...predicate.Street) predicate.City {
 	return predicate.City(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(StreetsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, StreetsTable, StreetsColumn),
-		)
+		step := newStreetsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/examples/edgeindex/ent/city_query.go
+++ b/examples/edgeindex/ent/city_query.go
@@ -24,7 +24,7 @@ import (
 type CityQuery struct {
 	config
 	ctx         *QueryContext
-	order       []OrderFunc
+	order       []city.Order
 	inters      []Interceptor
 	predicates  []predicate.City
 	withStreets *StreetQuery
@@ -59,7 +59,7 @@ func (cq *CityQuery) Unique(unique bool) *CityQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *CityQuery) Order(o ...OrderFunc) *CityQuery {
+func (cq *CityQuery) Order(o ...city.Order) *CityQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -275,7 +275,7 @@ func (cq *CityQuery) Clone() *CityQuery {
 	return &CityQuery{
 		config:      cq.config,
 		ctx:         cq.ctx.Clone(),
-		order:       append([]OrderFunc{}, cq.order...),
+		order:       append([]city.Order{}, cq.order...),
 		inters:      append([]Interceptor{}, cq.inters...),
 		predicates:  append([]predicate.City{}, cq.predicates...),
 		withStreets: cq.withStreets.Clone(),

--- a/examples/edgeindex/ent/ent.go
+++ b/examples/edgeindex/ent/ent.go
@@ -66,6 +66,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -85,7 +86,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -97,7 +98,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/examples/edgeindex/ent/street/street.go
+++ b/examples/edgeindex/ent/street/street.go
@@ -6,6 +6,11 @@
 
 package street
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the street type in the database.
 	Label = "street"
@@ -51,4 +56,31 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Street queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByCityField orders the results by city field.
+func ByCityField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newCityStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newCityStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(CityInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, CityTable, CityColumn),
+	)
 }

--- a/examples/edgeindex/ent/street/where.go
+++ b/examples/edgeindex/ent/street/where.go
@@ -141,11 +141,7 @@ func HasCity() predicate.Street {
 // HasCityWith applies the HasEdge predicate on the "city" edge with a given conditions (other predicates).
 func HasCityWith(preds ...predicate.City) predicate.Street {
 	return predicate.Street(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(CityInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, CityTable, CityColumn),
-		)
+		step := newCityStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/examples/edgeindex/ent/street_query.go
+++ b/examples/edgeindex/ent/street_query.go
@@ -23,7 +23,7 @@ import (
 type StreetQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []street.Order
 	inters     []Interceptor
 	predicates []predicate.Street
 	withCity   *CityQuery
@@ -59,7 +59,7 @@ func (sq *StreetQuery) Unique(unique bool) *StreetQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (sq *StreetQuery) Order(o ...OrderFunc) *StreetQuery {
+func (sq *StreetQuery) Order(o ...street.Order) *StreetQuery {
 	sq.order = append(sq.order, o...)
 	return sq
 }
@@ -275,7 +275,7 @@ func (sq *StreetQuery) Clone() *StreetQuery {
 	return &StreetQuery{
 		config:     sq.config,
 		ctx:        sq.ctx.Clone(),
-		order:      append([]OrderFunc{}, sq.order...),
+		order:      append([]street.Order{}, sq.order...),
 		inters:     append([]Interceptor{}, sq.inters...),
 		predicates: append([]predicate.Street{}, sq.predicates...),
 		withCity:   sq.withCity.Clone(),

--- a/examples/encryptfield/ent/ent.go
+++ b/examples/encryptfield/ent/ent.go
@@ -65,6 +65,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -83,7 +84,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -95,7 +96,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/examples/encryptfield/ent/intercept/intercept.go
+++ b/examples/encryptfield/ent/intercept/intercept.go
@@ -13,6 +13,7 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/examples/encryptfield/ent"
 	"entgo.io/ent/examples/encryptfield/ent/predicate"
+	"entgo.io/ent/examples/encryptfield/ent/user"
 )
 
 // The Query interface represents an operation that queries a graph.
@@ -28,7 +29,7 @@ type Query interface {
 	// Unique configures the query builder to filter duplicate records.
 	Unique(bool)
 	// Order specifies how the records should be ordered.
-	Order(...ent.OrderFunc)
+	Order(...func(*sql.Selector))
 	// WhereP appends storage-level predicates to the query builder. Using this method, users
 	// can use type-assertion to append predicates that do not depend on any generated package.
 	WhereP(...func(*sql.Selector))
@@ -102,44 +103,48 @@ func (f TraverseUser) Traverse(ctx context.Context, q ent.Query) error {
 func NewQuery(q ent.Query) (Query, error) {
 	switch q := q.(type) {
 	case *ent.UserQuery:
-		return &query[*ent.UserQuery, predicate.User]{typ: ent.TypeUser, tq: q}, nil
+		return &query[*ent.UserQuery, predicate.User, user.Order]{typ: ent.TypeUser, tq: q}, nil
 	default:
 		return nil, fmt.Errorf("unknown query type %T", q)
 	}
 }
 
-type query[T any, P ~func(*sql.Selector)] struct {
+type query[T any, P ~func(*sql.Selector), R ~func(*sql.Selector)] struct {
 	typ string
 	tq  interface {
 		Limit(int) T
 		Offset(int) T
 		Unique(bool) T
-		Order(...ent.OrderFunc) T
+		Order(...R) T
 		Where(...P) T
 	}
 }
 
-func (q query[T, P]) Type() string {
+func (q query[T, P, R]) Type() string {
 	return q.typ
 }
 
-func (q query[T, P]) Limit(limit int) {
+func (q query[T, P, R]) Limit(limit int) {
 	q.tq.Limit(limit)
 }
 
-func (q query[T, P]) Offset(offset int) {
+func (q query[T, P, R]) Offset(offset int) {
 	q.tq.Offset(offset)
 }
 
-func (q query[T, P]) Unique(unique bool) {
+func (q query[T, P, R]) Unique(unique bool) {
 	q.tq.Unique(unique)
 }
 
-func (q query[T, P]) Order(orders ...ent.OrderFunc) {
-	q.tq.Order(orders...)
+func (q query[T, P, R]) Order(orders ...func(*sql.Selector)) {
+	rs := make([]R, len(orders))
+	for i := range orders {
+		rs[i] = orders[i]
+	}
+	q.tq.Order(rs...)
 }
 
-func (q query[T, P]) WhereP(ps ...func(*sql.Selector)) {
+func (q query[T, P, R]) WhereP(ps ...func(*sql.Selector)) {
 	p := make([]P, len(ps))
 	for i := range ps {
 		p[i] = ps[i]

--- a/examples/encryptfield/ent/user/user.go
+++ b/examples/encryptfield/ent/user/user.go
@@ -8,6 +8,7 @@ package user
 
 import (
 	"entgo.io/ent"
+	"entgo.io/ent/dialect/sql"
 )
 
 const (
@@ -49,3 +50,21 @@ var (
 	Hooks        [1]ent.Hook
 	Interceptors [1]ent.Interceptor
 )
+
+// Order defines the ordering method for the User queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByNickname orders the results by the nickname field.
+func ByNickname(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldNickname, opts...).ToFunc()
+}

--- a/examples/encryptfield/ent/user_query.go
+++ b/examples/encryptfield/ent/user_query.go
@@ -22,7 +22,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []user.Order
 	inters     []Interceptor
 	predicates []predicate.User
 	// intermediate query (i.e. traversal path).
@@ -56,7 +56,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...OrderFunc) *UserQuery {
+func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -250,7 +250,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]OrderFunc{}, uq.order...),
+		order:      append([]user.Order{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		// clone intermediate query.

--- a/examples/entcpkg/ent/ent.go
+++ b/examples/entcpkg/ent/ent.go
@@ -65,6 +65,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -83,7 +84,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -95,7 +96,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/examples/entcpkg/ent/user/user.go
+++ b/examples/entcpkg/ent/user/user.go
@@ -6,6 +6,10 @@
 
 package user
 
+import (
+	"entgo.io/ent/dialect/sql"
+)
+
 const (
 	// Label holds the string label denoting the user type in the database.
 	Label = "user"
@@ -34,4 +38,22 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the User queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByAge orders the results by the age field.
+func ByAge(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldAge, opts...).ToFunc()
 }

--- a/examples/entcpkg/ent/user_query.go
+++ b/examples/entcpkg/ent/user_query.go
@@ -22,7 +22,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []user.Order
 	inters     []Interceptor
 	predicates []predicate.User
 	// intermediate query (i.e. traversal path).
@@ -56,7 +56,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...OrderFunc) *UserQuery {
+func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -250,7 +250,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]OrderFunc{}, uq.order...),
+		order:      append([]user.Order{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		// clone intermediate query.

--- a/examples/fs/ent/ent.go
+++ b/examples/fs/ent/ent.go
@@ -65,6 +65,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -83,7 +84,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -95,7 +96,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/examples/fs/ent/file/where.go
+++ b/examples/fs/ent/file/where.go
@@ -191,11 +191,7 @@ func HasParent() predicate.File {
 // HasParentWith applies the HasEdge predicate on the "parent" edge with a given conditions (other predicates).
 func HasParentWith(preds ...predicate.File) predicate.File {
 	return predicate.File(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, ParentTable, ParentColumn),
-		)
+		step := newParentStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -218,11 +214,7 @@ func HasChildren() predicate.File {
 // HasChildrenWith applies the HasEdge predicate on the "children" edge with a given conditions (other predicates).
 func HasChildrenWith(preds ...predicate.File) predicate.File {
 	return predicate.File(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, ChildrenTable, ChildrenColumn),
-		)
+		step := newChildrenStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/examples/fs/ent/file_query.go
+++ b/examples/fs/ent/file_query.go
@@ -23,7 +23,7 @@ import (
 type FileQuery struct {
 	config
 	ctx          *QueryContext
-	order        []OrderFunc
+	order        []file.Order
 	inters       []Interceptor
 	predicates   []predicate.File
 	withParent   *FileQuery
@@ -59,7 +59,7 @@ func (fq *FileQuery) Unique(unique bool) *FileQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (fq *FileQuery) Order(o ...OrderFunc) *FileQuery {
+func (fq *FileQuery) Order(o ...file.Order) *FileQuery {
 	fq.order = append(fq.order, o...)
 	return fq
 }
@@ -297,7 +297,7 @@ func (fq *FileQuery) Clone() *FileQuery {
 	return &FileQuery{
 		config:       fq.config,
 		ctx:          fq.ctx.Clone(),
-		order:        append([]OrderFunc{}, fq.order...),
+		order:        append([]file.Order{}, fq.order...),
 		inters:       append([]Interceptor{}, fq.inters...),
 		predicates:   append([]predicate.File{}, fq.predicates...),
 		withParent:   fq.withParent.Clone(),

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -26,7 +26,7 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.3.0 // indirect
 	golang.org/x/mod v0.8.0 // indirect
-	golang.org/x/net v0.4.0 // indirect
+	golang.org/x/net v0.6.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/text v0.8.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -1954,8 +1954,9 @@ golang.org/x/net v0.0.0-20221012135044-0b7e1fb9d458/go.mod h1:YDH+HFinaLZZlnHAfS
 golang.org/x/net v0.0.0-20221014081412-f15817d10f9b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
 golang.org/x/net v0.2.0/go.mod h1:KqCZLdyyvdV855qA2rE3GC2aiw5xGR5TEjj8smXukLY=
-golang.org/x/net v0.4.0 h1:Q5QPcMlvfxFTAPV0+07Xz/MpK9NTXu2VDUuy0FeMfaU=
 golang.org/x/net v0.4.0/go.mod h1:MBQ8lrhLObU/6UmLb4fmbmk5OcyYmqtbGd/9yIeKjEE=
+golang.org/x/net v0.6.0 h1:L4ZwwTvKW9gr0ZMS1yrHD9GZhIuVjOBBnaKH+SPQK0Q=
+golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/examples/jsonencode/ent/card/card.go
+++ b/examples/jsonencode/ent/card/card.go
@@ -6,6 +6,10 @@
 
 package card
 
+import (
+	"entgo.io/ent/dialect/sql"
+)
+
 const (
 	// Label holds the string label denoting the card type in the database.
 	Label = "card"
@@ -31,4 +35,17 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Card queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByNumber orders the results by the number field.
+func ByNumber(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldNumber, opts...).ToFunc()
 }

--- a/examples/jsonencode/ent/card_query.go
+++ b/examples/jsonencode/ent/card_query.go
@@ -22,7 +22,7 @@ import (
 type CardQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []card.Order
 	inters     []Interceptor
 	predicates []predicate.Card
 	// intermediate query (i.e. traversal path).
@@ -56,7 +56,7 @@ func (cq *CardQuery) Unique(unique bool) *CardQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *CardQuery) Order(o ...OrderFunc) *CardQuery {
+func (cq *CardQuery) Order(o ...card.Order) *CardQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -250,7 +250,7 @@ func (cq *CardQuery) Clone() *CardQuery {
 	return &CardQuery{
 		config:     cq.config,
 		ctx:        cq.ctx.Clone(),
-		order:      append([]OrderFunc{}, cq.order...),
+		order:      append([]card.Order{}, cq.order...),
 		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Card{}, cq.predicates...),
 		// clone intermediate query.

--- a/examples/jsonencode/ent/ent.go
+++ b/examples/jsonencode/ent/ent.go
@@ -67,6 +67,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -87,7 +88,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -99,7 +100,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/examples/jsonencode/ent/pet/pet.go
+++ b/examples/jsonencode/ent/pet/pet.go
@@ -6,6 +6,11 @@
 
 package pet
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the pet type in the database.
 	Label = "pet"
@@ -46,4 +51,41 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Pet queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByAge orders the results by the age field.
+func ByAge(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldAge, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByOwnerID orders the results by the owner_id field.
+func ByOwnerID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldOwnerID, opts...).ToFunc()
+}
+
+// ByOwnerField orders the results by owner field.
+func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newOwnerStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(OwnerInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
+	)
 }

--- a/examples/jsonencode/ent/pet/where.go
+++ b/examples/jsonencode/ent/pet/where.go
@@ -211,11 +211,7 @@ func HasOwner() predicate.Pet {
 // HasOwnerWith applies the HasEdge predicate on the "owner" edge with a given conditions (other predicates).
 func HasOwnerWith(preds ...predicate.User) predicate.Pet {
 	return predicate.Pet(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(OwnerInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
-		)
+		step := newOwnerStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/examples/jsonencode/ent/pet_query.go
+++ b/examples/jsonencode/ent/pet_query.go
@@ -23,7 +23,7 @@ import (
 type PetQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []pet.Order
 	inters     []Interceptor
 	predicates []predicate.Pet
 	withOwner  *UserQuery
@@ -58,7 +58,7 @@ func (pq *PetQuery) Unique(unique bool) *PetQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (pq *PetQuery) Order(o ...OrderFunc) *PetQuery {
+func (pq *PetQuery) Order(o ...pet.Order) *PetQuery {
 	pq.order = append(pq.order, o...)
 	return pq
 }
@@ -274,7 +274,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 	return &PetQuery{
 		config:     pq.config,
 		ctx:        pq.ctx.Clone(),
-		order:      append([]OrderFunc{}, pq.order...),
+		order:      append([]pet.Order{}, pq.order...),
 		inters:     append([]Interceptor{}, pq.inters...),
 		predicates: append([]predicate.Pet{}, pq.predicates...),
 		withOwner:  pq.withOwner.Clone(),

--- a/examples/jsonencode/ent/user/user.go
+++ b/examples/jsonencode/ent/user/user.go
@@ -6,6 +6,11 @@
 
 package user
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the user type in the database.
 	Label = "user"
@@ -43,4 +48,43 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the User queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByAge orders the results by the age field.
+func ByAge(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldAge, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByPetsCount orders the results by pets count.
+func ByPetsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newPetsStep(), opts...)
+	}
+}
+
+// ByPets orders the results by pets terms.
+func ByPets(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newPetsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newPetsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(PetsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, PetsTable, PetsColumn),
+	)
 }

--- a/examples/jsonencode/ent/user/where.go
+++ b/examples/jsonencode/ent/user/where.go
@@ -186,11 +186,7 @@ func HasPets() predicate.User {
 // HasPetsWith applies the HasEdge predicate on the "pets" edge with a given conditions (other predicates).
 func HasPetsWith(preds ...predicate.Pet) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(PetsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, PetsTable, PetsColumn),
-		)
+		step := newPetsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/examples/jsonencode/ent/user_query.go
+++ b/examples/jsonencode/ent/user_query.go
@@ -24,7 +24,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []user.Order
 	inters     []Interceptor
 	predicates []predicate.User
 	withPets   *PetQuery
@@ -59,7 +59,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...OrderFunc) *UserQuery {
+func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -275,7 +275,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]OrderFunc{}, uq.order...),
+		order:      append([]user.Order{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		withPets:   uq.withPets.Clone(),

--- a/examples/m2m2types/ent/ent.go
+++ b/examples/m2m2types/ent/ent.go
@@ -66,6 +66,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -85,7 +86,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -97,7 +98,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/examples/m2m2types/ent/group/group.go
+++ b/examples/m2m2types/ent/group/group.go
@@ -6,6 +6,11 @@
 
 package group
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the group type in the database.
 	Label = "group"
@@ -44,4 +49,38 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Group queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByUsersCount orders the results by users count.
+func ByUsersCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newUsersStep(), opts...)
+	}
+}
+
+// ByUsers orders the results by users terms.
+func ByUsers(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newUsersStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newUsersStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(UsersInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, UsersTable, UsersPrimaryKey...),
+	)
 }

--- a/examples/m2m2types/ent/group/where.go
+++ b/examples/m2m2types/ent/group/where.go
@@ -141,11 +141,7 @@ func HasUsers() predicate.Group {
 // HasUsersWith applies the HasEdge predicate on the "users" edge with a given conditions (other predicates).
 func HasUsersWith(preds ...predicate.User) predicate.Group {
 	return predicate.Group(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(UsersInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, UsersTable, UsersPrimaryKey...),
-		)
+		step := newUsersStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/examples/m2m2types/ent/group_query.go
+++ b/examples/m2m2types/ent/group_query.go
@@ -24,7 +24,7 @@ import (
 type GroupQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []group.Order
 	inters     []Interceptor
 	predicates []predicate.Group
 	withUsers  *UserQuery
@@ -59,7 +59,7 @@ func (gq *GroupQuery) Unique(unique bool) *GroupQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (gq *GroupQuery) Order(o ...OrderFunc) *GroupQuery {
+func (gq *GroupQuery) Order(o ...group.Order) *GroupQuery {
 	gq.order = append(gq.order, o...)
 	return gq
 }
@@ -275,7 +275,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 	return &GroupQuery{
 		config:     gq.config,
 		ctx:        gq.ctx.Clone(),
-		order:      append([]OrderFunc{}, gq.order...),
+		order:      append([]group.Order{}, gq.order...),
 		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Group{}, gq.predicates...),
 		withUsers:  gq.withUsers.Clone(),

--- a/examples/m2m2types/ent/user/user.go
+++ b/examples/m2m2types/ent/user/user.go
@@ -6,6 +6,11 @@
 
 package user
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the user type in the database.
 	Label = "user"
@@ -47,4 +52,43 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the User queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByAge orders the results by the age field.
+func ByAge(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldAge, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByGroupsCount orders the results by groups count.
+func ByGroupsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newGroupsStep(), opts...)
+	}
+}
+
+// ByGroups orders the results by groups terms.
+func ByGroups(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newGroupsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newGroupsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(GroupsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, true, GroupsTable, GroupsPrimaryKey...),
+	)
 }

--- a/examples/m2m2types/ent/user/where.go
+++ b/examples/m2m2types/ent/user/where.go
@@ -186,11 +186,7 @@ func HasGroups() predicate.User {
 // HasGroupsWith applies the HasEdge predicate on the "groups" edge with a given conditions (other predicates).
 func HasGroupsWith(preds ...predicate.Group) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(GroupsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, true, GroupsTable, GroupsPrimaryKey...),
-		)
+		step := newGroupsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/examples/m2m2types/ent/user_query.go
+++ b/examples/m2m2types/ent/user_query.go
@@ -24,7 +24,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []user.Order
 	inters     []Interceptor
 	predicates []predicate.User
 	withGroups *GroupQuery
@@ -59,7 +59,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...OrderFunc) *UserQuery {
+func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -275,7 +275,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]OrderFunc{}, uq.order...),
+		order:      append([]user.Order{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		withGroups: uq.withGroups.Clone(),

--- a/examples/m2mbidi/ent/ent.go
+++ b/examples/m2mbidi/ent/ent.go
@@ -65,6 +65,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -83,7 +84,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -95,7 +96,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/examples/m2mbidi/ent/user/user.go
+++ b/examples/m2mbidi/ent/user/user.go
@@ -6,6 +6,11 @@
 
 package user
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the user type in the database.
 	Label = "user"
@@ -44,4 +49,43 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the User queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByAge orders the results by the age field.
+func ByAge(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldAge, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByFriendsCount orders the results by friends count.
+func ByFriendsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newFriendsStep(), opts...)
+	}
+}
+
+// ByFriends orders the results by friends terms.
+func ByFriends(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newFriendsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newFriendsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, FriendsTable, FriendsPrimaryKey...),
+	)
 }

--- a/examples/m2mbidi/ent/user/where.go
+++ b/examples/m2mbidi/ent/user/where.go
@@ -186,11 +186,7 @@ func HasFriends() predicate.User {
 // HasFriendsWith applies the HasEdge predicate on the "friends" edge with a given conditions (other predicates).
 func HasFriendsWith(preds ...predicate.User) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, FriendsTable, FriendsPrimaryKey...),
-		)
+		step := newFriendsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/examples/m2mbidi/ent/user_query.go
+++ b/examples/m2mbidi/ent/user_query.go
@@ -23,7 +23,7 @@ import (
 type UserQuery struct {
 	config
 	ctx         *QueryContext
-	order       []OrderFunc
+	order       []user.Order
 	inters      []Interceptor
 	predicates  []predicate.User
 	withFriends *UserQuery
@@ -58,7 +58,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...OrderFunc) *UserQuery {
+func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -274,7 +274,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:      uq.config,
 		ctx:         uq.ctx.Clone(),
-		order:       append([]OrderFunc{}, uq.order...),
+		order:       append([]user.Order{}, uq.order...),
 		inters:      append([]Interceptor{}, uq.inters...),
 		predicates:  append([]predicate.User{}, uq.predicates...),
 		withFriends: uq.withFriends.Clone(),

--- a/examples/m2mrecur/ent/ent.go
+++ b/examples/m2mrecur/ent/ent.go
@@ -65,6 +65,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -83,7 +84,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -95,7 +96,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/examples/m2mrecur/ent/user/user.go
+++ b/examples/m2mrecur/ent/user/user.go
@@ -6,6 +6,11 @@
 
 package user
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the user type in the database.
 	Label = "user"
@@ -51,4 +56,64 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the User queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByAge orders the results by the age field.
+func ByAge(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldAge, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByFollowersCount orders the results by followers count.
+func ByFollowersCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newFollowersStep(), opts...)
+	}
+}
+
+// ByFollowers orders the results by followers terms.
+func ByFollowers(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newFollowersStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByFollowingCount orders the results by following count.
+func ByFollowingCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newFollowingStep(), opts...)
+	}
+}
+
+// ByFollowing orders the results by following terms.
+func ByFollowing(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newFollowingStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newFollowersStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, true, FollowersTable, FollowersPrimaryKey...),
+	)
+}
+func newFollowingStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, FollowingTable, FollowingPrimaryKey...),
+	)
 }

--- a/examples/m2mrecur/ent/user/where.go
+++ b/examples/m2mrecur/ent/user/where.go
@@ -186,11 +186,7 @@ func HasFollowers() predicate.User {
 // HasFollowersWith applies the HasEdge predicate on the "followers" edge with a given conditions (other predicates).
 func HasFollowersWith(preds ...predicate.User) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, true, FollowersTable, FollowersPrimaryKey...),
-		)
+		step := newFollowersStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -213,11 +209,7 @@ func HasFollowing() predicate.User {
 // HasFollowingWith applies the HasEdge predicate on the "following" edge with a given conditions (other predicates).
 func HasFollowingWith(preds ...predicate.User) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, FollowingTable, FollowingPrimaryKey...),
-		)
+		step := newFollowingStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/examples/m2mrecur/ent/user_query.go
+++ b/examples/m2mrecur/ent/user_query.go
@@ -23,7 +23,7 @@ import (
 type UserQuery struct {
 	config
 	ctx           *QueryContext
-	order         []OrderFunc
+	order         []user.Order
 	inters        []Interceptor
 	predicates    []predicate.User
 	withFollowers *UserQuery
@@ -59,7 +59,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...OrderFunc) *UserQuery {
+func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -297,7 +297,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:        uq.config,
 		ctx:           uq.ctx.Clone(),
-		order:         append([]OrderFunc{}, uq.order...),
+		order:         append([]user.Order{}, uq.order...),
 		inters:        append([]Interceptor{}, uq.inters...),
 		predicates:    append([]predicate.User{}, uq.predicates...),
 		withFollowers: uq.withFollowers.Clone(),

--- a/examples/migration/ent/card/card.go
+++ b/examples/migration/ent/card/card.go
@@ -6,6 +6,11 @@
 
 package card
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the card type in the database.
 	Label = "card"
@@ -46,3 +51,30 @@ var (
 	// DefaultOwnerID holds the default value on creation for the "owner_id" field.
 	DefaultOwnerID int
 )
+
+// Order defines the ordering method for the Card queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByOwnerID orders the results by the owner_id field.
+func ByOwnerID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldOwnerID, opts...).ToFunc()
+}
+
+// ByOwnerField orders the results by owner field.
+func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newOwnerStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(OwnerInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
+	)
+}

--- a/examples/migration/ent/card/where.go
+++ b/examples/migration/ent/card/where.go
@@ -96,11 +96,7 @@ func HasOwner() predicate.Card {
 // HasOwnerWith applies the HasEdge predicate on the "owner" edge with a given conditions (other predicates).
 func HasOwnerWith(preds ...predicate.User) predicate.Card {
 	return predicate.Card(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(OwnerInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
-		)
+		step := newOwnerStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/examples/migration/ent/card_query.go
+++ b/examples/migration/ent/card_query.go
@@ -23,7 +23,7 @@ import (
 type CardQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []card.Order
 	inters     []Interceptor
 	predicates []predicate.Card
 	withOwner  *UserQuery
@@ -58,7 +58,7 @@ func (cq *CardQuery) Unique(unique bool) *CardQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *CardQuery) Order(o ...OrderFunc) *CardQuery {
+func (cq *CardQuery) Order(o ...card.Order) *CardQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -274,7 +274,7 @@ func (cq *CardQuery) Clone() *CardQuery {
 	return &CardQuery{
 		config:     cq.config,
 		ctx:        cq.ctx.Clone(),
-		order:      append([]OrderFunc{}, cq.order...),
+		order:      append([]card.Order{}, cq.order...),
 		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Card{}, cq.predicates...),
 		withOwner:  cq.withOwner.Clone(),

--- a/examples/migration/ent/ent.go
+++ b/examples/migration/ent/ent.go
@@ -67,6 +67,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -87,7 +88,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -99,7 +100,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/examples/migration/ent/pet/pet.go
+++ b/examples/migration/ent/pet/pet.go
@@ -7,6 +7,8 @@
 package pet
 
 import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
 	"github.com/google/uuid"
 )
 
@@ -61,3 +63,49 @@ var (
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() uuid.UUID
 )
+
+// Order defines the ordering method for the Pet queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByBestFriendID orders the results by the best_friend_id field.
+func ByBestFriendID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldBestFriendID, opts...).ToFunc()
+}
+
+// ByOwnerID orders the results by the owner_id field.
+func ByOwnerID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldOwnerID, opts...).ToFunc()
+}
+
+// ByBestFriendField orders the results by best_friend field.
+func ByBestFriendField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newBestFriendStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByOwnerField orders the results by owner field.
+func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newBestFriendStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.O2O, false, BestFriendTable, BestFriendColumn),
+	)
+}
+func newOwnerStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(OwnerInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, false, OwnerTable, OwnerColumn),
+	)
+}

--- a/examples/migration/ent/pet/where.go
+++ b/examples/migration/ent/pet/where.go
@@ -122,11 +122,7 @@ func HasBestFriend() predicate.Pet {
 // HasBestFriendWith applies the HasEdge predicate on the "best_friend" edge with a given conditions (other predicates).
 func HasBestFriendWith(preds ...predicate.Pet) predicate.Pet {
 	return predicate.Pet(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, false, BestFriendTable, BestFriendColumn),
-		)
+		step := newBestFriendStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -149,11 +145,7 @@ func HasOwner() predicate.Pet {
 // HasOwnerWith applies the HasEdge predicate on the "owner" edge with a given conditions (other predicates).
 func HasOwnerWith(preds ...predicate.User) predicate.Pet {
 	return predicate.Pet(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(OwnerInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, OwnerTable, OwnerColumn),
-		)
+		step := newOwnerStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/examples/migration/ent/pet_query.go
+++ b/examples/migration/ent/pet_query.go
@@ -24,7 +24,7 @@ import (
 type PetQuery struct {
 	config
 	ctx            *QueryContext
-	order          []OrderFunc
+	order          []pet.Order
 	inters         []Interceptor
 	predicates     []predicate.Pet
 	withBestFriend *PetQuery
@@ -60,7 +60,7 @@ func (pq *PetQuery) Unique(unique bool) *PetQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (pq *PetQuery) Order(o ...OrderFunc) *PetQuery {
+func (pq *PetQuery) Order(o ...pet.Order) *PetQuery {
 	pq.order = append(pq.order, o...)
 	return pq
 }
@@ -298,7 +298,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 	return &PetQuery{
 		config:         pq.config,
 		ctx:            pq.ctx.Clone(),
-		order:          append([]OrderFunc{}, pq.order...),
+		order:          append([]pet.Order{}, pq.order...),
 		inters:         append([]Interceptor{}, pq.inters...),
 		predicates:     append([]predicate.Pet{}, pq.predicates...),
 		withBestFriend: pq.withBestFriend.Clone(),

--- a/examples/migration/ent/user/user.go
+++ b/examples/migration/ent/user/user.go
@@ -6,6 +6,11 @@
 
 package user
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the user type in the database.
 	Label = "user"
@@ -46,4 +51,43 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the User queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByAge orders the results by the age field.
+func ByAge(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldAge, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByCardsCount orders the results by cards count.
+func ByCardsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newCardsStep(), opts...)
+	}
+}
+
+// ByCards orders the results by cards terms.
+func ByCards(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newCardsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newCardsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(CardsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, CardsTable, CardsColumn),
+	)
 }

--- a/examples/migration/ent/user/where.go
+++ b/examples/migration/ent/user/where.go
@@ -196,11 +196,7 @@ func HasCards() predicate.User {
 // HasCardsWith applies the HasEdge predicate on the "cards" edge with a given conditions (other predicates).
 func HasCardsWith(preds ...predicate.Card) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(CardsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, CardsTable, CardsColumn),
-		)
+		step := newCardsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/examples/migration/ent/user_query.go
+++ b/examples/migration/ent/user_query.go
@@ -24,7 +24,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []user.Order
 	inters     []Interceptor
 	predicates []predicate.User
 	withCards  *CardQuery
@@ -59,7 +59,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...OrderFunc) *UserQuery {
+func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -275,7 +275,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]OrderFunc{}, uq.order...),
+		order:      append([]user.Order{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		withCards:  uq.withCards.Clone(),

--- a/examples/o2m2types/ent/ent.go
+++ b/examples/o2m2types/ent/ent.go
@@ -66,6 +66,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -85,7 +86,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -97,7 +98,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/examples/o2m2types/ent/pet/pet.go
+++ b/examples/o2m2types/ent/pet/pet.go
@@ -6,6 +6,11 @@
 
 package pet
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the pet type in the database.
 	Label = "pet"
@@ -51,4 +56,31 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Pet queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByOwnerField orders the results by owner field.
+func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newOwnerStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(OwnerInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
+	)
 }

--- a/examples/o2m2types/ent/pet/where.go
+++ b/examples/o2m2types/ent/pet/where.go
@@ -141,11 +141,7 @@ func HasOwner() predicate.Pet {
 // HasOwnerWith applies the HasEdge predicate on the "owner" edge with a given conditions (other predicates).
 func HasOwnerWith(preds ...predicate.User) predicate.Pet {
 	return predicate.Pet(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(OwnerInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
-		)
+		step := newOwnerStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/examples/o2m2types/ent/pet_query.go
+++ b/examples/o2m2types/ent/pet_query.go
@@ -23,7 +23,7 @@ import (
 type PetQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []pet.Order
 	inters     []Interceptor
 	predicates []predicate.Pet
 	withOwner  *UserQuery
@@ -59,7 +59,7 @@ func (pq *PetQuery) Unique(unique bool) *PetQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (pq *PetQuery) Order(o ...OrderFunc) *PetQuery {
+func (pq *PetQuery) Order(o ...pet.Order) *PetQuery {
 	pq.order = append(pq.order, o...)
 	return pq
 }
@@ -275,7 +275,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 	return &PetQuery{
 		config:     pq.config,
 		ctx:        pq.ctx.Clone(),
-		order:      append([]OrderFunc{}, pq.order...),
+		order:      append([]pet.Order{}, pq.order...),
 		inters:     append([]Interceptor{}, pq.inters...),
 		predicates: append([]predicate.Pet{}, pq.predicates...),
 		withOwner:  pq.withOwner.Clone(),

--- a/examples/o2m2types/ent/user/user.go
+++ b/examples/o2m2types/ent/user/user.go
@@ -6,6 +6,11 @@
 
 package user
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the user type in the database.
 	Label = "user"
@@ -43,4 +48,43 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the User queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByAge orders the results by the age field.
+func ByAge(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldAge, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByPetsCount orders the results by pets count.
+func ByPetsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newPetsStep(), opts...)
+	}
+}
+
+// ByPets orders the results by pets terms.
+func ByPets(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newPetsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newPetsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(PetsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, PetsTable, PetsColumn),
+	)
 }

--- a/examples/o2m2types/ent/user/where.go
+++ b/examples/o2m2types/ent/user/where.go
@@ -186,11 +186,7 @@ func HasPets() predicate.User {
 // HasPetsWith applies the HasEdge predicate on the "pets" edge with a given conditions (other predicates).
 func HasPetsWith(preds ...predicate.Pet) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(PetsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, PetsTable, PetsColumn),
-		)
+		step := newPetsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/examples/o2m2types/ent/user_query.go
+++ b/examples/o2m2types/ent/user_query.go
@@ -24,7 +24,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []user.Order
 	inters     []Interceptor
 	predicates []predicate.User
 	withPets   *PetQuery
@@ -59,7 +59,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...OrderFunc) *UserQuery {
+func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -275,7 +275,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]OrderFunc{}, uq.order...),
+		order:      append([]user.Order{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		withPets:   uq.withPets.Clone(),

--- a/examples/o2mrecur/ent/ent.go
+++ b/examples/o2mrecur/ent/ent.go
@@ -65,6 +65,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -83,7 +84,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -95,7 +96,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/examples/o2mrecur/ent/node/node.go
+++ b/examples/o2mrecur/ent/node/node.go
@@ -6,6 +6,11 @@
 
 package node
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the node type in the database.
 	Label = "node"
@@ -46,4 +51,57 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Node queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByValue orders the results by the value field.
+func ByValue(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldValue, opts...).ToFunc()
+}
+
+// ByParentID orders the results by the parent_id field.
+func ByParentID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldParentID, opts...).ToFunc()
+}
+
+// ByParentField orders the results by parent field.
+func ByParentField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newParentStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByChildrenCount orders the results by children count.
+func ByChildrenCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newChildrenStep(), opts...)
+	}
+}
+
+// ByChildren orders the results by children terms.
+func ByChildren(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newChildrenStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newParentStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, ParentTable, ParentColumn),
+	)
+}
+func newChildrenStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, ChildrenTable, ChildrenColumn),
+	)
 }

--- a/examples/o2mrecur/ent/node/where.go
+++ b/examples/o2mrecur/ent/node/where.go
@@ -151,11 +151,7 @@ func HasParent() predicate.Node {
 // HasParentWith applies the HasEdge predicate on the "parent" edge with a given conditions (other predicates).
 func HasParentWith(preds ...predicate.Node) predicate.Node {
 	return predicate.Node(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, ParentTable, ParentColumn),
-		)
+		step := newParentStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -178,11 +174,7 @@ func HasChildren() predicate.Node {
 // HasChildrenWith applies the HasEdge predicate on the "children" edge with a given conditions (other predicates).
 func HasChildrenWith(preds ...predicate.Node) predicate.Node {
 	return predicate.Node(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, ChildrenTable, ChildrenColumn),
-		)
+		step := newChildrenStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/examples/o2mrecur/ent/node_query.go
+++ b/examples/o2mrecur/ent/node_query.go
@@ -23,7 +23,7 @@ import (
 type NodeQuery struct {
 	config
 	ctx          *QueryContext
-	order        []OrderFunc
+	order        []node.Order
 	inters       []Interceptor
 	predicates   []predicate.Node
 	withParent   *NodeQuery
@@ -59,7 +59,7 @@ func (nq *NodeQuery) Unique(unique bool) *NodeQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (nq *NodeQuery) Order(o ...OrderFunc) *NodeQuery {
+func (nq *NodeQuery) Order(o ...node.Order) *NodeQuery {
 	nq.order = append(nq.order, o...)
 	return nq
 }
@@ -297,7 +297,7 @@ func (nq *NodeQuery) Clone() *NodeQuery {
 	return &NodeQuery{
 		config:       nq.config,
 		ctx:          nq.ctx.Clone(),
-		order:        append([]OrderFunc{}, nq.order...),
+		order:        append([]node.Order{}, nq.order...),
 		inters:       append([]Interceptor{}, nq.inters...),
 		predicates:   append([]predicate.Node{}, nq.predicates...),
 		withParent:   nq.withParent.Clone(),

--- a/examples/o2o2types/ent/card/card.go
+++ b/examples/o2o2types/ent/card/card.go
@@ -6,6 +6,11 @@
 
 package card
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the card type in the database.
 	Label = "card"
@@ -54,4 +59,36 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Card queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByExpired orders the results by the expired field.
+func ByExpired(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldExpired, opts...).ToFunc()
+}
+
+// ByNumber orders the results by the number field.
+func ByNumber(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldNumber, opts...).ToFunc()
+}
+
+// ByOwnerField orders the results by owner field.
+func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newOwnerStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(OwnerInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2O, true, OwnerTable, OwnerColumn),
+	)
 }

--- a/examples/o2o2types/ent/card/where.go
+++ b/examples/o2o2types/ent/card/where.go
@@ -188,11 +188,7 @@ func HasOwner() predicate.Card {
 // HasOwnerWith applies the HasEdge predicate on the "owner" edge with a given conditions (other predicates).
 func HasOwnerWith(preds ...predicate.User) predicate.Card {
 	return predicate.Card(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(OwnerInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, true, OwnerTable, OwnerColumn),
-		)
+		step := newOwnerStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/examples/o2o2types/ent/card_query.go
+++ b/examples/o2o2types/ent/card_query.go
@@ -23,7 +23,7 @@ import (
 type CardQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []card.Order
 	inters     []Interceptor
 	predicates []predicate.Card
 	withOwner  *UserQuery
@@ -59,7 +59,7 @@ func (cq *CardQuery) Unique(unique bool) *CardQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *CardQuery) Order(o ...OrderFunc) *CardQuery {
+func (cq *CardQuery) Order(o ...card.Order) *CardQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -275,7 +275,7 @@ func (cq *CardQuery) Clone() *CardQuery {
 	return &CardQuery{
 		config:     cq.config,
 		ctx:        cq.ctx.Clone(),
-		order:      append([]OrderFunc{}, cq.order...),
+		order:      append([]card.Order{}, cq.order...),
 		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Card{}, cq.predicates...),
 		withOwner:  cq.withOwner.Clone(),

--- a/examples/o2o2types/ent/ent.go
+++ b/examples/o2o2types/ent/ent.go
@@ -66,6 +66,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -85,7 +86,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -97,7 +98,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/examples/o2o2types/ent/user/user.go
+++ b/examples/o2o2types/ent/user/user.go
@@ -6,6 +6,11 @@
 
 package user
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the user type in the database.
 	Label = "user"
@@ -43,4 +48,36 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the User queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByAge orders the results by the age field.
+func ByAge(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldAge, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByCardField orders the results by card field.
+func ByCardField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newCardStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newCardStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(CardInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2O, false, CardTable, CardColumn),
+	)
 }

--- a/examples/o2o2types/ent/user/where.go
+++ b/examples/o2o2types/ent/user/where.go
@@ -186,11 +186,7 @@ func HasCard() predicate.User {
 // HasCardWith applies the HasEdge predicate on the "card" edge with a given conditions (other predicates).
 func HasCardWith(preds ...predicate.Card) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(CardInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, false, CardTable, CardColumn),
-		)
+		step := newCardStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/examples/o2o2types/ent/user_query.go
+++ b/examples/o2o2types/ent/user_query.go
@@ -24,7 +24,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []user.Order
 	inters     []Interceptor
 	predicates []predicate.User
 	withCard   *CardQuery
@@ -59,7 +59,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...OrderFunc) *UserQuery {
+func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -275,7 +275,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]OrderFunc{}, uq.order...),
+		order:      append([]user.Order{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		withCard:   uq.withCard.Clone(),

--- a/examples/o2obidi/ent/ent.go
+++ b/examples/o2obidi/ent/ent.go
@@ -65,6 +65,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -83,7 +84,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -95,7 +96,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/examples/o2obidi/ent/user/user.go
+++ b/examples/o2obidi/ent/user/user.go
@@ -6,6 +6,11 @@
 
 package user
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the user type in the database.
 	Label = "user"
@@ -51,4 +56,36 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the User queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByAge orders the results by the age field.
+func ByAge(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldAge, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// BySpouseField orders the results by spouse field.
+func BySpouseField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newSpouseStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newSpouseStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.O2O, false, SpouseTable, SpouseColumn),
+	)
 }

--- a/examples/o2obidi/ent/user/where.go
+++ b/examples/o2obidi/ent/user/where.go
@@ -186,11 +186,7 @@ func HasSpouse() predicate.User {
 // HasSpouseWith applies the HasEdge predicate on the "spouse" edge with a given conditions (other predicates).
 func HasSpouseWith(preds ...predicate.User) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, false, SpouseTable, SpouseColumn),
-		)
+		step := newSpouseStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/examples/o2obidi/ent/user_query.go
+++ b/examples/o2obidi/ent/user_query.go
@@ -22,7 +22,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []user.Order
 	inters     []Interceptor
 	predicates []predicate.User
 	withSpouse *UserQuery
@@ -58,7 +58,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...OrderFunc) *UserQuery {
+func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -274,7 +274,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]OrderFunc{}, uq.order...),
+		order:      append([]user.Order{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		withSpouse: uq.withSpouse.Clone(),

--- a/examples/o2orecur/ent/ent.go
+++ b/examples/o2orecur/ent/ent.go
@@ -65,6 +65,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -83,7 +84,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -95,7 +96,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/examples/o2orecur/ent/node/node.go
+++ b/examples/o2orecur/ent/node/node.go
@@ -6,6 +6,11 @@
 
 package node
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the node type in the database.
 	Label = "node"
@@ -46,4 +51,50 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Node queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByValue orders the results by the value field.
+func ByValue(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldValue, opts...).ToFunc()
+}
+
+// ByPrevID orders the results by the prev_id field.
+func ByPrevID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldPrevID, opts...).ToFunc()
+}
+
+// ByPrevField orders the results by prev field.
+func ByPrevField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newPrevStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByNextField orders the results by next field.
+func ByNextField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newNextStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newPrevStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.O2O, true, PrevTable, PrevColumn),
+	)
+}
+func newNextStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.O2O, false, NextTable, NextColumn),
+	)
 }

--- a/examples/o2orecur/ent/node/where.go
+++ b/examples/o2orecur/ent/node/where.go
@@ -151,11 +151,7 @@ func HasPrev() predicate.Node {
 // HasPrevWith applies the HasEdge predicate on the "prev" edge with a given conditions (other predicates).
 func HasPrevWith(preds ...predicate.Node) predicate.Node {
 	return predicate.Node(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, true, PrevTable, PrevColumn),
-		)
+		step := newPrevStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -178,11 +174,7 @@ func HasNext() predicate.Node {
 // HasNextWith applies the HasEdge predicate on the "next" edge with a given conditions (other predicates).
 func HasNextWith(preds ...predicate.Node) predicate.Node {
 	return predicate.Node(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2O, false, NextTable, NextColumn),
-		)
+		step := newNextStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/examples/o2orecur/ent/node_query.go
+++ b/examples/o2orecur/ent/node_query.go
@@ -23,7 +23,7 @@ import (
 type NodeQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []node.Order
 	inters     []Interceptor
 	predicates []predicate.Node
 	withPrev   *NodeQuery
@@ -59,7 +59,7 @@ func (nq *NodeQuery) Unique(unique bool) *NodeQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (nq *NodeQuery) Order(o ...OrderFunc) *NodeQuery {
+func (nq *NodeQuery) Order(o ...node.Order) *NodeQuery {
 	nq.order = append(nq.order, o...)
 	return nq
 }
@@ -297,7 +297,7 @@ func (nq *NodeQuery) Clone() *NodeQuery {
 	return &NodeQuery{
 		config:     nq.config,
 		ctx:        nq.ctx.Clone(),
-		order:      append([]OrderFunc{}, nq.order...),
+		order:      append([]node.Order{}, nq.order...),
 		inters:     append([]Interceptor{}, nq.inters...),
 		predicates: append([]predicate.Node{}, nq.predicates...),
 		withPrev:   nq.withPrev.Clone(),

--- a/examples/privacyadmin/ent/ent.go
+++ b/examples/privacyadmin/ent/ent.go
@@ -65,6 +65,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -83,7 +84,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -95,7 +96,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/examples/privacyadmin/ent/user/user.go
+++ b/examples/privacyadmin/ent/user/user.go
@@ -8,6 +8,7 @@ package user
 
 import (
 	"entgo.io/ent"
+	"entgo.io/ent/dialect/sql"
 )
 
 const (
@@ -48,3 +49,16 @@ var (
 	// DefaultName holds the default value on creation for the "name" field.
 	DefaultName string
 )
+
+// Order defines the ordering method for the User queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}

--- a/examples/privacyadmin/ent/user_query.go
+++ b/examples/privacyadmin/ent/user_query.go
@@ -23,7 +23,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []user.Order
 	inters     []Interceptor
 	predicates []predicate.User
 	// intermediate query (i.e. traversal path).
@@ -57,7 +57,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...OrderFunc) *UserQuery {
+func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -251,7 +251,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]OrderFunc{}, uq.order...),
+		order:      append([]user.Order{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		// clone intermediate query.

--- a/examples/privacytenant/ent/ent.go
+++ b/examples/privacytenant/ent/ent.go
@@ -67,6 +67,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -87,7 +88,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -99,7 +100,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/examples/privacytenant/ent/group/where.go
+++ b/examples/privacytenant/ent/group/where.go
@@ -166,11 +166,7 @@ func HasTenant() predicate.Group {
 // HasTenantWith applies the HasEdge predicate on the "tenant" edge with a given conditions (other predicates).
 func HasTenantWith(preds ...predicate.Tenant) predicate.Group {
 	return predicate.Group(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(TenantInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, TenantTable, TenantColumn),
-		)
+		step := newTenantStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -193,11 +189,7 @@ func HasUsers() predicate.Group {
 // HasUsersWith applies the HasEdge predicate on the "users" edge with a given conditions (other predicates).
 func HasUsersWith(preds ...predicate.User) predicate.Group {
 	return predicate.Group(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(UsersInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, true, UsersTable, UsersPrimaryKey...),
-		)
+		step := newUsersStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/examples/privacytenant/ent/group_query.go
+++ b/examples/privacytenant/ent/group_query.go
@@ -26,7 +26,7 @@ import (
 type GroupQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []group.Order
 	inters     []Interceptor
 	predicates []predicate.Group
 	withTenant *TenantQuery
@@ -62,7 +62,7 @@ func (gq *GroupQuery) Unique(unique bool) *GroupQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (gq *GroupQuery) Order(o ...OrderFunc) *GroupQuery {
+func (gq *GroupQuery) Order(o ...group.Order) *GroupQuery {
 	gq.order = append(gq.order, o...)
 	return gq
 }
@@ -300,7 +300,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 	return &GroupQuery{
 		config:     gq.config,
 		ctx:        gq.ctx.Clone(),
-		order:      append([]OrderFunc{}, gq.order...),
+		order:      append([]group.Order{}, gq.order...),
 		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Group{}, gq.predicates...),
 		withTenant: gq.withTenant.Clone(),

--- a/examples/privacytenant/ent/tenant/tenant.go
+++ b/examples/privacytenant/ent/tenant/tenant.go
@@ -8,6 +8,7 @@ package tenant
 
 import (
 	"entgo.io/ent"
+	"entgo.io/ent/dialect/sql"
 )
 
 const (
@@ -48,3 +49,16 @@ var (
 	// NameValidator is a validator for the "name" field. It is called by the builders before save.
 	NameValidator func(string) error
 )
+
+// Order defines the ordering method for the Tenant queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}

--- a/examples/privacytenant/ent/tenant_query.go
+++ b/examples/privacytenant/ent/tenant_query.go
@@ -23,7 +23,7 @@ import (
 type TenantQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []tenant.Order
 	inters     []Interceptor
 	predicates []predicate.Tenant
 	// intermediate query (i.e. traversal path).
@@ -57,7 +57,7 @@ func (tq *TenantQuery) Unique(unique bool) *TenantQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (tq *TenantQuery) Order(o ...OrderFunc) *TenantQuery {
+func (tq *TenantQuery) Order(o ...tenant.Order) *TenantQuery {
 	tq.order = append(tq.order, o...)
 	return tq
 }
@@ -251,7 +251,7 @@ func (tq *TenantQuery) Clone() *TenantQuery {
 	return &TenantQuery{
 		config:     tq.config,
 		ctx:        tq.ctx.Clone(),
-		order:      append([]OrderFunc{}, tq.order...),
+		order:      append([]tenant.Order{}, tq.order...),
 		inters:     append([]Interceptor{}, tq.inters...),
 		predicates: append([]predicate.Tenant{}, tq.predicates...),
 		// clone intermediate query.

--- a/examples/privacytenant/ent/user/user.go
+++ b/examples/privacytenant/ent/user/user.go
@@ -8,6 +8,8 @@ package user
 
 import (
 	"entgo.io/ent"
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
 )
 
 const (
@@ -76,3 +78,56 @@ var (
 	// DefaultName holds the default value on creation for the "name" field.
 	DefaultName string
 )
+
+// Order defines the ordering method for the User queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByTenantID orders the results by the tenant_id field.
+func ByTenantID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldTenantID, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByTenantField orders the results by tenant field.
+func ByTenantField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newTenantStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByGroupsCount orders the results by groups count.
+func ByGroupsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newGroupsStep(), opts...)
+	}
+}
+
+// ByGroups orders the results by groups terms.
+func ByGroups(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newGroupsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newTenantStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(TenantInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, false, TenantTable, TenantColumn),
+	)
+}
+func newGroupsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(GroupsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, GroupsTable, GroupsPrimaryKey...),
+	)
+}

--- a/examples/privacytenant/ent/user/where.go
+++ b/examples/privacytenant/ent/user/where.go
@@ -176,11 +176,7 @@ func HasTenant() predicate.User {
 // HasTenantWith applies the HasEdge predicate on the "tenant" edge with a given conditions (other predicates).
 func HasTenantWith(preds ...predicate.Tenant) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(TenantInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, TenantTable, TenantColumn),
-		)
+		step := newTenantStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -203,11 +199,7 @@ func HasGroups() predicate.User {
 // HasGroupsWith applies the HasEdge predicate on the "groups" edge with a given conditions (other predicates).
 func HasGroupsWith(preds ...predicate.Group) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(GroupsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, GroupsTable, GroupsPrimaryKey...),
-		)
+		step := newGroupsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/examples/privacytenant/ent/user_query.go
+++ b/examples/privacytenant/ent/user_query.go
@@ -26,7 +26,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []user.Order
 	inters     []Interceptor
 	predicates []predicate.User
 	withTenant *TenantQuery
@@ -62,7 +62,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...OrderFunc) *UserQuery {
+func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -300,7 +300,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]OrderFunc{}, uq.order...),
+		order:      append([]user.Order{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		withTenant: uq.withTenant.Clone(),

--- a/examples/start/ent/car/car.go
+++ b/examples/start/ent/car/car.go
@@ -6,6 +6,11 @@
 
 package car
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the car type in the database.
 	Label = "car"
@@ -54,4 +59,36 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Car queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByModel orders the results by the model field.
+func ByModel(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldModel, opts...).ToFunc()
+}
+
+// ByRegisteredAt orders the results by the registered_at field.
+func ByRegisteredAt(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldRegisteredAt, opts...).ToFunc()
+}
+
+// ByOwnerField orders the results by owner field.
+func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newOwnerStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(OwnerInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
+	)
 }

--- a/examples/start/ent/car/where.go
+++ b/examples/start/ent/car/where.go
@@ -188,11 +188,7 @@ func HasOwner() predicate.Car {
 // HasOwnerWith applies the HasEdge predicate on the "owner" edge with a given conditions (other predicates).
 func HasOwnerWith(preds ...predicate.User) predicate.Car {
 	return predicate.Car(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(OwnerInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
-		)
+		step := newOwnerStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/examples/start/ent/car_query.go
+++ b/examples/start/ent/car_query.go
@@ -23,7 +23,7 @@ import (
 type CarQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []car.Order
 	inters     []Interceptor
 	predicates []predicate.Car
 	withOwner  *UserQuery
@@ -59,7 +59,7 @@ func (cq *CarQuery) Unique(unique bool) *CarQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *CarQuery) Order(o ...OrderFunc) *CarQuery {
+func (cq *CarQuery) Order(o ...car.Order) *CarQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -275,7 +275,7 @@ func (cq *CarQuery) Clone() *CarQuery {
 	return &CarQuery{
 		config:     cq.config,
 		ctx:        cq.ctx.Clone(),
-		order:      append([]OrderFunc{}, cq.order...),
+		order:      append([]car.Order{}, cq.order...),
 		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Car{}, cq.predicates...),
 		withOwner:  cq.withOwner.Clone(),

--- a/examples/start/ent/ent.go
+++ b/examples/start/ent/ent.go
@@ -67,6 +67,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -87,7 +88,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -99,7 +100,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/examples/start/ent/group/group.go
+++ b/examples/start/ent/group/group.go
@@ -6,6 +6,11 @@
 
 package group
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the group type in the database.
 	Label = "group"
@@ -50,3 +55,37 @@ var (
 	// NameValidator is a validator for the "name" field. It is called by the builders before save.
 	NameValidator func(string) error
 )
+
+// Order defines the ordering method for the Group queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByUsersCount orders the results by users count.
+func ByUsersCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newUsersStep(), opts...)
+	}
+}
+
+// ByUsers orders the results by users terms.
+func ByUsers(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newUsersStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newUsersStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(UsersInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, UsersTable, UsersPrimaryKey...),
+	)
+}

--- a/examples/start/ent/group/where.go
+++ b/examples/start/ent/group/where.go
@@ -141,11 +141,7 @@ func HasUsers() predicate.Group {
 // HasUsersWith applies the HasEdge predicate on the "users" edge with a given conditions (other predicates).
 func HasUsersWith(preds ...predicate.User) predicate.Group {
 	return predicate.Group(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(UsersInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, UsersTable, UsersPrimaryKey...),
-		)
+		step := newUsersStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/examples/start/ent/group_query.go
+++ b/examples/start/ent/group_query.go
@@ -24,7 +24,7 @@ import (
 type GroupQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []group.Order
 	inters     []Interceptor
 	predicates []predicate.Group
 	withUsers  *UserQuery
@@ -59,7 +59,7 @@ func (gq *GroupQuery) Unique(unique bool) *GroupQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (gq *GroupQuery) Order(o ...OrderFunc) *GroupQuery {
+func (gq *GroupQuery) Order(o ...group.Order) *GroupQuery {
 	gq.order = append(gq.order, o...)
 	return gq
 }
@@ -275,7 +275,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 	return &GroupQuery{
 		config:     gq.config,
 		ctx:        gq.ctx.Clone(),
-		order:      append([]OrderFunc{}, gq.order...),
+		order:      append([]group.Order{}, gq.order...),
 		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Group{}, gq.predicates...),
 		withUsers:  gq.withUsers.Clone(),

--- a/examples/start/ent/user/user.go
+++ b/examples/start/ent/user/user.go
@@ -6,6 +6,11 @@
 
 package user
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the user type in the database.
 	Label = "user"
@@ -64,3 +69,63 @@ var (
 	// DefaultName holds the default value on creation for the "name" field.
 	DefaultName string
 )
+
+// Order defines the ordering method for the User queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByAge orders the results by the age field.
+func ByAge(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldAge, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByCarsCount orders the results by cars count.
+func ByCarsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newCarsStep(), opts...)
+	}
+}
+
+// ByCars orders the results by cars terms.
+func ByCars(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newCarsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByGroupsCount orders the results by groups count.
+func ByGroupsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newGroupsStep(), opts...)
+	}
+}
+
+// ByGroups orders the results by groups terms.
+func ByGroups(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newGroupsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newCarsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(CarsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, CarsTable, CarsColumn),
+	)
+}
+func newGroupsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(GroupsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, true, GroupsTable, GroupsPrimaryKey...),
+	)
+}

--- a/examples/start/ent/user/where.go
+++ b/examples/start/ent/user/where.go
@@ -186,11 +186,7 @@ func HasCars() predicate.User {
 // HasCarsWith applies the HasEdge predicate on the "cars" edge with a given conditions (other predicates).
 func HasCarsWith(preds ...predicate.Car) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(CarsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, CarsTable, CarsColumn),
-		)
+		step := newCarsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -213,11 +209,7 @@ func HasGroups() predicate.User {
 // HasGroupsWith applies the HasEdge predicate on the "groups" edge with a given conditions (other predicates).
 func HasGroupsWith(preds ...predicate.Group) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(GroupsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, true, GroupsTable, GroupsPrimaryKey...),
-		)
+		step := newGroupsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/examples/start/ent/user_query.go
+++ b/examples/start/ent/user_query.go
@@ -25,7 +25,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []user.Order
 	inters     []Interceptor
 	predicates []predicate.User
 	withCars   *CarQuery
@@ -61,7 +61,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...OrderFunc) *UserQuery {
+func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -299,7 +299,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]OrderFunc{}, uq.order...),
+		order:      append([]user.Order{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		withCars:   uq.withCars.Clone(),

--- a/examples/traversal/ent/ent.go
+++ b/examples/traversal/ent/ent.go
@@ -67,6 +67,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -87,7 +88,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -99,7 +100,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/examples/traversal/ent/group/group.go
+++ b/examples/traversal/ent/group/group.go
@@ -6,6 +6,11 @@
 
 package group
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the group type in the database.
 	Label = "group"
@@ -64,4 +69,52 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Group queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByUsersCount orders the results by users count.
+func ByUsersCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newUsersStep(), opts...)
+	}
+}
+
+// ByUsers orders the results by users terms.
+func ByUsers(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newUsersStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByAdminField orders the results by admin field.
+func ByAdminField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newAdminStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newUsersStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(UsersInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, UsersTable, UsersPrimaryKey...),
+	)
+}
+func newAdminStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(AdminInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, false, AdminTable, AdminColumn),
+	)
 }

--- a/examples/traversal/ent/group/where.go
+++ b/examples/traversal/ent/group/where.go
@@ -141,11 +141,7 @@ func HasUsers() predicate.Group {
 // HasUsersWith applies the HasEdge predicate on the "users" edge with a given conditions (other predicates).
 func HasUsersWith(preds ...predicate.User) predicate.Group {
 	return predicate.Group(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(UsersInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, UsersTable, UsersPrimaryKey...),
-		)
+		step := newUsersStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -168,11 +164,7 @@ func HasAdmin() predicate.Group {
 // HasAdminWith applies the HasEdge predicate on the "admin" edge with a given conditions (other predicates).
 func HasAdminWith(preds ...predicate.User) predicate.Group {
 	return predicate.Group(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(AdminInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, AdminTable, AdminColumn),
-		)
+		step := newAdminStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/examples/traversal/ent/group_query.go
+++ b/examples/traversal/ent/group_query.go
@@ -24,7 +24,7 @@ import (
 type GroupQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []group.Order
 	inters     []Interceptor
 	predicates []predicate.Group
 	withUsers  *UserQuery
@@ -61,7 +61,7 @@ func (gq *GroupQuery) Unique(unique bool) *GroupQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (gq *GroupQuery) Order(o ...OrderFunc) *GroupQuery {
+func (gq *GroupQuery) Order(o ...group.Order) *GroupQuery {
 	gq.order = append(gq.order, o...)
 	return gq
 }
@@ -299,7 +299,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 	return &GroupQuery{
 		config:     gq.config,
 		ctx:        gq.ctx.Clone(),
-		order:      append([]OrderFunc{}, gq.order...),
+		order:      append([]group.Order{}, gq.order...),
 		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Group{}, gq.predicates...),
 		withUsers:  gq.withUsers.Clone(),

--- a/examples/traversal/ent/pet/pet.go
+++ b/examples/traversal/ent/pet/pet.go
@@ -6,6 +6,11 @@
 
 package pet
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the pet type in the database.
 	Label = "pet"
@@ -61,4 +66,52 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the Pet queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByFriendsCount orders the results by friends count.
+func ByFriendsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newFriendsStep(), opts...)
+	}
+}
+
+// ByFriends orders the results by friends terms.
+func ByFriends(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newFriendsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByOwnerField orders the results by owner field.
+func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
+	}
+}
+func newFriendsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, FriendsTable, FriendsPrimaryKey...),
+	)
+}
+func newOwnerStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(OwnerInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
+	)
 }

--- a/examples/traversal/ent/pet/where.go
+++ b/examples/traversal/ent/pet/where.go
@@ -141,11 +141,7 @@ func HasFriends() predicate.Pet {
 // HasFriendsWith applies the HasEdge predicate on the "friends" edge with a given conditions (other predicates).
 func HasFriendsWith(preds ...predicate.Pet) predicate.Pet {
 	return predicate.Pet(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, FriendsTable, FriendsPrimaryKey...),
-		)
+		step := newFriendsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -168,11 +164,7 @@ func HasOwner() predicate.Pet {
 // HasOwnerWith applies the HasEdge predicate on the "owner" edge with a given conditions (other predicates).
 func HasOwnerWith(preds ...predicate.User) predicate.Pet {
 	return predicate.Pet(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(OwnerInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
-		)
+		step := newOwnerStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/examples/traversal/ent/pet_query.go
+++ b/examples/traversal/ent/pet_query.go
@@ -24,7 +24,7 @@ import (
 type PetQuery struct {
 	config
 	ctx         *QueryContext
-	order       []OrderFunc
+	order       []pet.Order
 	inters      []Interceptor
 	predicates  []predicate.Pet
 	withFriends *PetQuery
@@ -61,7 +61,7 @@ func (pq *PetQuery) Unique(unique bool) *PetQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (pq *PetQuery) Order(o ...OrderFunc) *PetQuery {
+func (pq *PetQuery) Order(o ...pet.Order) *PetQuery {
 	pq.order = append(pq.order, o...)
 	return pq
 }
@@ -299,7 +299,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 	return &PetQuery{
 		config:      pq.config,
 		ctx:         pq.ctx.Clone(),
-		order:       append([]OrderFunc{}, pq.order...),
+		order:       append([]pet.Order{}, pq.order...),
 		inters:      append([]Interceptor{}, pq.inters...),
 		predicates:  append([]predicate.Pet{}, pq.predicates...),
 		withFriends: pq.withFriends.Clone(),

--- a/examples/traversal/ent/user/user.go
+++ b/examples/traversal/ent/user/user.go
@@ -6,6 +6,11 @@
 
 package user
 
+import (
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqlgraph"
+)
+
 const (
 	// Label holds the string label denoting the user type in the database.
 	Label = "user"
@@ -72,4 +77,106 @@ func ValidColumn(column string) bool {
 		}
 	}
 	return false
+}
+
+// Order defines the ordering method for the User queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByAge orders the results by the age field.
+func ByAge(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldAge, opts...).ToFunc()
+}
+
+// ByName orders the results by the name field.
+func ByName(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByPetsCount orders the results by pets count.
+func ByPetsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newPetsStep(), opts...)
+	}
+}
+
+// ByPets orders the results by pets terms.
+func ByPets(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newPetsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByFriendsCount orders the results by friends count.
+func ByFriendsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newFriendsStep(), opts...)
+	}
+}
+
+// ByFriends orders the results by friends terms.
+func ByFriends(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newFriendsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByGroupsCount orders the results by groups count.
+func ByGroupsCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newGroupsStep(), opts...)
+	}
+}
+
+// ByGroups orders the results by groups terms.
+func ByGroups(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newGroupsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByManageCount orders the results by manage count.
+func ByManageCount(opts ...sql.OrderTermOption) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newManageStep(), opts...)
+	}
+}
+
+// ByManage orders the results by manage terms.
+func ByManage(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newManageStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+func newPetsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(PetsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, PetsTable, PetsColumn),
+	)
+}
+func newFriendsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, FriendsTable, FriendsPrimaryKey...),
+	)
+}
+func newGroupsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(GroupsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, true, GroupsTable, GroupsPrimaryKey...),
+	)
+}
+func newManageStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(ManageInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, true, ManageTable, ManageColumn),
+	)
 }

--- a/examples/traversal/ent/user/where.go
+++ b/examples/traversal/ent/user/where.go
@@ -186,11 +186,7 @@ func HasPets() predicate.User {
 // HasPetsWith applies the HasEdge predicate on the "pets" edge with a given conditions (other predicates).
 func HasPetsWith(preds ...predicate.Pet) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(PetsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, PetsTable, PetsColumn),
-		)
+		step := newPetsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -213,11 +209,7 @@ func HasFriends() predicate.User {
 // HasFriendsWith applies the HasEdge predicate on the "friends" edge with a given conditions (other predicates).
 func HasFriendsWith(preds ...predicate.User) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, FriendsTable, FriendsPrimaryKey...),
-		)
+		step := newFriendsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -240,11 +232,7 @@ func HasGroups() predicate.User {
 // HasGroupsWith applies the HasEdge predicate on the "groups" edge with a given conditions (other predicates).
 func HasGroupsWith(preds ...predicate.Group) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(GroupsInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, true, GroupsTable, GroupsPrimaryKey...),
-		)
+		step := newGroupsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)
@@ -267,11 +255,7 @@ func HasManage() predicate.User {
 // HasManageWith applies the HasEdge predicate on the "manage" edge with a given conditions (other predicates).
 func HasManageWith(preds ...predicate.Group) predicate.User {
 	return predicate.User(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.To(ManageInverseTable, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, true, ManageTable, ManageColumn),
-		)
+		step := newManageStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/examples/traversal/ent/user_query.go
+++ b/examples/traversal/ent/user_query.go
@@ -25,7 +25,7 @@ import (
 type UserQuery struct {
 	config
 	ctx         *QueryContext
-	order       []OrderFunc
+	order       []user.Order
 	inters      []Interceptor
 	predicates  []predicate.User
 	withPets    *PetQuery
@@ -63,7 +63,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...OrderFunc) *UserQuery {
+func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -345,7 +345,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:      uq.config,
 		ctx:         uq.ctx.Clone(),
-		order:       append([]OrderFunc{}, uq.order...),
+		order:       append([]user.Order{}, uq.order...),
 		inters:      append([]Interceptor{}, uq.inters...),
 		predicates:  append([]predicate.User{}, uq.predicates...),
 		withPets:    uq.withPets.Clone(),

--- a/examples/version/ent/ent.go
+++ b/examples/version/ent/ent.go
@@ -65,6 +65,7 @@ func NewTxContext(parent context.Context, tx *Tx) context.Context {
 }
 
 // OrderFunc applies an ordering on the sql selector.
+// Deprecated: Use Asc/Desc functions or the package builders instead.
 type OrderFunc func(*sql.Selector)
 
 var (
@@ -83,7 +84,7 @@ func checkColumn(table, column string) error {
 }
 
 // Asc applies the given fields in ASC order.
-func Asc(fields ...string) OrderFunc {
+func Asc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {
@@ -95,7 +96,7 @@ func Asc(fields ...string) OrderFunc {
 }
 
 // Desc applies the given fields in DESC order.
-func Desc(fields ...string) OrderFunc {
+func Desc(fields ...string) func(*sql.Selector) {
 	return func(s *sql.Selector) {
 		for _, f := range fields {
 			if err := checkColumn(s.TableName(), f); err != nil {

--- a/examples/version/ent/user/user.go
+++ b/examples/version/ent/user/user.go
@@ -8,6 +8,8 @@ package user
 
 import (
 	"fmt"
+
+	"entgo.io/ent/dialect/sql"
 )
 
 const (
@@ -66,4 +68,22 @@ func StatusValidator(s Status) error {
 	default:
 		return fmt.Errorf("user: invalid enum value for status field: %q", s)
 	}
+}
+
+// Order defines the ordering method for the User queries.
+type Order func(*sql.Selector)
+
+// ByID orders the results by the id field.
+func ByID(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByVersion orders the results by the version field.
+func ByVersion(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldVersion, opts...).ToFunc()
+}
+
+// ByStatus orders the results by the status field.
+func ByStatus(opts ...sql.OrderTermOption) Order {
+	return sql.OrderByField(FieldStatus, opts...).ToFunc()
 }

--- a/examples/version/ent/user_query.go
+++ b/examples/version/ent/user_query.go
@@ -22,7 +22,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []OrderFunc
+	order      []user.Order
 	inters     []Interceptor
 	predicates []predicate.User
 	// intermediate query (i.e. traversal path).
@@ -56,7 +56,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...OrderFunc) *UserQuery {
+func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -250,7 +250,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]OrderFunc{}, uq.order...),
+		order:      append([]user.Order{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		// clone intermediate query.


### PR DESCRIPTION
```go
// NULLs are ordered first.
user.ByName()

// NULLs are ordered last.
user.ByName(
	sql.OrderDesc(),
)

user.ByName(
	sql.OrderDesc(),
	sql.OrderNullsFirst(),
)

// Order by (non-unique) edge count.
user.ByPostsCount()

// Order by (unique) edge field.
post.ByAuthorField(
	user.FieldName,
	sql.OrderDesc(),
)

// Order by arbitrary order terms.
user.ByPosts(
	sql.OrderBySum(post.FieldNumLikes),
	sql.OrderBySum(post.FieldNumViews),
)
```