### PR TITLE
Rename Order type to OrderSelectorFunc

### DIFF
--- a/entc/gen/template/builder/query.tmpl
+++ b/entc/gen/template/builder/query.tmpl
@@ -22,7 +22,7 @@ in the LICENSE file in the root directory of this source tree.
 type {{ $builder }} struct {
 	config
 	ctx			*QueryContext
-	order		[]{{ $.Package }}.Order
+	order		[]{{ $.Package }}.OrderingSelectorFunc
 	inters		[]Interceptor
 	predicates 	[]predicate.{{ $.Name }}
 	{{- /* Eager loading fields. */}}
@@ -65,7 +65,7 @@ func ({{ $receiver }} *{{ $builder }}) Unique(unique bool) *{{ $builder }} {
 }
 
 // Order specifies how the records should be ordered.
-func ({{ $receiver }} *{{ $builder }}) Order(o ...{{ $.Package }}.Order) *{{ $builder }} {
+func ({{ $receiver }} *{{ $builder }}) Order(o ...{{ $.Package }}.OrderingSelectorFunc) *{{ $builder }} {
 	{{ $receiver }}.order = append({{ $receiver }}.order, o...)
 	return {{ $receiver }}
 }
@@ -90,7 +90,7 @@ func ({{ $receiver }} *{{ $builder }}) Order(o ...{{ $.Package }}.Order) *{{ $bu
 	}
 {{ end }}
 
-// First returns the first {{ $.Name }} entity from the query. 
+// First returns the first {{ $.Name }} entity from the query.
 // Returns a *NotFoundError when no {{ $.Name }} was found.
 func ({{ $receiver }} *{{ $builder }}) First(ctx context.Context) (*{{ $.Name }}, error) {
 	nodes, err := {{ $receiver }}.Limit(1).All(setContextOp(ctx, {{ $receiver }}.ctx, "First"))
@@ -286,7 +286,7 @@ func ({{ $receiver }} *{{ $builder }}) Clone() *{{ $builder }} {
 	return &{{ $builder }}{
 		config: 	{{ $receiver }}.config,
 		ctx: 		{{ $receiver }}.ctx.Clone(),
-		order: 		append([]{{ $.Package }}.Order{}, {{ $receiver }}.order...),
+		order: 		append([]{{ $.Package }}.OrderingSelectorFunc{}, {{ $receiver }}.order...),
 		inters: 	append([]Interceptor{}, {{ $receiver }}.inters...),
 		predicates: append([]predicate.{{ $.Name }}{}, {{ $receiver }}.predicates...),
 		{{- range $e := $.Edges }}

--- a/entc/gen/template/dialect/sql/meta.tmpl
+++ b/entc/gen/template/dialect/sql/meta.tmpl
@@ -95,14 +95,14 @@ func ValidColumn(column string) bool {
 {{ define "dialect/sql/meta/order" }}
 	{{ if $.HasOneFieldID }}
 		// {{ $.ID.OrderName }} orders the results by the {{ $.ID.Name }} field.
-		func {{ $.ID.OrderName }}(opts ...sql.OrderTermOption) Order {
+		func {{ $.ID.OrderName }}(opts ...sql.OrderTermOption) OrderingSelectorFunc {
 			return sql.OrderByField({{ $.ID.Constant }}, opts...).ToFunc()
 		}
 	{{ end }}
 	{{- range $f := $.Fields }}
 		{{- if $f.Type.Comparable }}
 			// {{ $f.OrderName }} orders the results by the {{ $f.Name }} field.
-			func {{ $f.OrderName }}(opts ...sql.OrderTermOption) Order {
+			func {{ $f.OrderName }}(opts ...sql.OrderTermOption) OrderingSelectorFunc {
 				return sql.OrderByField({{ $f.Constant }}, opts...).ToFunc()
 			}
 		{{- end }}
@@ -110,21 +110,21 @@ func ValidColumn(column string) bool {
 	{{- range $e := $.Edges }}
 		{{- if $e.Unique }}
 			// {{ $e.OrderFieldName }} orders the results by {{ $e.Name }} field.
-			func {{ $e.OrderFieldName }}(field string, opts ...sql.OrderTermOption) Order {
+			func {{ $e.OrderFieldName }}(field string, opts ...sql.OrderTermOption) OrderingSelectorFunc {
 				return func(s *sql.Selector) {
 					sqlgraph.OrderByNeighborTerms(s, new{{ pascal $e.Name }}Step(), sql.OrderByField(field, opts...))
 				}
 			}
 		{{- else }}
 			// {{ $e.OrderCountName }} orders the results by {{ $e.Name }} count.
-			func {{ $e.OrderCountName }}(opts ...sql.OrderTermOption) Order {
+			func {{ $e.OrderCountName }}(opts ...sql.OrderTermOption) OrderingSelectorFunc {
 				return func(s *sql.Selector) {
 					sqlgraph.OrderByNeighborsCount(s, new{{ pascal $e.Name }}Step(), opts...)
 				}
 			}
 
 			// {{ $e.OrderTermsName }} orders the results by {{ $e.Name }} terms.
-			func {{ $e.OrderTermsName }}(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+			func {{ $e.OrderTermsName }}(term sql.OrderTerm, terms ...sql.OrderTerm) OrderingSelectorFunc {
 				return func(s *sql.Selector) {
 					sqlgraph.OrderByNeighborTerms(s, new{{ pascal $e.Name }}Step(), append([]sql.OrderTerm{term}, terms...)...)
 				}

--- a/entc/gen/template/meta.tmpl
+++ b/entc/gen/template/meta.tmpl
@@ -155,8 +155,8 @@ const (
 {{ end }}
 
 {{ $tmpl = printf "dialect/%s/meta/order" $.Storage }}
-// Order defines the ordering method for the {{ $.Name }} queries.
-type Order func({{ $.Config.Storage.Builder }})
+// OrderingSelectorFunc defines the ordering method for the {{ $.Name }} queries.
+type OrderingSelectorFunc func({{ $.Config.Storage.Builder }})
 {{ if hasTemplate $tmpl }}
 	{{ xtemplate $tmpl $ }}
 {{ end }}


### PR DESCRIPTION
https://github.com/ent/ent/issues/3465

This doesn't fix the core issue, which is that there is a naming conflict between generated function names and the public `type Order`. 

This fixed the build issue on my system. This can be merged in as a temporary fix but the real solution would be to put the supporting types in their own packge where they won't conflict with the generated types. Something like

`ent/TABLE_NAME/meta:Order`

Note: This is not a backwards compatible change. It will break if anyone uses the typename.Order field in their code. 