### PR TITLE
entc/gen: rename <type>.Order to <type>.OrderOption

### DIFF
--- a/entc/gen/template/builder/query.tmpl
+++ b/entc/gen/template/builder/query.tmpl
@@ -22,7 +22,7 @@ in the LICENSE file in the root directory of this source tree.
 type {{ $builder }} struct {
 	config
 	ctx			*QueryContext
-	order		[]{{ $.Package }}.Order
+	order		[]{{ $.Package }}.OrderOption
 	inters		[]Interceptor
 	predicates 	[]predicate.{{ $.Name }}
 	{{- /* Eager loading fields. */}}
@@ -65,7 +65,7 @@ func ({{ $receiver }} *{{ $builder }}) Unique(unique bool) *{{ $builder }} {
 }
 
 // Order specifies how the records should be ordered.
-func ({{ $receiver }} *{{ $builder }}) Order(o ...{{ $.Package }}.Order) *{{ $builder }} {
+func ({{ $receiver }} *{{ $builder }}) Order(o ...{{ $.Package }}.OrderOption) *{{ $builder }} {
 	{{ $receiver }}.order = append({{ $receiver }}.order, o...)
 	return {{ $receiver }}
 }
@@ -286,7 +286,7 @@ func ({{ $receiver }} *{{ $builder }}) Clone() *{{ $builder }} {
 	return &{{ $builder }}{
 		config: 	{{ $receiver }}.config,
 		ctx: 		{{ $receiver }}.ctx.Clone(),
-		order: 		append([]{{ $.Package }}.Order{}, {{ $receiver }}.order...),
+		order: 		append([]{{ $.Package }}.OrderOption{}, {{ $receiver }}.order...),
 		inters: 	append([]Interceptor{}, {{ $receiver }}.inters...),
 		predicates: append([]predicate.{{ $.Name }}{}, {{ $receiver }}.predicates...),
 		{{- range $e := $.Edges }}

--- a/entc/gen/template/dialect/sql/meta.tmpl
+++ b/entc/gen/template/dialect/sql/meta.tmpl
@@ -95,14 +95,14 @@ func ValidColumn(column string) bool {
 {{ define "dialect/sql/meta/order" }}
 	{{ if $.HasOneFieldID }}
 		// {{ $.ID.OrderName }} orders the results by the {{ $.ID.Name }} field.
-		func {{ $.ID.OrderName }}(opts ...sql.OrderTermOption) Order {
+		func {{ $.ID.OrderName }}(opts ...sql.OrderTermOption) OrderOption {
 			return sql.OrderByField({{ $.ID.Constant }}, opts...).ToFunc()
 		}
 	{{ end }}
 	{{- range $f := $.Fields }}
 		{{- if $f.Type.Comparable }}
 			// {{ $f.OrderName }} orders the results by the {{ $f.Name }} field.
-			func {{ $f.OrderName }}(opts ...sql.OrderTermOption) Order {
+			func {{ $f.OrderName }}(opts ...sql.OrderTermOption) OrderOption {
 				return sql.OrderByField({{ $f.Constant }}, opts...).ToFunc()
 			}
 		{{- end }}
@@ -110,21 +110,21 @@ func ValidColumn(column string) bool {
 	{{- range $e := $.Edges }}
 		{{- if $e.Unique }}
 			// {{ $e.OrderFieldName }} orders the results by {{ $e.Name }} field.
-			func {{ $e.OrderFieldName }}(field string, opts ...sql.OrderTermOption) Order {
+			func {{ $e.OrderFieldName }}(field string, opts ...sql.OrderTermOption) OrderOption {
 				return func(s *sql.Selector) {
 					sqlgraph.OrderByNeighborTerms(s, new{{ pascal $e.Name }}Step(), sql.OrderByField(field, opts...))
 				}
 			}
 		{{- else }}
 			// {{ $e.OrderCountName }} orders the results by {{ $e.Name }} count.
-			func {{ $e.OrderCountName }}(opts ...sql.OrderTermOption) Order {
+			func {{ $e.OrderCountName }}(opts ...sql.OrderTermOption) OrderOption {
 				return func(s *sql.Selector) {
 					sqlgraph.OrderByNeighborsCount(s, new{{ pascal $e.Name }}Step(), opts...)
 				}
 			}
 
 			// {{ $e.OrderTermsName }} orders the results by {{ $e.Name }} terms.
-			func {{ $e.OrderTermsName }}(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+			func {{ $e.OrderTermsName }}(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 				return func(s *sql.Selector) {
 					sqlgraph.OrderByNeighborTerms(s, new{{ pascal $e.Name }}Step(), append([]sql.OrderTerm{term}, terms...)...)
 				}

--- a/entc/gen/template/intercept.tmpl
+++ b/entc/gen/template/intercept.tmpl
@@ -109,7 +109,7 @@ func NewQuery(q {{ $pkg }}.Query) (Query, error) {
 	switch q := q.(type) {
 	{{- range $n := $.Nodes }}
 		case *{{ $pkg }}.{{ $n.QueryName }}:
-		return &query[*{{ $pkg }}.{{ $n.QueryName }}, predicate.{{ $n.Name }}, {{ $n.Package }}.Order]{typ: {{ $pkg }}.{{ $n.TypeName }}, tq: q}, nil
+		return &query[*{{ $pkg }}.{{ $n.QueryName }}, predicate.{{ $n.Name }}, {{ $n.Package }}.OrderOption]{typ: {{ $pkg }}.{{ $n.TypeName }}, tq: q}, nil
 	{{- end }}
 	default:
 		return nil, fmt.Errorf("unknown query type %T", q)

--- a/entc/gen/template/meta.tmpl
+++ b/entc/gen/template/meta.tmpl
@@ -155,8 +155,8 @@ const (
 {{ end }}
 
 {{ $tmpl = printf "dialect/%s/meta/order" $.Storage }}
-// Order defines the ordering method for the {{ $.Name }} queries.
-type Order func({{ $.Config.Storage.Builder }})
+// OrderOption defines the ordering options for the {{ $.Name }} queries.
+type OrderOption func({{ $.Config.Storage.Builder }})
 {{ if hasTemplate $tmpl }}
 	{{ xtemplate $tmpl $ }}
 {{ end }}

--- a/entc/gen/template/where.tmpl
+++ b/entc/gen/template/where.tmpl
@@ -43,7 +43,7 @@ in the LICENSE file in the root directory of this source tree.
 	{{/* JSON cannot be compared using "=" and Enum has a type defined with the field name */}}
 	{{ $hasP := not (or $f.IsJSON $f.IsEnum) }}
 	{{ $comparable := or $f.ConvertedToBasic $f.Type.Valuer }}
-	{{ $undeclared := (and (ne $func "Label") (ne $func "Hooks") (ne $func "Policy") (ne $func "Table") (ne $func "FieldID")) }}
+	{{ $undeclared := (and (ne $func "Label") (ne $func "OrderOption") (ne $func "Hooks") (ne $func "Policy") (ne $func "Table") (ne $func "FieldID")) }}
 	{{- if and $hasP $comparable $undeclared }}
 		{{ $arg := "v" }}
 		// {{ $func }} applies equality check predicate on the {{ quote $f.Name }} field. It's identical to {{ $func }}EQ.

--- a/entc/integration/cascadelete/ent/comment/comment.go
+++ b/entc/integration/cascadelete/ent/comment/comment.go
@@ -50,26 +50,26 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Comment queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Comment queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByText orders the results by the text field.
-func ByText(opts ...sql.OrderTermOption) Order {
+func ByText(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldText, opts...).ToFunc()
 }
 
 // ByPostID orders the results by the post_id field.
-func ByPostID(opts ...sql.OrderTermOption) Order {
+func ByPostID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldPostID, opts...).ToFunc()
 }
 
 // ByPostField orders the results by post field.
-func ByPostField(field string, opts ...sql.OrderTermOption) Order {
+func ByPostField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newPostStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/cascadelete/ent/comment_query.go
+++ b/entc/integration/cascadelete/ent/comment_query.go
@@ -23,7 +23,7 @@ import (
 type CommentQuery struct {
 	config
 	ctx        *QueryContext
-	order      []comment.Order
+	order      []comment.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Comment
 	withPost   *PostQuery
@@ -58,7 +58,7 @@ func (cq *CommentQuery) Unique(unique bool) *CommentQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *CommentQuery) Order(o ...comment.Order) *CommentQuery {
+func (cq *CommentQuery) Order(o ...comment.OrderOption) *CommentQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -274,7 +274,7 @@ func (cq *CommentQuery) Clone() *CommentQuery {
 	return &CommentQuery{
 		config:     cq.config,
 		ctx:        cq.ctx.Clone(),
-		order:      append([]comment.Order{}, cq.order...),
+		order:      append([]comment.OrderOption{}, cq.order...),
 		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Comment{}, cq.predicates...),
 		withPost:   cq.withPost.Clone(),

--- a/entc/integration/cascadelete/ent/post/post.go
+++ b/entc/integration/cascadelete/ent/post/post.go
@@ -64,40 +64,40 @@ var (
 	DefaultText string
 )
 
-// Order defines the ordering method for the Post queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Post queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByText orders the results by the text field.
-func ByText(opts ...sql.OrderTermOption) Order {
+func ByText(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldText, opts...).ToFunc()
 }
 
 // ByAuthorID orders the results by the author_id field.
-func ByAuthorID(opts ...sql.OrderTermOption) Order {
+func ByAuthorID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAuthorID, opts...).ToFunc()
 }
 
 // ByAuthorField orders the results by author field.
-func ByAuthorField(field string, opts ...sql.OrderTermOption) Order {
+func ByAuthorField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newAuthorStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByCommentsCount orders the results by comments count.
-func ByCommentsCount(opts ...sql.OrderTermOption) Order {
+func ByCommentsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newCommentsStep(), opts...)
 	}
 }
 
 // ByComments orders the results by comments terms.
-func ByComments(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByComments(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newCommentsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/entc/integration/cascadelete/ent/post_query.go
+++ b/entc/integration/cascadelete/ent/post_query.go
@@ -25,7 +25,7 @@ import (
 type PostQuery struct {
 	config
 	ctx          *QueryContext
-	order        []post.Order
+	order        []post.OrderOption
 	inters       []Interceptor
 	predicates   []predicate.Post
 	withAuthor   *UserQuery
@@ -61,7 +61,7 @@ func (pq *PostQuery) Unique(unique bool) *PostQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (pq *PostQuery) Order(o ...post.Order) *PostQuery {
+func (pq *PostQuery) Order(o ...post.OrderOption) *PostQuery {
 	pq.order = append(pq.order, o...)
 	return pq
 }
@@ -299,7 +299,7 @@ func (pq *PostQuery) Clone() *PostQuery {
 	return &PostQuery{
 		config:       pq.config,
 		ctx:          pq.ctx.Clone(),
-		order:        append([]post.Order{}, pq.order...),
+		order:        append([]post.OrderOption{}, pq.order...),
 		inters:       append([]Interceptor{}, pq.inters...),
 		predicates:   append([]predicate.Post{}, pq.predicates...),
 		withAuthor:   pq.withAuthor.Clone(),

--- a/entc/integration/cascadelete/ent/user/user.go
+++ b/entc/integration/cascadelete/ent/user/user.go
@@ -52,28 +52,28 @@ var (
 	DefaultName string
 )
 
-// Order defines the ordering method for the User queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the User queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByPostsCount orders the results by posts count.
-func ByPostsCount(opts ...sql.OrderTermOption) Order {
+func ByPostsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newPostsStep(), opts...)
 	}
 }
 
 // ByPosts orders the results by posts terms.
-func ByPosts(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByPosts(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newPostsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/entc/integration/cascadelete/ent/user_query.go
+++ b/entc/integration/cascadelete/ent/user_query.go
@@ -24,7 +24,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []user.Order
+	order      []user.OrderOption
 	inters     []Interceptor
 	predicates []predicate.User
 	withPosts  *PostQuery
@@ -59,7 +59,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
+func (uq *UserQuery) Order(o ...user.OrderOption) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -275,7 +275,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]user.Order{}, uq.order...),
+		order:      append([]user.OrderOption{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		withPosts:  uq.withPosts.Clone(),

--- a/entc/integration/config/ent/user/user.go
+++ b/entc/integration/config/ent/user/user.go
@@ -40,20 +40,20 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the User queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the User queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByLabel orders the results by the label field.
-func ByLabel(opts ...sql.OrderTermOption) Order {
+func ByLabel(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldLabel, opts...).ToFunc()
 }

--- a/entc/integration/config/ent/user_query.go
+++ b/entc/integration/config/ent/user_query.go
@@ -22,7 +22,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []user.Order
+	order      []user.OrderOption
 	inters     []Interceptor
 	predicates []predicate.User
 	// intermediate query (i.e. traversal path).
@@ -56,7 +56,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
+func (uq *UserQuery) Order(o ...user.OrderOption) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -250,7 +250,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]user.Order{}, uq.order...),
+		order:      append([]user.OrderOption{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/customid/ent/account/account.go
+++ b/entc/integration/customid/ent/account/account.go
@@ -55,28 +55,28 @@ var (
 	DefaultID func() sid.ID
 )
 
-// Order defines the ordering method for the Account queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Account queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByEmail orders the results by the email field.
-func ByEmail(opts ...sql.OrderTermOption) Order {
+func ByEmail(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldEmail, opts...).ToFunc()
 }
 
 // ByTokenCount orders the results by token count.
-func ByTokenCount(opts ...sql.OrderTermOption) Order {
+func ByTokenCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newTokenStep(), opts...)
 	}
 }
 
 // ByToken orders the results by token terms.
-func ByToken(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByToken(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newTokenStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/entc/integration/customid/ent/account_query.go
+++ b/entc/integration/customid/ent/account_query.go
@@ -25,7 +25,7 @@ import (
 type AccountQuery struct {
 	config
 	ctx        *QueryContext
-	order      []account.Order
+	order      []account.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Account
 	withToken  *TokenQuery
@@ -60,7 +60,7 @@ func (aq *AccountQuery) Unique(unique bool) *AccountQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (aq *AccountQuery) Order(o ...account.Order) *AccountQuery {
+func (aq *AccountQuery) Order(o ...account.OrderOption) *AccountQuery {
 	aq.order = append(aq.order, o...)
 	return aq
 }
@@ -276,7 +276,7 @@ func (aq *AccountQuery) Clone() *AccountQuery {
 	return &AccountQuery{
 		config:     aq.config,
 		ctx:        aq.ctx.Clone(),
-		order:      append([]account.Order{}, aq.order...),
+		order:      append([]account.OrderOption{}, aq.order...),
 		inters:     append([]Interceptor{}, aq.inters...),
 		predicates: append([]predicate.Account{}, aq.predicates...),
 		withToken:  aq.withToken.Clone(),

--- a/entc/integration/customid/ent/blob/blob.go
+++ b/entc/integration/customid/ent/blob/blob.go
@@ -87,54 +87,54 @@ var (
 	DefaultID func() uuid.UUID
 )
 
-// Order defines the ordering method for the Blob queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Blob queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByUUID orders the results by the uuid field.
-func ByUUID(opts ...sql.OrderTermOption) Order {
+func ByUUID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUUID, opts...).ToFunc()
 }
 
 // ByCount orders the results by the count field.
-func ByCount(opts ...sql.OrderTermOption) Order {
+func ByCount(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCount, opts...).ToFunc()
 }
 
 // ByParentField orders the results by parent field.
-func ByParentField(field string, opts ...sql.OrderTermOption) Order {
+func ByParentField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newParentStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByLinksCount orders the results by links count.
-func ByLinksCount(opts ...sql.OrderTermOption) Order {
+func ByLinksCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newLinksStep(), opts...)
 	}
 }
 
 // ByLinks orders the results by links terms.
-func ByLinks(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByLinks(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newLinksStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByBlobLinksCount orders the results by blob_links count.
-func ByBlobLinksCount(opts ...sql.OrderTermOption) Order {
+func ByBlobLinksCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newBlobLinksStep(), opts...)
 	}
 }
 
 // ByBlobLinks orders the results by blob_links terms.
-func ByBlobLinks(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByBlobLinks(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newBlobLinksStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/entc/integration/customid/ent/blob_query.go
+++ b/entc/integration/customid/ent/blob_query.go
@@ -25,7 +25,7 @@ import (
 type BlobQuery struct {
 	config
 	ctx           *QueryContext
-	order         []blob.Order
+	order         []blob.OrderOption
 	inters        []Interceptor
 	predicates    []predicate.Blob
 	withParent    *BlobQuery
@@ -63,7 +63,7 @@ func (bq *BlobQuery) Unique(unique bool) *BlobQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (bq *BlobQuery) Order(o ...blob.Order) *BlobQuery {
+func (bq *BlobQuery) Order(o ...blob.OrderOption) *BlobQuery {
 	bq.order = append(bq.order, o...)
 	return bq
 }
@@ -323,7 +323,7 @@ func (bq *BlobQuery) Clone() *BlobQuery {
 	return &BlobQuery{
 		config:        bq.config,
 		ctx:           bq.ctx.Clone(),
-		order:         append([]blob.Order{}, bq.order...),
+		order:         append([]blob.OrderOption{}, bq.order...),
 		inters:        append([]Interceptor{}, bq.inters...),
 		predicates:    append([]predicate.Blob{}, bq.predicates...),
 		withParent:    bq.withParent.Clone(),

--- a/entc/integration/customid/ent/bloblink/bloblink.go
+++ b/entc/integration/customid/ent/bloblink/bloblink.go
@@ -68,33 +68,33 @@ var (
 	DefaultCreatedAt func() time.Time
 )
 
-// Order defines the ordering method for the BlobLink queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the BlobLink queries.
+type OrderOption func(*sql.Selector)
 
 // ByCreatedAt orders the results by the created_at field.
-func ByCreatedAt(opts ...sql.OrderTermOption) Order {
+func ByCreatedAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCreatedAt, opts...).ToFunc()
 }
 
 // ByBlobID orders the results by the blob_id field.
-func ByBlobID(opts ...sql.OrderTermOption) Order {
+func ByBlobID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldBlobID, opts...).ToFunc()
 }
 
 // ByLinkID orders the results by the link_id field.
-func ByLinkID(opts ...sql.OrderTermOption) Order {
+func ByLinkID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldLinkID, opts...).ToFunc()
 }
 
 // ByBlobField orders the results by blob field.
-func ByBlobField(field string, opts ...sql.OrderTermOption) Order {
+func ByBlobField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newBlobStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByLinkField orders the results by link field.
-func ByLinkField(field string, opts ...sql.OrderTermOption) Order {
+func ByLinkField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newLinkStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/customid/ent/bloblink_query.go
+++ b/entc/integration/customid/ent/bloblink_query.go
@@ -23,7 +23,7 @@ import (
 type BlobLinkQuery struct {
 	config
 	ctx        *QueryContext
-	order      []bloblink.Order
+	order      []bloblink.OrderOption
 	inters     []Interceptor
 	predicates []predicate.BlobLink
 	withBlob   *BlobQuery
@@ -59,7 +59,7 @@ func (blq *BlobLinkQuery) Unique(unique bool) *BlobLinkQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (blq *BlobLinkQuery) Order(o ...bloblink.Order) *BlobLinkQuery {
+func (blq *BlobLinkQuery) Order(o ...bloblink.OrderOption) *BlobLinkQuery {
 	blq.order = append(blq.order, o...)
 	return blq
 }
@@ -225,7 +225,7 @@ func (blq *BlobLinkQuery) Clone() *BlobLinkQuery {
 	return &BlobLinkQuery{
 		config:     blq.config,
 		ctx:        blq.ctx.Clone(),
-		order:      append([]bloblink.Order{}, blq.order...),
+		order:      append([]bloblink.OrderOption{}, blq.order...),
 		inters:     append([]Interceptor{}, blq.inters...),
 		predicates: append([]predicate.BlobLink{}, blq.predicates...),
 		withBlob:   blq.withBlob.Clone(),

--- a/entc/integration/customid/ent/car/car.go
+++ b/entc/integration/customid/ent/car/car.go
@@ -73,31 +73,31 @@ var (
 	IDValidator func(int) error
 )
 
-// Order defines the ordering method for the Car queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Car queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByBeforeID orders the results by the before_id field.
-func ByBeforeID(opts ...sql.OrderTermOption) Order {
+func ByBeforeID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldBeforeID, opts...).ToFunc()
 }
 
 // ByAfterID orders the results by the after_id field.
-func ByAfterID(opts ...sql.OrderTermOption) Order {
+func ByAfterID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAfterID, opts...).ToFunc()
 }
 
 // ByModel orders the results by the model field.
-func ByModel(opts ...sql.OrderTermOption) Order {
+func ByModel(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldModel, opts...).ToFunc()
 }
 
 // ByOwnerField orders the results by owner field.
-func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+func ByOwnerField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/customid/ent/car_query.go
+++ b/entc/integration/customid/ent/car_query.go
@@ -23,7 +23,7 @@ import (
 type CarQuery struct {
 	config
 	ctx        *QueryContext
-	order      []car.Order
+	order      []car.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Car
 	withOwner  *PetQuery
@@ -59,7 +59,7 @@ func (cq *CarQuery) Unique(unique bool) *CarQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *CarQuery) Order(o ...car.Order) *CarQuery {
+func (cq *CarQuery) Order(o ...car.OrderOption) *CarQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -275,7 +275,7 @@ func (cq *CarQuery) Clone() *CarQuery {
 	return &CarQuery{
 		config:     cq.config,
 		ctx:        cq.ctx.Clone(),
-		order:      append([]car.Order{}, cq.order...),
+		order:      append([]car.OrderOption{}, cq.order...),
 		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Car{}, cq.predicates...),
 		withOwner:  cq.withOwner.Clone(),

--- a/entc/integration/customid/ent/device/device.go
+++ b/entc/integration/customid/ent/device/device.go
@@ -72,30 +72,30 @@ var (
 	IDValidator func([]byte) error
 )
 
-// Order defines the ordering method for the Device queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Device queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByActiveSessionField orders the results by active_session field.
-func ByActiveSessionField(field string, opts ...sql.OrderTermOption) Order {
+func ByActiveSessionField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newActiveSessionStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // BySessionsCount orders the results by sessions count.
-func BySessionsCount(opts ...sql.OrderTermOption) Order {
+func BySessionsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newSessionsStep(), opts...)
 	}
 }
 
 // BySessions orders the results by sessions terms.
-func BySessions(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func BySessions(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newSessionsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/entc/integration/customid/ent/device_query.go
+++ b/entc/integration/customid/ent/device_query.go
@@ -25,7 +25,7 @@ import (
 type DeviceQuery struct {
 	config
 	ctx               *QueryContext
-	order             []device.Order
+	order             []device.OrderOption
 	inters            []Interceptor
 	predicates        []predicate.Device
 	withActiveSession *SessionQuery
@@ -62,7 +62,7 @@ func (dq *DeviceQuery) Unique(unique bool) *DeviceQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (dq *DeviceQuery) Order(o ...device.Order) *DeviceQuery {
+func (dq *DeviceQuery) Order(o ...device.OrderOption) *DeviceQuery {
 	dq.order = append(dq.order, o...)
 	return dq
 }
@@ -300,7 +300,7 @@ func (dq *DeviceQuery) Clone() *DeviceQuery {
 	return &DeviceQuery{
 		config:            dq.config,
 		ctx:               dq.ctx.Clone(),
-		order:             append([]device.Order{}, dq.order...),
+		order:             append([]device.OrderOption{}, dq.order...),
 		inters:            append([]Interceptor{}, dq.inters...),
 		predicates:        append([]predicate.Device{}, dq.predicates...),
 		withActiveSession: dq.withActiveSession.Clone(),

--- a/entc/integration/customid/ent/doc/doc.go
+++ b/entc/integration/customid/ent/doc/doc.go
@@ -79,49 +79,49 @@ var (
 	IDValidator func(string) error
 )
 
-// Order defines the ordering method for the Doc queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Doc queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByText orders the results by the text field.
-func ByText(opts ...sql.OrderTermOption) Order {
+func ByText(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldText, opts...).ToFunc()
 }
 
 // ByParentField orders the results by parent field.
-func ByParentField(field string, opts ...sql.OrderTermOption) Order {
+func ByParentField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newParentStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByChildrenCount orders the results by children count.
-func ByChildrenCount(opts ...sql.OrderTermOption) Order {
+func ByChildrenCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newChildrenStep(), opts...)
 	}
 }
 
 // ByChildren orders the results by children terms.
-func ByChildren(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByChildren(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newChildrenStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByRelatedCount orders the results by related count.
-func ByRelatedCount(opts ...sql.OrderTermOption) Order {
+func ByRelatedCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newRelatedStep(), opts...)
 	}
 }
 
 // ByRelated orders the results by related terms.
-func ByRelated(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByRelated(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newRelatedStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/entc/integration/customid/ent/doc_query.go
+++ b/entc/integration/customid/ent/doc_query.go
@@ -24,7 +24,7 @@ import (
 type DocQuery struct {
 	config
 	ctx          *QueryContext
-	order        []doc.Order
+	order        []doc.OrderOption
 	inters       []Interceptor
 	predicates   []predicate.Doc
 	withParent   *DocQuery
@@ -62,7 +62,7 @@ func (dq *DocQuery) Unique(unique bool) *DocQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (dq *DocQuery) Order(o ...doc.Order) *DocQuery {
+func (dq *DocQuery) Order(o ...doc.OrderOption) *DocQuery {
 	dq.order = append(dq.order, o...)
 	return dq
 }
@@ -322,7 +322,7 @@ func (dq *DocQuery) Clone() *DocQuery {
 	return &DocQuery{
 		config:       dq.config,
 		ctx:          dq.ctx.Clone(),
-		order:        append([]doc.Order{}, dq.order...),
+		order:        append([]doc.OrderOption{}, dq.order...),
 		inters:       append([]Interceptor{}, dq.inters...),
 		predicates:   append([]predicate.Doc{}, dq.predicates...),
 		withParent:   dq.withParent.Clone(),

--- a/entc/integration/customid/ent/group/group.go
+++ b/entc/integration/customid/ent/group/group.go
@@ -50,23 +50,23 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Group queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Group queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByUsersCount orders the results by users count.
-func ByUsersCount(opts ...sql.OrderTermOption) Order {
+func ByUsersCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newUsersStep(), opts...)
 	}
 }
 
 // ByUsers orders the results by users terms.
-func ByUsers(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByUsers(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newUsersStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/entc/integration/customid/ent/group_query.go
+++ b/entc/integration/customid/ent/group_query.go
@@ -24,7 +24,7 @@ import (
 type GroupQuery struct {
 	config
 	ctx        *QueryContext
-	order      []group.Order
+	order      []group.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Group
 	withUsers  *UserQuery
@@ -59,7 +59,7 @@ func (gq *GroupQuery) Unique(unique bool) *GroupQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (gq *GroupQuery) Order(o ...group.Order) *GroupQuery {
+func (gq *GroupQuery) Order(o ...group.OrderOption) *GroupQuery {
 	gq.order = append(gq.order, o...)
 	return gq
 }
@@ -275,7 +275,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 	return &GroupQuery{
 		config:     gq.config,
 		ctx:        gq.ctx.Clone(),
-		order:      append([]group.Order{}, gq.order...),
+		order:      append([]group.OrderOption{}, gq.order...),
 		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Group{}, gq.predicates...),
 		withUsers:  gq.withUsers.Clone(),

--- a/entc/integration/customid/ent/intsid/intsid.go
+++ b/entc/integration/customid/ent/intsid/intsid.go
@@ -58,30 +58,30 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the IntSID queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the IntSID queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByParentField orders the results by parent field.
-func ByParentField(field string, opts ...sql.OrderTermOption) Order {
+func ByParentField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newParentStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByChildrenCount orders the results by children count.
-func ByChildrenCount(opts ...sql.OrderTermOption) Order {
+func ByChildrenCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newChildrenStep(), opts...)
 	}
 }
 
 // ByChildren orders the results by children terms.
-func ByChildren(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByChildren(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newChildrenStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/entc/integration/customid/ent/intsid_query.go
+++ b/entc/integration/customid/ent/intsid_query.go
@@ -24,7 +24,7 @@ import (
 type IntSIDQuery struct {
 	config
 	ctx          *QueryContext
-	order        []intsid.Order
+	order        []intsid.OrderOption
 	inters       []Interceptor
 	predicates   []predicate.IntSID
 	withParent   *IntSIDQuery
@@ -61,7 +61,7 @@ func (isq *IntSIDQuery) Unique(unique bool) *IntSIDQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (isq *IntSIDQuery) Order(o ...intsid.Order) *IntSIDQuery {
+func (isq *IntSIDQuery) Order(o ...intsid.OrderOption) *IntSIDQuery {
 	isq.order = append(isq.order, o...)
 	return isq
 }
@@ -299,7 +299,7 @@ func (isq *IntSIDQuery) Clone() *IntSIDQuery {
 	return &IntSIDQuery{
 		config:       isq.config,
 		ctx:          isq.ctx.Clone(),
-		order:        append([]intsid.Order{}, isq.order...),
+		order:        append([]intsid.OrderOption{}, isq.order...),
 		inters:       append([]Interceptor{}, isq.inters...),
 		predicates:   append([]predicate.IntSID{}, isq.predicates...),
 		withParent:   isq.withParent.Clone(),

--- a/entc/integration/customid/ent/link/link.go
+++ b/entc/integration/customid/ent/link/link.go
@@ -46,10 +46,10 @@ var (
 	DefaultID func() uuidc.UUIDC
 )
 
-// Order defines the ordering method for the Link queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Link queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }

--- a/entc/integration/customid/ent/link_query.go
+++ b/entc/integration/customid/ent/link_query.go
@@ -23,7 +23,7 @@ import (
 type LinkQuery struct {
 	config
 	ctx        *QueryContext
-	order      []link.Order
+	order      []link.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Link
 	// intermediate query (i.e. traversal path).
@@ -57,7 +57,7 @@ func (lq *LinkQuery) Unique(unique bool) *LinkQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (lq *LinkQuery) Order(o ...link.Order) *LinkQuery {
+func (lq *LinkQuery) Order(o ...link.OrderOption) *LinkQuery {
 	lq.order = append(lq.order, o...)
 	return lq
 }
@@ -251,7 +251,7 @@ func (lq *LinkQuery) Clone() *LinkQuery {
 	return &LinkQuery{
 		config:     lq.config,
 		ctx:        lq.ctx.Clone(),
-		order:      append([]link.Order{}, lq.order...),
+		order:      append([]link.OrderOption{}, lq.order...),
 		inters:     append([]Interceptor{}, lq.inters...),
 		predicates: append([]predicate.Link{}, lq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/customid/ent/mixinid/mixinid.go
+++ b/entc/integration/customid/ent/mixinid/mixinid.go
@@ -46,20 +46,20 @@ var (
 	DefaultID func() uuid.UUID
 )
 
-// Order defines the ordering method for the MixinID queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the MixinID queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // BySomeField orders the results by the some_field field.
-func BySomeField(opts ...sql.OrderTermOption) Order {
+func BySomeField(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldSomeField, opts...).ToFunc()
 }
 
 // ByMixinField orders the results by the mixin_field field.
-func ByMixinField(opts ...sql.OrderTermOption) Order {
+func ByMixinField(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldMixinField, opts...).ToFunc()
 }

--- a/entc/integration/customid/ent/mixinid_query.go
+++ b/entc/integration/customid/ent/mixinid_query.go
@@ -23,7 +23,7 @@ import (
 type MixinIDQuery struct {
 	config
 	ctx        *QueryContext
-	order      []mixinid.Order
+	order      []mixinid.OrderOption
 	inters     []Interceptor
 	predicates []predicate.MixinID
 	// intermediate query (i.e. traversal path).
@@ -57,7 +57,7 @@ func (miq *MixinIDQuery) Unique(unique bool) *MixinIDQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (miq *MixinIDQuery) Order(o ...mixinid.Order) *MixinIDQuery {
+func (miq *MixinIDQuery) Order(o ...mixinid.OrderOption) *MixinIDQuery {
 	miq.order = append(miq.order, o...)
 	return miq
 }
@@ -251,7 +251,7 @@ func (miq *MixinIDQuery) Clone() *MixinIDQuery {
 	return &MixinIDQuery{
 		config:     miq.config,
 		ctx:        miq.ctx.Clone(),
-		order:      append([]mixinid.Order{}, miq.order...),
+		order:      append([]mixinid.OrderOption{}, miq.order...),
 		inters:     append([]Interceptor{}, miq.inters...),
 		predicates: append([]predicate.MixinID{}, miq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/customid/ent/note/note.go
+++ b/entc/integration/customid/ent/note/note.go
@@ -69,35 +69,35 @@ var (
 	IDValidator func(string) error
 )
 
-// Order defines the ordering method for the Note queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Note queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByText orders the results by the text field.
-func ByText(opts ...sql.OrderTermOption) Order {
+func ByText(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldText, opts...).ToFunc()
 }
 
 // ByParentField orders the results by parent field.
-func ByParentField(field string, opts ...sql.OrderTermOption) Order {
+func ByParentField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newParentStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByChildrenCount orders the results by children count.
-func ByChildrenCount(opts ...sql.OrderTermOption) Order {
+func ByChildrenCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newChildrenStep(), opts...)
 	}
 }
 
 // ByChildren orders the results by children terms.
-func ByChildren(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByChildren(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newChildrenStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/entc/integration/customid/ent/note_query.go
+++ b/entc/integration/customid/ent/note_query.go
@@ -24,7 +24,7 @@ import (
 type NoteQuery struct {
 	config
 	ctx          *QueryContext
-	order        []note.Order
+	order        []note.OrderOption
 	inters       []Interceptor
 	predicates   []predicate.Note
 	withParent   *NoteQuery
@@ -61,7 +61,7 @@ func (nq *NoteQuery) Unique(unique bool) *NoteQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (nq *NoteQuery) Order(o ...note.Order) *NoteQuery {
+func (nq *NoteQuery) Order(o ...note.OrderOption) *NoteQuery {
 	nq.order = append(nq.order, o...)
 	return nq
 }
@@ -299,7 +299,7 @@ func (nq *NoteQuery) Clone() *NoteQuery {
 	return &NoteQuery{
 		config:       nq.config,
 		ctx:          nq.ctx.Clone(),
-		order:        append([]note.Order{}, nq.order...),
+		order:        append([]note.OrderOption{}, nq.order...),
 		inters:       append([]Interceptor{}, nq.inters...),
 		predicates:   append([]predicate.Note{}, nq.predicates...),
 		withParent:   nq.withParent.Clone(),

--- a/entc/integration/customid/ent/other/other.go
+++ b/entc/integration/customid/ent/other/other.go
@@ -40,10 +40,10 @@ var (
 	DefaultID func() sid.ID
 )
 
-// Order defines the ordering method for the Other queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Other queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }

--- a/entc/integration/customid/ent/other_query.go
+++ b/entc/integration/customid/ent/other_query.go
@@ -23,7 +23,7 @@ import (
 type OtherQuery struct {
 	config
 	ctx        *QueryContext
-	order      []other.Order
+	order      []other.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Other
 	// intermediate query (i.e. traversal path).
@@ -57,7 +57,7 @@ func (oq *OtherQuery) Unique(unique bool) *OtherQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (oq *OtherQuery) Order(o ...other.Order) *OtherQuery {
+func (oq *OtherQuery) Order(o ...other.OrderOption) *OtherQuery {
 	oq.order = append(oq.order, o...)
 	return oq
 }
@@ -251,7 +251,7 @@ func (oq *OtherQuery) Clone() *OtherQuery {
 	return &OtherQuery{
 		config:     oq.config,
 		ctx:        oq.ctx.Clone(),
-		order:      append([]other.Order{}, oq.order...),
+		order:      append([]other.OrderOption{}, oq.order...),
 		inters:     append([]Interceptor{}, oq.inters...),
 		predicates: append([]predicate.Other{}, oq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/customid/ent/pet/pet.go
+++ b/entc/integration/customid/ent/pet/pet.go
@@ -90,51 +90,51 @@ var (
 	IDValidator func(string) error
 )
 
-// Order defines the ordering method for the Pet queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Pet queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByOwnerField orders the results by owner field.
-func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+func ByOwnerField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByCarsCount orders the results by cars count.
-func ByCarsCount(opts ...sql.OrderTermOption) Order {
+func ByCarsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newCarsStep(), opts...)
 	}
 }
 
 // ByCars orders the results by cars terms.
-func ByCars(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByCars(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newCarsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByFriendsCount orders the results by friends count.
-func ByFriendsCount(opts ...sql.OrderTermOption) Order {
+func ByFriendsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newFriendsStep(), opts...)
 	}
 }
 
 // ByFriends orders the results by friends terms.
-func ByFriends(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByFriends(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newFriendsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByBestFriendField orders the results by best_friend field.
-func ByBestFriendField(field string, opts ...sql.OrderTermOption) Order {
+func ByBestFriendField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newBestFriendStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/customid/ent/pet_query.go
+++ b/entc/integration/customid/ent/pet_query.go
@@ -25,7 +25,7 @@ import (
 type PetQuery struct {
 	config
 	ctx            *QueryContext
-	order          []pet.Order
+	order          []pet.OrderOption
 	inters         []Interceptor
 	predicates     []predicate.Pet
 	withOwner      *UserQuery
@@ -64,7 +64,7 @@ func (pq *PetQuery) Unique(unique bool) *PetQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (pq *PetQuery) Order(o ...pet.Order) *PetQuery {
+func (pq *PetQuery) Order(o ...pet.OrderOption) *PetQuery {
 	pq.order = append(pq.order, o...)
 	return pq
 }
@@ -346,7 +346,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 	return &PetQuery{
 		config:         pq.config,
 		ctx:            pq.ctx.Clone(),
-		order:          append([]pet.Order{}, pq.order...),
+		order:          append([]pet.OrderOption{}, pq.order...),
 		inters:         append([]Interceptor{}, pq.inters...),
 		predicates:     append([]predicate.Pet{}, pq.predicates...),
 		withOwner:      pq.withOwner.Clone(),

--- a/entc/integration/customid/ent/revision/revision.go
+++ b/entc/integration/customid/ent/revision/revision.go
@@ -34,10 +34,10 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Revision queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Revision queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }

--- a/entc/integration/customid/ent/revision_query.go
+++ b/entc/integration/customid/ent/revision_query.go
@@ -22,7 +22,7 @@ import (
 type RevisionQuery struct {
 	config
 	ctx        *QueryContext
-	order      []revision.Order
+	order      []revision.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Revision
 	// intermediate query (i.e. traversal path).
@@ -56,7 +56,7 @@ func (rq *RevisionQuery) Unique(unique bool) *RevisionQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (rq *RevisionQuery) Order(o ...revision.Order) *RevisionQuery {
+func (rq *RevisionQuery) Order(o ...revision.OrderOption) *RevisionQuery {
 	rq.order = append(rq.order, o...)
 	return rq
 }
@@ -250,7 +250,7 @@ func (rq *RevisionQuery) Clone() *RevisionQuery {
 	return &RevisionQuery{
 		config:     rq.config,
 		ctx:        rq.ctx.Clone(),
-		order:      append([]revision.Order{}, rq.order...),
+		order:      append([]revision.OrderOption{}, rq.order...),
 		inters:     append([]Interceptor{}, rq.inters...),
 		predicates: append([]predicate.Revision{}, rq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/customid/ent/session/session.go
+++ b/entc/integration/customid/ent/session/session.go
@@ -63,16 +63,16 @@ var (
 	IDValidator func([]byte) error
 )
 
-// Order defines the ordering method for the Session queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Session queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByDeviceField orders the results by device field.
-func ByDeviceField(field string, opts ...sql.OrderTermOption) Order {
+func ByDeviceField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newDeviceStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/customid/ent/session_query.go
+++ b/entc/integration/customid/ent/session_query.go
@@ -24,7 +24,7 @@ import (
 type SessionQuery struct {
 	config
 	ctx        *QueryContext
-	order      []session.Order
+	order      []session.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Session
 	withDevice *DeviceQuery
@@ -60,7 +60,7 @@ func (sq *SessionQuery) Unique(unique bool) *SessionQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (sq *SessionQuery) Order(o ...session.Order) *SessionQuery {
+func (sq *SessionQuery) Order(o ...session.OrderOption) *SessionQuery {
 	sq.order = append(sq.order, o...)
 	return sq
 }
@@ -276,7 +276,7 @@ func (sq *SessionQuery) Clone() *SessionQuery {
 	return &SessionQuery{
 		config:     sq.config,
 		ctx:        sq.ctx.Clone(),
-		order:      append([]session.Order{}, sq.order...),
+		order:      append([]session.OrderOption{}, sq.order...),
 		inters:     append([]Interceptor{}, sq.inters...),
 		predicates: append([]predicate.Session{}, sq.predicates...),
 		withDevice: sq.withDevice.Clone(),

--- a/entc/integration/customid/ent/token/token.go
+++ b/entc/integration/customid/ent/token/token.go
@@ -66,21 +66,21 @@ var (
 	DefaultID func() sid.ID
 )
 
-// Order defines the ordering method for the Token queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Token queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByBody orders the results by the body field.
-func ByBody(opts ...sql.OrderTermOption) Order {
+func ByBody(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldBody, opts...).ToFunc()
 }
 
 // ByAccountField orders the results by account field.
-func ByAccountField(field string, opts ...sql.OrderTermOption) Order {
+func ByAccountField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newAccountStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/customid/ent/token_query.go
+++ b/entc/integration/customid/ent/token_query.go
@@ -24,7 +24,7 @@ import (
 type TokenQuery struct {
 	config
 	ctx         *QueryContext
-	order       []token.Order
+	order       []token.OrderOption
 	inters      []Interceptor
 	predicates  []predicate.Token
 	withAccount *AccountQuery
@@ -60,7 +60,7 @@ func (tq *TokenQuery) Unique(unique bool) *TokenQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (tq *TokenQuery) Order(o ...token.Order) *TokenQuery {
+func (tq *TokenQuery) Order(o ...token.OrderOption) *TokenQuery {
 	tq.order = append(tq.order, o...)
 	return tq
 }
@@ -276,7 +276,7 @@ func (tq *TokenQuery) Clone() *TokenQuery {
 	return &TokenQuery{
 		config:      tq.config,
 		ctx:         tq.ctx.Clone(),
-		order:       append([]token.Order{}, tq.order...),
+		order:       append([]token.OrderOption{}, tq.order...),
 		inters:      append([]Interceptor{}, tq.inters...),
 		predicates:  append([]predicate.Token{}, tq.predicates...),
 		withAccount: tq.withAccount.Clone(),

--- a/entc/integration/customid/ent/user/user.go
+++ b/entc/integration/customid/ent/user/user.go
@@ -84,58 +84,58 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the User queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the User queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByGroupsCount orders the results by groups count.
-func ByGroupsCount(opts ...sql.OrderTermOption) Order {
+func ByGroupsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newGroupsStep(), opts...)
 	}
 }
 
 // ByGroups orders the results by groups terms.
-func ByGroups(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByGroups(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newGroupsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByParentField orders the results by parent field.
-func ByParentField(field string, opts ...sql.OrderTermOption) Order {
+func ByParentField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newParentStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByChildrenCount orders the results by children count.
-func ByChildrenCount(opts ...sql.OrderTermOption) Order {
+func ByChildrenCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newChildrenStep(), opts...)
 	}
 }
 
 // ByChildren orders the results by children terms.
-func ByChildren(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByChildren(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newChildrenStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByPetsCount orders the results by pets count.
-func ByPetsCount(opts ...sql.OrderTermOption) Order {
+func ByPetsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newPetsStep(), opts...)
 	}
 }
 
 // ByPets orders the results by pets terms.
-func ByPets(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByPets(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newPetsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/entc/integration/customid/ent/user_query.go
+++ b/entc/integration/customid/ent/user_query.go
@@ -25,7 +25,7 @@ import (
 type UserQuery struct {
 	config
 	ctx          *QueryContext
-	order        []user.Order
+	order        []user.OrderOption
 	inters       []Interceptor
 	predicates   []predicate.User
 	withGroups   *GroupQuery
@@ -64,7 +64,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
+func (uq *UserQuery) Order(o ...user.OrderOption) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -346,7 +346,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:       uq.config,
 		ctx:          uq.ctx.Clone(),
-		order:        append([]user.Order{}, uq.order...),
+		order:        append([]user.OrderOption{}, uq.order...),
 		inters:       append([]Interceptor{}, uq.inters...),
 		predicates:   append([]predicate.User{}, uq.predicates...),
 		withGroups:   uq.withGroups.Clone(),

--- a/entc/integration/edgefield/ent/car/car.go
+++ b/entc/integration/edgefield/ent/car/car.go
@@ -53,28 +53,28 @@ var (
 	DefaultID func() uuid.UUID
 )
 
-// Order defines the ordering method for the Car queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Car queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByNumber orders the results by the number field.
-func ByNumber(opts ...sql.OrderTermOption) Order {
+func ByNumber(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldNumber, opts...).ToFunc()
 }
 
 // ByRentalsCount orders the results by rentals count.
-func ByRentalsCount(opts ...sql.OrderTermOption) Order {
+func ByRentalsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newRentalsStep(), opts...)
 	}
 }
 
 // ByRentals orders the results by rentals terms.
-func ByRentals(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByRentals(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newRentalsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/entc/integration/edgefield/ent/car_query.go
+++ b/entc/integration/edgefield/ent/car_query.go
@@ -25,7 +25,7 @@ import (
 type CarQuery struct {
 	config
 	ctx         *QueryContext
-	order       []car.Order
+	order       []car.OrderOption
 	inters      []Interceptor
 	predicates  []predicate.Car
 	withRentals *RentalQuery
@@ -60,7 +60,7 @@ func (cq *CarQuery) Unique(unique bool) *CarQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *CarQuery) Order(o ...car.Order) *CarQuery {
+func (cq *CarQuery) Order(o ...car.OrderOption) *CarQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -276,7 +276,7 @@ func (cq *CarQuery) Clone() *CarQuery {
 	return &CarQuery{
 		config:      cq.config,
 		ctx:         cq.ctx.Clone(),
-		order:       append([]car.Order{}, cq.order...),
+		order:       append([]car.OrderOption{}, cq.order...),
 		inters:      append([]Interceptor{}, cq.inters...),
 		predicates:  append([]predicate.Car{}, cq.predicates...),
 		withRentals: cq.withRentals.Clone(),

--- a/entc/integration/edgefield/ent/card/card.go
+++ b/entc/integration/edgefield/ent/card/card.go
@@ -50,26 +50,26 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Card queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Card queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByNumber orders the results by the number field.
-func ByNumber(opts ...sql.OrderTermOption) Order {
+func ByNumber(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldNumber, opts...).ToFunc()
 }
 
 // ByOwnerID orders the results by the owner_id field.
-func ByOwnerID(opts ...sql.OrderTermOption) Order {
+func ByOwnerID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldOwnerID, opts...).ToFunc()
 }
 
 // ByOwnerField orders the results by owner field.
-func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+func ByOwnerField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/edgefield/ent/card_query.go
+++ b/entc/integration/edgefield/ent/card_query.go
@@ -23,7 +23,7 @@ import (
 type CardQuery struct {
 	config
 	ctx        *QueryContext
-	order      []card.Order
+	order      []card.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Card
 	withOwner  *UserQuery
@@ -58,7 +58,7 @@ func (cq *CardQuery) Unique(unique bool) *CardQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *CardQuery) Order(o ...card.Order) *CardQuery {
+func (cq *CardQuery) Order(o ...card.OrderOption) *CardQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -274,7 +274,7 @@ func (cq *CardQuery) Clone() *CardQuery {
 	return &CardQuery{
 		config:     cq.config,
 		ctx:        cq.ctx.Clone(),
-		order:      append([]card.Order{}, cq.order...),
+		order:      append([]card.OrderOption{}, cq.order...),
 		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Card{}, cq.predicates...),
 		withOwner:  cq.withOwner.Clone(),

--- a/entc/integration/edgefield/ent/info/info.go
+++ b/entc/integration/edgefield/ent/info/info.go
@@ -47,16 +47,16 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Info queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Info queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByUserField orders the results by user field.
-func ByUserField(field string, opts ...sql.OrderTermOption) Order {
+func ByUserField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newUserStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/edgefield/ent/info_query.go
+++ b/entc/integration/edgefield/ent/info_query.go
@@ -23,7 +23,7 @@ import (
 type InfoQuery struct {
 	config
 	ctx        *QueryContext
-	order      []info.Order
+	order      []info.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Info
 	withUser   *UserQuery
@@ -58,7 +58,7 @@ func (iq *InfoQuery) Unique(unique bool) *InfoQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (iq *InfoQuery) Order(o ...info.Order) *InfoQuery {
+func (iq *InfoQuery) Order(o ...info.OrderOption) *InfoQuery {
 	iq.order = append(iq.order, o...)
 	return iq
 }
@@ -274,7 +274,7 @@ func (iq *InfoQuery) Clone() *InfoQuery {
 	return &InfoQuery{
 		config:     iq.config,
 		ctx:        iq.ctx.Clone(),
-		order:      append([]info.Order{}, iq.order...),
+		order:      append([]info.OrderOption{}, iq.order...),
 		inters:     append([]Interceptor{}, iq.inters...),
 		predicates: append([]predicate.Info{}, iq.predicates...),
 		withUser:   iq.withUser.Clone(),

--- a/entc/integration/edgefield/ent/metadata/metadata.go
+++ b/entc/integration/edgefield/ent/metadata/metadata.go
@@ -67,47 +67,47 @@ var (
 	DefaultAge int
 )
 
-// Order defines the ordering method for the Metadata queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Metadata queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByAge orders the results by the age field.
-func ByAge(opts ...sql.OrderTermOption) Order {
+func ByAge(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAge, opts...).ToFunc()
 }
 
 // ByParentID orders the results by the parent_id field.
-func ByParentID(opts ...sql.OrderTermOption) Order {
+func ByParentID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldParentID, opts...).ToFunc()
 }
 
 // ByUserField orders the results by user field.
-func ByUserField(field string, opts ...sql.OrderTermOption) Order {
+func ByUserField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newUserStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByChildrenCount orders the results by children count.
-func ByChildrenCount(opts ...sql.OrderTermOption) Order {
+func ByChildrenCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newChildrenStep(), opts...)
 	}
 }
 
 // ByChildren orders the results by children terms.
-func ByChildren(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByChildren(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newChildrenStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByParentField orders the results by parent field.
-func ByParentField(field string, opts ...sql.OrderTermOption) Order {
+func ByParentField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newParentStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/edgefield/ent/metadata_query.go
+++ b/entc/integration/edgefield/ent/metadata_query.go
@@ -24,7 +24,7 @@ import (
 type MetadataQuery struct {
 	config
 	ctx          *QueryContext
-	order        []metadata.Order
+	order        []metadata.OrderOption
 	inters       []Interceptor
 	predicates   []predicate.Metadata
 	withUser     *UserQuery
@@ -61,7 +61,7 @@ func (mq *MetadataQuery) Unique(unique bool) *MetadataQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (mq *MetadataQuery) Order(o ...metadata.Order) *MetadataQuery {
+func (mq *MetadataQuery) Order(o ...metadata.OrderOption) *MetadataQuery {
 	mq.order = append(mq.order, o...)
 	return mq
 }
@@ -321,7 +321,7 @@ func (mq *MetadataQuery) Clone() *MetadataQuery {
 	return &MetadataQuery{
 		config:       mq.config,
 		ctx:          mq.ctx.Clone(),
-		order:        append([]metadata.Order{}, mq.order...),
+		order:        append([]metadata.OrderOption{}, mq.order...),
 		inters:       append([]Interceptor{}, mq.inters...),
 		predicates:   append([]predicate.Metadata{}, mq.predicates...),
 		withUser:     mq.withUser.Clone(),

--- a/entc/integration/edgefield/ent/node/node.go
+++ b/entc/integration/edgefield/ent/node/node.go
@@ -58,33 +58,33 @@ var (
 	DefaultValue int
 )
 
-// Order defines the ordering method for the Node queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Node queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByValue orders the results by the value field.
-func ByValue(opts ...sql.OrderTermOption) Order {
+func ByValue(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldValue, opts...).ToFunc()
 }
 
 // ByPrevID orders the results by the prev_id field.
-func ByPrevID(opts ...sql.OrderTermOption) Order {
+func ByPrevID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldPrevID, opts...).ToFunc()
 }
 
 // ByPrevField orders the results by prev field.
-func ByPrevField(field string, opts ...sql.OrderTermOption) Order {
+func ByPrevField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newPrevStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByNextField orders the results by next field.
-func ByNextField(field string, opts ...sql.OrderTermOption) Order {
+func ByNextField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newNextStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/edgefield/ent/node_query.go
+++ b/entc/integration/edgefield/ent/node_query.go
@@ -23,7 +23,7 @@ import (
 type NodeQuery struct {
 	config
 	ctx        *QueryContext
-	order      []node.Order
+	order      []node.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Node
 	withPrev   *NodeQuery
@@ -59,7 +59,7 @@ func (nq *NodeQuery) Unique(unique bool) *NodeQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (nq *NodeQuery) Order(o ...node.Order) *NodeQuery {
+func (nq *NodeQuery) Order(o ...node.OrderOption) *NodeQuery {
 	nq.order = append(nq.order, o...)
 	return nq
 }
@@ -297,7 +297,7 @@ func (nq *NodeQuery) Clone() *NodeQuery {
 	return &NodeQuery{
 		config:     nq.config,
 		ctx:        nq.ctx.Clone(),
-		order:      append([]node.Order{}, nq.order...),
+		order:      append([]node.OrderOption{}, nq.order...),
 		inters:     append([]Interceptor{}, nq.inters...),
 		predicates: append([]predicate.Node{}, nq.predicates...),
 		withPrev:   nq.withPrev.Clone(),

--- a/entc/integration/edgefield/ent/pet/pet.go
+++ b/entc/integration/edgefield/ent/pet/pet.go
@@ -47,21 +47,21 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Pet queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Pet queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByOwnerID orders the results by the owner_id field.
-func ByOwnerID(opts ...sql.OrderTermOption) Order {
+func ByOwnerID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldOwnerID, opts...).ToFunc()
 }
 
 // ByOwnerField orders the results by owner field.
-func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+func ByOwnerField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/edgefield/ent/pet_query.go
+++ b/entc/integration/edgefield/ent/pet_query.go
@@ -23,7 +23,7 @@ import (
 type PetQuery struct {
 	config
 	ctx        *QueryContext
-	order      []pet.Order
+	order      []pet.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Pet
 	withOwner  *UserQuery
@@ -58,7 +58,7 @@ func (pq *PetQuery) Unique(unique bool) *PetQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (pq *PetQuery) Order(o ...pet.Order) *PetQuery {
+func (pq *PetQuery) Order(o ...pet.OrderOption) *PetQuery {
 	pq.order = append(pq.order, o...)
 	return pq
 }
@@ -274,7 +274,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 	return &PetQuery{
 		config:     pq.config,
 		ctx:        pq.ctx.Clone(),
-		order:      append([]pet.Order{}, pq.order...),
+		order:      append([]pet.OrderOption{}, pq.order...),
 		inters:     append([]Interceptor{}, pq.inters...),
 		predicates: append([]predicate.Pet{}, pq.predicates...),
 		withOwner:  pq.withOwner.Clone(),

--- a/entc/integration/edgefield/ent/post/post.go
+++ b/entc/integration/edgefield/ent/post/post.go
@@ -50,26 +50,26 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Post queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Post queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByText orders the results by the text field.
-func ByText(opts ...sql.OrderTermOption) Order {
+func ByText(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldText, opts...).ToFunc()
 }
 
 // ByAuthorID orders the results by the author_id field.
-func ByAuthorID(opts ...sql.OrderTermOption) Order {
+func ByAuthorID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAuthorID, opts...).ToFunc()
 }
 
 // ByAuthorField orders the results by author field.
-func ByAuthorField(field string, opts ...sql.OrderTermOption) Order {
+func ByAuthorField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newAuthorStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/edgefield/ent/post_query.go
+++ b/entc/integration/edgefield/ent/post_query.go
@@ -23,7 +23,7 @@ import (
 type PostQuery struct {
 	config
 	ctx        *QueryContext
-	order      []post.Order
+	order      []post.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Post
 	withAuthor *UserQuery
@@ -58,7 +58,7 @@ func (pq *PostQuery) Unique(unique bool) *PostQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (pq *PostQuery) Order(o ...post.Order) *PostQuery {
+func (pq *PostQuery) Order(o ...post.OrderOption) *PostQuery {
 	pq.order = append(pq.order, o...)
 	return pq
 }
@@ -274,7 +274,7 @@ func (pq *PostQuery) Clone() *PostQuery {
 	return &PostQuery{
 		config:     pq.config,
 		ctx:        pq.ctx.Clone(),
-		order:      append([]post.Order{}, pq.order...),
+		order:      append([]post.OrderOption{}, pq.order...),
 		inters:     append([]Interceptor{}, pq.inters...),
 		predicates: append([]predicate.Post{}, pq.predicates...),
 		withAuthor: pq.withAuthor.Clone(),

--- a/entc/integration/edgefield/ent/rental/rental.go
+++ b/entc/integration/edgefield/ent/rental/rental.go
@@ -69,38 +69,38 @@ var (
 	DefaultDate func() time.Time
 )
 
-// Order defines the ordering method for the Rental queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Rental queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByDate orders the results by the date field.
-func ByDate(opts ...sql.OrderTermOption) Order {
+func ByDate(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDate, opts...).ToFunc()
 }
 
 // ByUserID orders the results by the user_id field.
-func ByUserID(opts ...sql.OrderTermOption) Order {
+func ByUserID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUserID, opts...).ToFunc()
 }
 
 // ByCarID orders the results by the car_id field.
-func ByCarID(opts ...sql.OrderTermOption) Order {
+func ByCarID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCarID, opts...).ToFunc()
 }
 
 // ByUserField orders the results by user field.
-func ByUserField(field string, opts ...sql.OrderTermOption) Order {
+func ByUserField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newUserStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByCarField orders the results by car field.
-func ByCarField(field string, opts ...sql.OrderTermOption) Order {
+func ByCarField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newCarStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/edgefield/ent/rental_query.go
+++ b/entc/integration/edgefield/ent/rental_query.go
@@ -25,7 +25,7 @@ import (
 type RentalQuery struct {
 	config
 	ctx        *QueryContext
-	order      []rental.Order
+	order      []rental.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Rental
 	withUser   *UserQuery
@@ -61,7 +61,7 @@ func (rq *RentalQuery) Unique(unique bool) *RentalQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (rq *RentalQuery) Order(o ...rental.Order) *RentalQuery {
+func (rq *RentalQuery) Order(o ...rental.OrderOption) *RentalQuery {
 	rq.order = append(rq.order, o...)
 	return rq
 }
@@ -299,7 +299,7 @@ func (rq *RentalQuery) Clone() *RentalQuery {
 	return &RentalQuery{
 		config:     rq.config,
 		ctx:        rq.ctx.Clone(),
-		order:      append([]rental.Order{}, rq.order...),
+		order:      append([]rental.OrderOption{}, rq.order...),
 		inters:     append([]Interceptor{}, rq.inters...),
 		predicates: append([]predicate.Rental{}, rq.predicates...),
 		withUser:   rq.withUser.Clone(),

--- a/entc/integration/edgefield/ent/user/user.go
+++ b/entc/integration/edgefield/ent/user/user.go
@@ -104,103 +104,103 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the User queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the User queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByParentID orders the results by the parent_id field.
-func ByParentID(opts ...sql.OrderTermOption) Order {
+func ByParentID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldParentID, opts...).ToFunc()
 }
 
 // BySpouseID orders the results by the spouse_id field.
-func BySpouseID(opts ...sql.OrderTermOption) Order {
+func BySpouseID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldSpouseID, opts...).ToFunc()
 }
 
 // ByPetsCount orders the results by pets count.
-func ByPetsCount(opts ...sql.OrderTermOption) Order {
+func ByPetsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newPetsStep(), opts...)
 	}
 }
 
 // ByPets orders the results by pets terms.
-func ByPets(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByPets(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newPetsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByParentField orders the results by parent field.
-func ByParentField(field string, opts ...sql.OrderTermOption) Order {
+func ByParentField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newParentStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByChildrenCount orders the results by children count.
-func ByChildrenCount(opts ...sql.OrderTermOption) Order {
+func ByChildrenCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newChildrenStep(), opts...)
 	}
 }
 
 // ByChildren orders the results by children terms.
-func ByChildren(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByChildren(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newChildrenStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // BySpouseField orders the results by spouse field.
-func BySpouseField(field string, opts ...sql.OrderTermOption) Order {
+func BySpouseField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newSpouseStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByCardField orders the results by card field.
-func ByCardField(field string, opts ...sql.OrderTermOption) Order {
+func ByCardField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newCardStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByMetadataField orders the results by metadata field.
-func ByMetadataField(field string, opts ...sql.OrderTermOption) Order {
+func ByMetadataField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newMetadataStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByInfoCount orders the results by info count.
-func ByInfoCount(opts ...sql.OrderTermOption) Order {
+func ByInfoCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newInfoStep(), opts...)
 	}
 }
 
 // ByInfo orders the results by info terms.
-func ByInfo(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByInfo(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newInfoStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByRentalsCount orders the results by rentals count.
-func ByRentalsCount(opts ...sql.OrderTermOption) Order {
+func ByRentalsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newRentalsStep(), opts...)
 	}
 }
 
 // ByRentals orders the results by rentals terms.
-func ByRentals(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByRentals(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newRentalsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/entc/integration/edgefield/ent/user_query.go
+++ b/entc/integration/edgefield/ent/user_query.go
@@ -28,7 +28,7 @@ import (
 type UserQuery struct {
 	config
 	ctx          *QueryContext
-	order        []user.Order
+	order        []user.OrderOption
 	inters       []Interceptor
 	predicates   []predicate.User
 	withPets     *PetQuery
@@ -70,7 +70,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
+func (uq *UserQuery) Order(o ...user.OrderOption) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -440,7 +440,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:       uq.config,
 		ctx:          uq.ctx.Clone(),
-		order:        append([]user.Order{}, uq.order...),
+		order:        append([]user.OrderOption{}, uq.order...),
 		inters:       append([]Interceptor{}, uq.inters...),
 		predicates:   append([]predicate.User{}, uq.predicates...),
 		withPets:     uq.withPets.Clone(),

--- a/entc/integration/edgeschema/ent/attachedfile/attachedfile.go
+++ b/entc/integration/edgeschema/ent/attachedfile/attachedfile.go
@@ -69,38 +69,38 @@ var (
 	DefaultAttachTime func() time.Time
 )
 
-// Order defines the ordering method for the AttachedFile queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the AttachedFile queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByAttachTime orders the results by the attach_time field.
-func ByAttachTime(opts ...sql.OrderTermOption) Order {
+func ByAttachTime(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAttachTime, opts...).ToFunc()
 }
 
 // ByFID orders the results by the f_id field.
-func ByFID(opts ...sql.OrderTermOption) Order {
+func ByFID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldFID, opts...).ToFunc()
 }
 
 // ByProcID orders the results by the proc_id field.
-func ByProcID(opts ...sql.OrderTermOption) Order {
+func ByProcID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldProcID, opts...).ToFunc()
 }
 
 // ByFiField orders the results by fi field.
-func ByFiField(field string, opts ...sql.OrderTermOption) Order {
+func ByFiField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newFiStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByProcField orders the results by proc field.
-func ByProcField(field string, opts ...sql.OrderTermOption) Order {
+func ByProcField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newProcStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/edgeschema/ent/attachedfile_query.go
+++ b/entc/integration/edgeschema/ent/attachedfile_query.go
@@ -24,7 +24,7 @@ import (
 type AttachedFileQuery struct {
 	config
 	ctx        *QueryContext
-	order      []attachedfile.Order
+	order      []attachedfile.OrderOption
 	inters     []Interceptor
 	predicates []predicate.AttachedFile
 	withFi     *FileQuery
@@ -60,7 +60,7 @@ func (afq *AttachedFileQuery) Unique(unique bool) *AttachedFileQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (afq *AttachedFileQuery) Order(o ...attachedfile.Order) *AttachedFileQuery {
+func (afq *AttachedFileQuery) Order(o ...attachedfile.OrderOption) *AttachedFileQuery {
 	afq.order = append(afq.order, o...)
 	return afq
 }
@@ -298,7 +298,7 @@ func (afq *AttachedFileQuery) Clone() *AttachedFileQuery {
 	return &AttachedFileQuery{
 		config:     afq.config,
 		ctx:        afq.ctx.Clone(),
-		order:      append([]attachedfile.Order{}, afq.order...),
+		order:      append([]attachedfile.OrderOption{}, afq.order...),
 		inters:     append([]Interceptor{}, afq.inters...),
 		predicates: append([]predicate.AttachedFile{}, afq.predicates...),
 		withFi:     afq.withFi.Clone(),

--- a/entc/integration/edgeschema/ent/file/file.go
+++ b/entc/integration/edgeschema/ent/file/file.go
@@ -51,28 +51,28 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the File queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the File queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByProcessesCount orders the results by processes count.
-func ByProcessesCount(opts ...sql.OrderTermOption) Order {
+func ByProcessesCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newProcessesStep(), opts...)
 	}
 }
 
 // ByProcesses orders the results by processes terms.
-func ByProcesses(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByProcesses(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newProcessesStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/entc/integration/edgeschema/ent/file_query.go
+++ b/entc/integration/edgeschema/ent/file_query.go
@@ -24,7 +24,7 @@ import (
 type FileQuery struct {
 	config
 	ctx           *QueryContext
-	order         []file.Order
+	order         []file.OrderOption
 	inters        []Interceptor
 	predicates    []predicate.File
 	withProcesses *ProcessQuery
@@ -59,7 +59,7 @@ func (fq *FileQuery) Unique(unique bool) *FileQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (fq *FileQuery) Order(o ...file.Order) *FileQuery {
+func (fq *FileQuery) Order(o ...file.OrderOption) *FileQuery {
 	fq.order = append(fq.order, o...)
 	return fq
 }
@@ -275,7 +275,7 @@ func (fq *FileQuery) Clone() *FileQuery {
 	return &FileQuery{
 		config:        fq.config,
 		ctx:           fq.ctx.Clone(),
-		order:         append([]file.Order{}, fq.order...),
+		order:         append([]file.OrderOption{}, fq.order...),
 		inters:        append([]Interceptor{}, fq.inters...),
 		predicates:    append([]predicate.File{}, fq.predicates...),
 		withProcesses: fq.withProcesses.Clone(),

--- a/entc/integration/edgeschema/ent/friendship/friendship.go
+++ b/entc/integration/edgeschema/ent/friendship/friendship.go
@@ -74,43 +74,43 @@ var (
 	DefaultCreatedAt func() time.Time
 )
 
-// Order defines the ordering method for the Friendship queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Friendship queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByWeight orders the results by the weight field.
-func ByWeight(opts ...sql.OrderTermOption) Order {
+func ByWeight(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldWeight, opts...).ToFunc()
 }
 
 // ByCreatedAt orders the results by the created_at field.
-func ByCreatedAt(opts ...sql.OrderTermOption) Order {
+func ByCreatedAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCreatedAt, opts...).ToFunc()
 }
 
 // ByUserID orders the results by the user_id field.
-func ByUserID(opts ...sql.OrderTermOption) Order {
+func ByUserID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUserID, opts...).ToFunc()
 }
 
 // ByFriendID orders the results by the friend_id field.
-func ByFriendID(opts ...sql.OrderTermOption) Order {
+func ByFriendID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldFriendID, opts...).ToFunc()
 }
 
 // ByUserField orders the results by user field.
-func ByUserField(field string, opts ...sql.OrderTermOption) Order {
+func ByUserField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newUserStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByFriendField orders the results by friend field.
-func ByFriendField(field string, opts ...sql.OrderTermOption) Order {
+func ByFriendField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newFriendStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/edgeschema/ent/friendship_query.go
+++ b/entc/integration/edgeschema/ent/friendship_query.go
@@ -23,7 +23,7 @@ import (
 type FriendshipQuery struct {
 	config
 	ctx        *QueryContext
-	order      []friendship.Order
+	order      []friendship.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Friendship
 	withUser   *UserQuery
@@ -59,7 +59,7 @@ func (fq *FriendshipQuery) Unique(unique bool) *FriendshipQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (fq *FriendshipQuery) Order(o ...friendship.Order) *FriendshipQuery {
+func (fq *FriendshipQuery) Order(o ...friendship.OrderOption) *FriendshipQuery {
 	fq.order = append(fq.order, o...)
 	return fq
 }
@@ -297,7 +297,7 @@ func (fq *FriendshipQuery) Clone() *FriendshipQuery {
 	return &FriendshipQuery{
 		config:     fq.config,
 		ctx:        fq.ctx.Clone(),
-		order:      append([]friendship.Order{}, fq.order...),
+		order:      append([]friendship.OrderOption{}, fq.order...),
 		inters:     append([]Interceptor{}, fq.inters...),
 		predicates: append([]predicate.Friendship{}, fq.predicates...),
 		withUser:   fq.withUser.Clone(),

--- a/entc/integration/edgeschema/ent/group/group.go
+++ b/entc/integration/edgeschema/ent/group/group.go
@@ -84,70 +84,70 @@ var (
 	DefaultName string
 )
 
-// Order defines the ordering method for the Group queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Group queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByUsersCount orders the results by users count.
-func ByUsersCount(opts ...sql.OrderTermOption) Order {
+func ByUsersCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newUsersStep(), opts...)
 	}
 }
 
 // ByUsers orders the results by users terms.
-func ByUsers(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByUsers(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newUsersStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByTagsCount orders the results by tags count.
-func ByTagsCount(opts ...sql.OrderTermOption) Order {
+func ByTagsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newTagsStep(), opts...)
 	}
 }
 
 // ByTags orders the results by tags terms.
-func ByTags(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByTags(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newTagsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByJoinedUsersCount orders the results by joined_users count.
-func ByJoinedUsersCount(opts ...sql.OrderTermOption) Order {
+func ByJoinedUsersCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newJoinedUsersStep(), opts...)
 	}
 }
 
 // ByJoinedUsers orders the results by joined_users terms.
-func ByJoinedUsers(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByJoinedUsers(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newJoinedUsersStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByGroupTagsCount orders the results by group_tags count.
-func ByGroupTagsCount(opts ...sql.OrderTermOption) Order {
+func ByGroupTagsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newGroupTagsStep(), opts...)
 	}
 }
 
 // ByGroupTags orders the results by group_tags terms.
-func ByGroupTags(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByGroupTags(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newGroupTagsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/entc/integration/edgeschema/ent/group_query.go
+++ b/entc/integration/edgeschema/ent/group_query.go
@@ -27,7 +27,7 @@ import (
 type GroupQuery struct {
 	config
 	ctx             *QueryContext
-	order           []group.Order
+	order           []group.OrderOption
 	inters          []Interceptor
 	predicates      []predicate.Group
 	withUsers       *UserQuery
@@ -65,7 +65,7 @@ func (gq *GroupQuery) Unique(unique bool) *GroupQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (gq *GroupQuery) Order(o ...group.Order) *GroupQuery {
+func (gq *GroupQuery) Order(o ...group.OrderOption) *GroupQuery {
 	gq.order = append(gq.order, o...)
 	return gq
 }
@@ -347,7 +347,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 	return &GroupQuery{
 		config:          gq.config,
 		ctx:             gq.ctx.Clone(),
-		order:           append([]group.Order{}, gq.order...),
+		order:           append([]group.OrderOption{}, gq.order...),
 		inters:          append([]Interceptor{}, gq.inters...),
 		predicates:      append([]predicate.Group{}, gq.predicates...),
 		withUsers:       gq.withUsers.Clone(),

--- a/entc/integration/edgeschema/ent/grouptag/grouptag.go
+++ b/entc/integration/edgeschema/ent/grouptag/grouptag.go
@@ -59,33 +59,33 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the GroupTag queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the GroupTag queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByTagID orders the results by the tag_id field.
-func ByTagID(opts ...sql.OrderTermOption) Order {
+func ByTagID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldTagID, opts...).ToFunc()
 }
 
 // ByGroupID orders the results by the group_id field.
-func ByGroupID(opts ...sql.OrderTermOption) Order {
+func ByGroupID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldGroupID, opts...).ToFunc()
 }
 
 // ByTagField orders the results by tag field.
-func ByTagField(field string, opts ...sql.OrderTermOption) Order {
+func ByTagField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newTagStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByGroupField orders the results by group field.
-func ByGroupField(field string, opts ...sql.OrderTermOption) Order {
+func ByGroupField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newGroupStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/edgeschema/ent/grouptag_query.go
+++ b/entc/integration/edgeschema/ent/grouptag_query.go
@@ -24,7 +24,7 @@ import (
 type GroupTagQuery struct {
 	config
 	ctx        *QueryContext
-	order      []grouptag.Order
+	order      []grouptag.OrderOption
 	inters     []Interceptor
 	predicates []predicate.GroupTag
 	withTag    *TagQuery
@@ -60,7 +60,7 @@ func (gtq *GroupTagQuery) Unique(unique bool) *GroupTagQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (gtq *GroupTagQuery) Order(o ...grouptag.Order) *GroupTagQuery {
+func (gtq *GroupTagQuery) Order(o ...grouptag.OrderOption) *GroupTagQuery {
 	gtq.order = append(gtq.order, o...)
 	return gtq
 }
@@ -298,7 +298,7 @@ func (gtq *GroupTagQuery) Clone() *GroupTagQuery {
 	return &GroupTagQuery{
 		config:     gtq.config,
 		ctx:        gtq.ctx.Clone(),
-		order:      append([]grouptag.Order{}, gtq.order...),
+		order:      append([]grouptag.OrderOption{}, gtq.order...),
 		inters:     append([]Interceptor{}, gtq.inters...),
 		predicates: append([]predicate.GroupTag{}, gtq.predicates...),
 		withTag:    gtq.withTag.Clone(),

--- a/entc/integration/edgeschema/ent/process/process.go
+++ b/entc/integration/edgeschema/ent/process/process.go
@@ -57,37 +57,37 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Process queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Process queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByFilesCount orders the results by files count.
-func ByFilesCount(opts ...sql.OrderTermOption) Order {
+func ByFilesCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newFilesStep(), opts...)
 	}
 }
 
 // ByFiles orders the results by files terms.
-func ByFiles(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByFiles(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newFilesStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByAttachedFilesCount orders the results by attached_files count.
-func ByAttachedFilesCount(opts ...sql.OrderTermOption) Order {
+func ByAttachedFilesCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newAttachedFilesStep(), opts...)
 	}
 }
 
 // ByAttachedFiles orders the results by attached_files terms.
-func ByAttachedFiles(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByAttachedFiles(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newAttachedFilesStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/entc/integration/edgeschema/ent/process_query.go
+++ b/entc/integration/edgeschema/ent/process_query.go
@@ -25,7 +25,7 @@ import (
 type ProcessQuery struct {
 	config
 	ctx               *QueryContext
-	order             []process.Order
+	order             []process.OrderOption
 	inters            []Interceptor
 	predicates        []predicate.Process
 	withFiles         *FileQuery
@@ -61,7 +61,7 @@ func (pq *ProcessQuery) Unique(unique bool) *ProcessQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (pq *ProcessQuery) Order(o ...process.Order) *ProcessQuery {
+func (pq *ProcessQuery) Order(o ...process.OrderOption) *ProcessQuery {
 	pq.order = append(pq.order, o...)
 	return pq
 }
@@ -299,7 +299,7 @@ func (pq *ProcessQuery) Clone() *ProcessQuery {
 	return &ProcessQuery{
 		config:            pq.config,
 		ctx:               pq.ctx.Clone(),
-		order:             append([]process.Order{}, pq.order...),
+		order:             append([]process.OrderOption{}, pq.order...),
 		inters:            append([]Interceptor{}, pq.inters...),
 		predicates:        append([]predicate.Process{}, pq.predicates...),
 		withFiles:         pq.withFiles.Clone(),

--- a/entc/integration/edgeschema/ent/relationship/relationship.go
+++ b/entc/integration/edgeschema/ent/relationship/relationship.go
@@ -88,45 +88,45 @@ var (
 	DefaultWeight int
 )
 
-// Order defines the ordering method for the Relationship queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Relationship queries.
+type OrderOption func(*sql.Selector)
 
 // ByWeight orders the results by the weight field.
-func ByWeight(opts ...sql.OrderTermOption) Order {
+func ByWeight(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldWeight, opts...).ToFunc()
 }
 
 // ByUserID orders the results by the user_id field.
-func ByUserID(opts ...sql.OrderTermOption) Order {
+func ByUserID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUserID, opts...).ToFunc()
 }
 
 // ByRelativeID orders the results by the relative_id field.
-func ByRelativeID(opts ...sql.OrderTermOption) Order {
+func ByRelativeID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldRelativeID, opts...).ToFunc()
 }
 
 // ByInfoID orders the results by the info_id field.
-func ByInfoID(opts ...sql.OrderTermOption) Order {
+func ByInfoID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldInfoID, opts...).ToFunc()
 }
 
 // ByUserField orders the results by user field.
-func ByUserField(field string, opts ...sql.OrderTermOption) Order {
+func ByUserField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newUserStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByRelativeField orders the results by relative field.
-func ByRelativeField(field string, opts ...sql.OrderTermOption) Order {
+func ByRelativeField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newRelativeStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByInfoField orders the results by info field.
-func ByInfoField(field string, opts ...sql.OrderTermOption) Order {
+func ByInfoField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newInfoStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/edgeschema/ent/relationship_query.go
+++ b/entc/integration/edgeschema/ent/relationship_query.go
@@ -24,7 +24,7 @@ import (
 type RelationshipQuery struct {
 	config
 	ctx          *QueryContext
-	order        []relationship.Order
+	order        []relationship.OrderOption
 	inters       []Interceptor
 	predicates   []predicate.Relationship
 	withUser     *UserQuery
@@ -61,7 +61,7 @@ func (rq *RelationshipQuery) Unique(unique bool) *RelationshipQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (rq *RelationshipQuery) Order(o ...relationship.Order) *RelationshipQuery {
+func (rq *RelationshipQuery) Order(o ...relationship.OrderOption) *RelationshipQuery {
 	rq.order = append(rq.order, o...)
 	return rq
 }
@@ -249,7 +249,7 @@ func (rq *RelationshipQuery) Clone() *RelationshipQuery {
 	return &RelationshipQuery{
 		config:       rq.config,
 		ctx:          rq.ctx.Clone(),
-		order:        append([]relationship.Order{}, rq.order...),
+		order:        append([]relationship.OrderOption{}, rq.order...),
 		inters:       append([]Interceptor{}, rq.inters...),
 		predicates:   append([]predicate.Relationship{}, rq.predicates...),
 		withUser:     rq.withUser.Clone(),

--- a/entc/integration/edgeschema/ent/relationshipinfo/relationshipinfo.go
+++ b/entc/integration/edgeschema/ent/relationshipinfo/relationshipinfo.go
@@ -37,15 +37,15 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the RelationshipInfo queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the RelationshipInfo queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByText orders the results by the text field.
-func ByText(opts ...sql.OrderTermOption) Order {
+func ByText(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldText, opts...).ToFunc()
 }

--- a/entc/integration/edgeschema/ent/relationshipinfo_query.go
+++ b/entc/integration/edgeschema/ent/relationshipinfo_query.go
@@ -22,7 +22,7 @@ import (
 type RelationshipInfoQuery struct {
 	config
 	ctx        *QueryContext
-	order      []relationshipinfo.Order
+	order      []relationshipinfo.OrderOption
 	inters     []Interceptor
 	predicates []predicate.RelationshipInfo
 	// intermediate query (i.e. traversal path).
@@ -56,7 +56,7 @@ func (riq *RelationshipInfoQuery) Unique(unique bool) *RelationshipInfoQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (riq *RelationshipInfoQuery) Order(o ...relationshipinfo.Order) *RelationshipInfoQuery {
+func (riq *RelationshipInfoQuery) Order(o ...relationshipinfo.OrderOption) *RelationshipInfoQuery {
 	riq.order = append(riq.order, o...)
 	return riq
 }
@@ -250,7 +250,7 @@ func (riq *RelationshipInfoQuery) Clone() *RelationshipInfoQuery {
 	return &RelationshipInfoQuery{
 		config:     riq.config,
 		ctx:        riq.ctx.Clone(),
-		order:      append([]relationshipinfo.Order{}, riq.order...),
+		order:      append([]relationshipinfo.OrderOption{}, riq.order...),
 		inters:     append([]Interceptor{}, riq.inters...),
 		predicates: append([]predicate.RelationshipInfo{}, riq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/edgeschema/ent/role/role.go
+++ b/entc/integration/edgeschema/ent/role/role.go
@@ -70,47 +70,47 @@ var (
 	DefaultCreatedAt func() time.Time
 )
 
-// Order defines the ordering method for the Role queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Role queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByCreatedAt orders the results by the created_at field.
-func ByCreatedAt(opts ...sql.OrderTermOption) Order {
+func ByCreatedAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCreatedAt, opts...).ToFunc()
 }
 
 // ByUserCount orders the results by user count.
-func ByUserCount(opts ...sql.OrderTermOption) Order {
+func ByUserCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newUserStep(), opts...)
 	}
 }
 
 // ByUser orders the results by user terms.
-func ByUser(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByUser(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newUserStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByRolesUsersCount orders the results by roles_users count.
-func ByRolesUsersCount(opts ...sql.OrderTermOption) Order {
+func ByRolesUsersCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newRolesUsersStep(), opts...)
 	}
 }
 
 // ByRolesUsers orders the results by roles_users terms.
-func ByRolesUsers(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByRolesUsers(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newRolesUsersStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/entc/integration/edgeschema/ent/role_query.go
+++ b/entc/integration/edgeschema/ent/role_query.go
@@ -25,7 +25,7 @@ import (
 type RoleQuery struct {
 	config
 	ctx            *QueryContext
-	order          []role.Order
+	order          []role.OrderOption
 	inters         []Interceptor
 	predicates     []predicate.Role
 	withUser       *UserQuery
@@ -61,7 +61,7 @@ func (rq *RoleQuery) Unique(unique bool) *RoleQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (rq *RoleQuery) Order(o ...role.Order) *RoleQuery {
+func (rq *RoleQuery) Order(o ...role.OrderOption) *RoleQuery {
 	rq.order = append(rq.order, o...)
 	return rq
 }
@@ -299,7 +299,7 @@ func (rq *RoleQuery) Clone() *RoleQuery {
 	return &RoleQuery{
 		config:         rq.config,
 		ctx:            rq.ctx.Clone(),
-		order:          append([]role.Order{}, rq.order...),
+		order:          append([]role.OrderOption{}, rq.order...),
 		inters:         append([]Interceptor{}, rq.inters...),
 		predicates:     append([]predicate.Role{}, rq.predicates...),
 		withUser:       rq.withUser.Clone(),

--- a/entc/integration/edgeschema/ent/roleuser/roleuser.go
+++ b/entc/integration/edgeschema/ent/roleuser/roleuser.go
@@ -70,33 +70,33 @@ var (
 	DefaultCreatedAt func() time.Time
 )
 
-// Order defines the ordering method for the RoleUser queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the RoleUser queries.
+type OrderOption func(*sql.Selector)
 
 // ByCreatedAt orders the results by the created_at field.
-func ByCreatedAt(opts ...sql.OrderTermOption) Order {
+func ByCreatedAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCreatedAt, opts...).ToFunc()
 }
 
 // ByRoleID orders the results by the role_id field.
-func ByRoleID(opts ...sql.OrderTermOption) Order {
+func ByRoleID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldRoleID, opts...).ToFunc()
 }
 
 // ByUserID orders the results by the user_id field.
-func ByUserID(opts ...sql.OrderTermOption) Order {
+func ByUserID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUserID, opts...).ToFunc()
 }
 
 // ByRoleField orders the results by role field.
-func ByRoleField(field string, opts ...sql.OrderTermOption) Order {
+func ByRoleField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newRoleStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByUserField orders the results by user field.
-func ByUserField(field string, opts ...sql.OrderTermOption) Order {
+func ByUserField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newUserStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/edgeschema/ent/roleuser_query.go
+++ b/entc/integration/edgeschema/ent/roleuser_query.go
@@ -23,7 +23,7 @@ import (
 type RoleUserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []roleuser.Order
+	order      []roleuser.OrderOption
 	inters     []Interceptor
 	predicates []predicate.RoleUser
 	withRole   *RoleQuery
@@ -59,7 +59,7 @@ func (ruq *RoleUserQuery) Unique(unique bool) *RoleUserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (ruq *RoleUserQuery) Order(o ...roleuser.Order) *RoleUserQuery {
+func (ruq *RoleUserQuery) Order(o ...roleuser.OrderOption) *RoleUserQuery {
 	ruq.order = append(ruq.order, o...)
 	return ruq
 }
@@ -225,7 +225,7 @@ func (ruq *RoleUserQuery) Clone() *RoleUserQuery {
 	return &RoleUserQuery{
 		config:     ruq.config,
 		ctx:        ruq.ctx.Clone(),
-		order:      append([]roleuser.Order{}, ruq.order...),
+		order:      append([]roleuser.OrderOption{}, ruq.order...),
 		inters:     append([]Interceptor{}, ruq.inters...),
 		predicates: append([]predicate.RoleUser{}, ruq.predicates...),
 		withRole:   ruq.withRole.Clone(),

--- a/entc/integration/edgeschema/ent/tag/tag.go
+++ b/entc/integration/edgeschema/ent/tag/tag.go
@@ -79,70 +79,70 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Tag queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Tag queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByValue orders the results by the value field.
-func ByValue(opts ...sql.OrderTermOption) Order {
+func ByValue(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldValue, opts...).ToFunc()
 }
 
 // ByTweetsCount orders the results by tweets count.
-func ByTweetsCount(opts ...sql.OrderTermOption) Order {
+func ByTweetsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newTweetsStep(), opts...)
 	}
 }
 
 // ByTweets orders the results by tweets terms.
-func ByTweets(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByTweets(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newTweetsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByGroupsCount orders the results by groups count.
-func ByGroupsCount(opts ...sql.OrderTermOption) Order {
+func ByGroupsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newGroupsStep(), opts...)
 	}
 }
 
 // ByGroups orders the results by groups terms.
-func ByGroups(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByGroups(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newGroupsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByTweetTagsCount orders the results by tweet_tags count.
-func ByTweetTagsCount(opts ...sql.OrderTermOption) Order {
+func ByTweetTagsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newTweetTagsStep(), opts...)
 	}
 }
 
 // ByTweetTags orders the results by tweet_tags terms.
-func ByTweetTags(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByTweetTags(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newTweetTagsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByGroupTagsCount orders the results by group_tags count.
-func ByGroupTagsCount(opts ...sql.OrderTermOption) Order {
+func ByGroupTagsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newGroupTagsStep(), opts...)
 	}
 }
 
 // ByGroupTags orders the results by group_tags terms.
-func ByGroupTags(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByGroupTags(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newGroupTagsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/entc/integration/edgeschema/ent/tag_query.go
+++ b/entc/integration/edgeschema/ent/tag_query.go
@@ -27,7 +27,7 @@ import (
 type TagQuery struct {
 	config
 	ctx           *QueryContext
-	order         []tag.Order
+	order         []tag.OrderOption
 	inters        []Interceptor
 	predicates    []predicate.Tag
 	withTweets    *TweetQuery
@@ -65,7 +65,7 @@ func (tq *TagQuery) Unique(unique bool) *TagQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (tq *TagQuery) Order(o ...tag.Order) *TagQuery {
+func (tq *TagQuery) Order(o ...tag.OrderOption) *TagQuery {
 	tq.order = append(tq.order, o...)
 	return tq
 }
@@ -347,7 +347,7 @@ func (tq *TagQuery) Clone() *TagQuery {
 	return &TagQuery{
 		config:        tq.config,
 		ctx:           tq.ctx.Clone(),
-		order:         append([]tag.Order{}, tq.order...),
+		order:         append([]tag.OrderOption{}, tq.order...),
 		inters:        append([]Interceptor{}, tq.inters...),
 		predicates:    append([]predicate.Tag{}, tq.predicates...),
 		withTweets:    tq.withTweets.Clone(),

--- a/entc/integration/edgeschema/ent/tweet/tweet.go
+++ b/entc/integration/edgeschema/ent/tweet/tweet.go
@@ -98,98 +98,98 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Tweet queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Tweet queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByText orders the results by the text field.
-func ByText(opts ...sql.OrderTermOption) Order {
+func ByText(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldText, opts...).ToFunc()
 }
 
 // ByLikedUsersCount orders the results by liked_users count.
-func ByLikedUsersCount(opts ...sql.OrderTermOption) Order {
+func ByLikedUsersCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newLikedUsersStep(), opts...)
 	}
 }
 
 // ByLikedUsers orders the results by liked_users terms.
-func ByLikedUsers(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByLikedUsers(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newLikedUsersStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByUserCount orders the results by user count.
-func ByUserCount(opts ...sql.OrderTermOption) Order {
+func ByUserCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newUserStep(), opts...)
 	}
 }
 
 // ByUser orders the results by user terms.
-func ByUser(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByUser(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newUserStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByTagsCount orders the results by tags count.
-func ByTagsCount(opts ...sql.OrderTermOption) Order {
+func ByTagsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newTagsStep(), opts...)
 	}
 }
 
 // ByTags orders the results by tags terms.
-func ByTags(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByTags(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newTagsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByLikesCount orders the results by likes count.
-func ByLikesCount(opts ...sql.OrderTermOption) Order {
+func ByLikesCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newLikesStep(), opts...)
 	}
 }
 
 // ByLikes orders the results by likes terms.
-func ByLikes(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByLikes(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newLikesStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByTweetUserCount orders the results by tweet_user count.
-func ByTweetUserCount(opts ...sql.OrderTermOption) Order {
+func ByTweetUserCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newTweetUserStep(), opts...)
 	}
 }
 
 // ByTweetUser orders the results by tweet_user terms.
-func ByTweetUser(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByTweetUser(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newTweetUserStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByTweetTagsCount orders the results by tweet_tags count.
-func ByTweetTagsCount(opts ...sql.OrderTermOption) Order {
+func ByTweetTagsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newTweetTagsStep(), opts...)
 	}
 }
 
 // ByTweetTags orders the results by tweet_tags terms.
-func ByTweetTags(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByTweetTags(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newTweetTagsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/entc/integration/edgeschema/ent/tweet_query.go
+++ b/entc/integration/edgeschema/ent/tweet_query.go
@@ -28,7 +28,7 @@ import (
 type TweetQuery struct {
 	config
 	ctx            *QueryContext
-	order          []tweet.Order
+	order          []tweet.OrderOption
 	inters         []Interceptor
 	predicates     []predicate.Tweet
 	withLikedUsers *UserQuery
@@ -68,7 +68,7 @@ func (tq *TweetQuery) Unique(unique bool) *TweetQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (tq *TweetQuery) Order(o ...tweet.Order) *TweetQuery {
+func (tq *TweetQuery) Order(o ...tweet.OrderOption) *TweetQuery {
 	tq.order = append(tq.order, o...)
 	return tq
 }
@@ -394,7 +394,7 @@ func (tq *TweetQuery) Clone() *TweetQuery {
 	return &TweetQuery{
 		config:         tq.config,
 		ctx:            tq.ctx.Clone(),
-		order:          append([]tweet.Order{}, tq.order...),
+		order:          append([]tweet.OrderOption{}, tq.order...),
 		inters:         append([]Interceptor{}, tq.inters...),
 		predicates:     append([]predicate.Tweet{}, tq.predicates...),
 		withLikedUsers: tq.withLikedUsers.Clone(),

--- a/entc/integration/edgeschema/ent/tweetlike/tweetlike.go
+++ b/entc/integration/edgeschema/ent/tweetlike/tweetlike.go
@@ -78,33 +78,33 @@ var (
 	DefaultLikedAt func() time.Time
 )
 
-// Order defines the ordering method for the TweetLike queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the TweetLike queries.
+type OrderOption func(*sql.Selector)
 
 // ByLikedAt orders the results by the liked_at field.
-func ByLikedAt(opts ...sql.OrderTermOption) Order {
+func ByLikedAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldLikedAt, opts...).ToFunc()
 }
 
 // ByUserID orders the results by the user_id field.
-func ByUserID(opts ...sql.OrderTermOption) Order {
+func ByUserID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUserID, opts...).ToFunc()
 }
 
 // ByTweetID orders the results by the tweet_id field.
-func ByTweetID(opts ...sql.OrderTermOption) Order {
+func ByTweetID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldTweetID, opts...).ToFunc()
 }
 
 // ByTweetField orders the results by tweet field.
-func ByTweetField(field string, opts ...sql.OrderTermOption) Order {
+func ByTweetField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newTweetStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByUserField orders the results by user field.
-func ByUserField(field string, opts ...sql.OrderTermOption) Order {
+func ByUserField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newUserStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/edgeschema/ent/tweetlike_query.go
+++ b/entc/integration/edgeschema/ent/tweetlike_query.go
@@ -24,7 +24,7 @@ import (
 type TweetLikeQuery struct {
 	config
 	ctx        *QueryContext
-	order      []tweetlike.Order
+	order      []tweetlike.OrderOption
 	inters     []Interceptor
 	predicates []predicate.TweetLike
 	withTweet  *TweetQuery
@@ -60,7 +60,7 @@ func (tlq *TweetLikeQuery) Unique(unique bool) *TweetLikeQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (tlq *TweetLikeQuery) Order(o ...tweetlike.Order) *TweetLikeQuery {
+func (tlq *TweetLikeQuery) Order(o ...tweetlike.OrderOption) *TweetLikeQuery {
 	tlq.order = append(tlq.order, o...)
 	return tlq
 }
@@ -226,7 +226,7 @@ func (tlq *TweetLikeQuery) Clone() *TweetLikeQuery {
 	return &TweetLikeQuery{
 		config:     tlq.config,
 		ctx:        tlq.ctx.Clone(),
-		order:      append([]tweetlike.Order{}, tlq.order...),
+		order:      append([]tweetlike.OrderOption{}, tlq.order...),
 		inters:     append([]Interceptor{}, tlq.inters...),
 		predicates: append([]predicate.TweetLike{}, tlq.predicates...),
 		withTweet:  tlq.withTweet.Clone(),

--- a/entc/integration/edgeschema/ent/tweettag/tweettag.go
+++ b/entc/integration/edgeschema/ent/tweettag/tweettag.go
@@ -72,38 +72,38 @@ var (
 	DefaultID func() uuid.UUID
 )
 
-// Order defines the ordering method for the TweetTag queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the TweetTag queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByAddedAt orders the results by the added_at field.
-func ByAddedAt(opts ...sql.OrderTermOption) Order {
+func ByAddedAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAddedAt, opts...).ToFunc()
 }
 
 // ByTagID orders the results by the tag_id field.
-func ByTagID(opts ...sql.OrderTermOption) Order {
+func ByTagID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldTagID, opts...).ToFunc()
 }
 
 // ByTweetID orders the results by the tweet_id field.
-func ByTweetID(opts ...sql.OrderTermOption) Order {
+func ByTweetID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldTweetID, opts...).ToFunc()
 }
 
 // ByTagField orders the results by tag field.
-func ByTagField(field string, opts ...sql.OrderTermOption) Order {
+func ByTagField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newTagStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByTweetField orders the results by tweet field.
-func ByTweetField(field string, opts ...sql.OrderTermOption) Order {
+func ByTweetField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newTweetStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/edgeschema/ent/tweettag_query.go
+++ b/entc/integration/edgeschema/ent/tweettag_query.go
@@ -25,7 +25,7 @@ import (
 type TweetTagQuery struct {
 	config
 	ctx        *QueryContext
-	order      []tweettag.Order
+	order      []tweettag.OrderOption
 	inters     []Interceptor
 	predicates []predicate.TweetTag
 	withTag    *TagQuery
@@ -61,7 +61,7 @@ func (ttq *TweetTagQuery) Unique(unique bool) *TweetTagQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (ttq *TweetTagQuery) Order(o ...tweettag.Order) *TweetTagQuery {
+func (ttq *TweetTagQuery) Order(o ...tweettag.OrderOption) *TweetTagQuery {
 	ttq.order = append(ttq.order, o...)
 	return ttq
 }
@@ -299,7 +299,7 @@ func (ttq *TweetTagQuery) Clone() *TweetTagQuery {
 	return &TweetTagQuery{
 		config:     ttq.config,
 		ctx:        ttq.ctx.Clone(),
-		order:      append([]tweettag.Order{}, ttq.order...),
+		order:      append([]tweettag.OrderOption{}, ttq.order...),
 		inters:     append([]Interceptor{}, ttq.inters...),
 		predicates: append([]predicate.TweetTag{}, ttq.predicates...),
 		withTag:    ttq.withTag.Clone(),

--- a/entc/integration/edgeschema/ent/user/user.go
+++ b/entc/integration/edgeschema/ent/user/user.go
@@ -162,182 +162,182 @@ var (
 	DefaultName string
 )
 
-// Order defines the ordering method for the User queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the User queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByGroupsCount orders the results by groups count.
-func ByGroupsCount(opts ...sql.OrderTermOption) Order {
+func ByGroupsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newGroupsStep(), opts...)
 	}
 }
 
 // ByGroups orders the results by groups terms.
-func ByGroups(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByGroups(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newGroupsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByFriendsCount orders the results by friends count.
-func ByFriendsCount(opts ...sql.OrderTermOption) Order {
+func ByFriendsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newFriendsStep(), opts...)
 	}
 }
 
 // ByFriends orders the results by friends terms.
-func ByFriends(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByFriends(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newFriendsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByRelativesCount orders the results by relatives count.
-func ByRelativesCount(opts ...sql.OrderTermOption) Order {
+func ByRelativesCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newRelativesStep(), opts...)
 	}
 }
 
 // ByRelatives orders the results by relatives terms.
-func ByRelatives(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByRelatives(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newRelativesStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByLikedTweetsCount orders the results by liked_tweets count.
-func ByLikedTweetsCount(opts ...sql.OrderTermOption) Order {
+func ByLikedTweetsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newLikedTweetsStep(), opts...)
 	}
 }
 
 // ByLikedTweets orders the results by liked_tweets terms.
-func ByLikedTweets(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByLikedTweets(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newLikedTweetsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByTweetsCount orders the results by tweets count.
-func ByTweetsCount(opts ...sql.OrderTermOption) Order {
+func ByTweetsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newTweetsStep(), opts...)
 	}
 }
 
 // ByTweets orders the results by tweets terms.
-func ByTweets(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByTweets(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newTweetsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByRolesCount orders the results by roles count.
-func ByRolesCount(opts ...sql.OrderTermOption) Order {
+func ByRolesCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newRolesStep(), opts...)
 	}
 }
 
 // ByRoles orders the results by roles terms.
-func ByRoles(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByRoles(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newRolesStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByJoinedGroupsCount orders the results by joined_groups count.
-func ByJoinedGroupsCount(opts ...sql.OrderTermOption) Order {
+func ByJoinedGroupsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newJoinedGroupsStep(), opts...)
 	}
 }
 
 // ByJoinedGroups orders the results by joined_groups terms.
-func ByJoinedGroups(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByJoinedGroups(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newJoinedGroupsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByFriendshipsCount orders the results by friendships count.
-func ByFriendshipsCount(opts ...sql.OrderTermOption) Order {
+func ByFriendshipsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newFriendshipsStep(), opts...)
 	}
 }
 
 // ByFriendships orders the results by friendships terms.
-func ByFriendships(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByFriendships(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newFriendshipsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByRelationshipCount orders the results by relationship count.
-func ByRelationshipCount(opts ...sql.OrderTermOption) Order {
+func ByRelationshipCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newRelationshipStep(), opts...)
 	}
 }
 
 // ByRelationship orders the results by relationship terms.
-func ByRelationship(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByRelationship(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newRelationshipStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByLikesCount orders the results by likes count.
-func ByLikesCount(opts ...sql.OrderTermOption) Order {
+func ByLikesCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newLikesStep(), opts...)
 	}
 }
 
 // ByLikes orders the results by likes terms.
-func ByLikes(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByLikes(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newLikesStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByUserTweetsCount orders the results by user_tweets count.
-func ByUserTweetsCount(opts ...sql.OrderTermOption) Order {
+func ByUserTweetsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newUserTweetsStep(), opts...)
 	}
 }
 
 // ByUserTweets orders the results by user_tweets terms.
-func ByUserTweets(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByUserTweets(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newUserTweetsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByRolesUsersCount orders the results by roles_users count.
-func ByRolesUsersCount(opts ...sql.OrderTermOption) Order {
+func ByRolesUsersCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newRolesUsersStep(), opts...)
 	}
 }
 
 // ByRolesUsers orders the results by roles_users terms.
-func ByRolesUsers(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByRolesUsers(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newRolesUsersStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/entc/integration/edgeschema/ent/user_query.go
+++ b/entc/integration/edgeschema/ent/user_query.go
@@ -33,7 +33,7 @@ import (
 type UserQuery struct {
 	config
 	ctx              *QueryContext
-	order            []user.Order
+	order            []user.OrderOption
 	inters           []Interceptor
 	predicates       []predicate.User
 	withGroups       *GroupQuery
@@ -79,7 +79,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
+func (uq *UserQuery) Order(o ...user.OrderOption) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -537,7 +537,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:           uq.config,
 		ctx:              uq.ctx.Clone(),
-		order:            append([]user.Order{}, uq.order...),
+		order:            append([]user.OrderOption{}, uq.order...),
 		inters:           append([]Interceptor{}, uq.inters...),
 		predicates:       append([]predicate.User{}, uq.predicates...),
 		withGroups:       uq.withGroups.Clone(),

--- a/entc/integration/edgeschema/ent/usergroup/usergroup.go
+++ b/entc/integration/edgeschema/ent/usergroup/usergroup.go
@@ -69,38 +69,38 @@ var (
 	DefaultJoinedAt func() time.Time
 )
 
-// Order defines the ordering method for the UserGroup queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the UserGroup queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByJoinedAt orders the results by the joined_at field.
-func ByJoinedAt(opts ...sql.OrderTermOption) Order {
+func ByJoinedAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldJoinedAt, opts...).ToFunc()
 }
 
 // ByUserID orders the results by the user_id field.
-func ByUserID(opts ...sql.OrderTermOption) Order {
+func ByUserID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUserID, opts...).ToFunc()
 }
 
 // ByGroupID orders the results by the group_id field.
-func ByGroupID(opts ...sql.OrderTermOption) Order {
+func ByGroupID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldGroupID, opts...).ToFunc()
 }
 
 // ByUserField orders the results by user field.
-func ByUserField(field string, opts ...sql.OrderTermOption) Order {
+func ByUserField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newUserStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByGroupField orders the results by group field.
-func ByGroupField(field string, opts ...sql.OrderTermOption) Order {
+func ByGroupField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newGroupStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/edgeschema/ent/usergroup_query.go
+++ b/entc/integration/edgeschema/ent/usergroup_query.go
@@ -24,7 +24,7 @@ import (
 type UserGroupQuery struct {
 	config
 	ctx        *QueryContext
-	order      []usergroup.Order
+	order      []usergroup.OrderOption
 	inters     []Interceptor
 	predicates []predicate.UserGroup
 	withUser   *UserQuery
@@ -60,7 +60,7 @@ func (ugq *UserGroupQuery) Unique(unique bool) *UserGroupQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (ugq *UserGroupQuery) Order(o ...usergroup.Order) *UserGroupQuery {
+func (ugq *UserGroupQuery) Order(o ...usergroup.OrderOption) *UserGroupQuery {
 	ugq.order = append(ugq.order, o...)
 	return ugq
 }
@@ -298,7 +298,7 @@ func (ugq *UserGroupQuery) Clone() *UserGroupQuery {
 	return &UserGroupQuery{
 		config:     ugq.config,
 		ctx:        ugq.ctx.Clone(),
-		order:      append([]usergroup.Order{}, ugq.order...),
+		order:      append([]usergroup.OrderOption{}, ugq.order...),
 		inters:     append([]Interceptor{}, ugq.inters...),
 		predicates: append([]predicate.UserGroup{}, ugq.predicates...),
 		withUser:   ugq.withUser.Clone(),

--- a/entc/integration/edgeschema/ent/usertweet/usertweet.go
+++ b/entc/integration/edgeschema/ent/usertweet/usertweet.go
@@ -69,38 +69,38 @@ var (
 	DefaultCreatedAt func() time.Time
 )
 
-// Order defines the ordering method for the UserTweet queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the UserTweet queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByCreatedAt orders the results by the created_at field.
-func ByCreatedAt(opts ...sql.OrderTermOption) Order {
+func ByCreatedAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCreatedAt, opts...).ToFunc()
 }
 
 // ByUserID orders the results by the user_id field.
-func ByUserID(opts ...sql.OrderTermOption) Order {
+func ByUserID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUserID, opts...).ToFunc()
 }
 
 // ByTweetID orders the results by the tweet_id field.
-func ByTweetID(opts ...sql.OrderTermOption) Order {
+func ByTweetID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldTweetID, opts...).ToFunc()
 }
 
 // ByUserField orders the results by user field.
-func ByUserField(field string, opts ...sql.OrderTermOption) Order {
+func ByUserField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newUserStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByTweetField orders the results by tweet field.
-func ByTweetField(field string, opts ...sql.OrderTermOption) Order {
+func ByTweetField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newTweetStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/edgeschema/ent/usertweet_query.go
+++ b/entc/integration/edgeschema/ent/usertweet_query.go
@@ -24,7 +24,7 @@ import (
 type UserTweetQuery struct {
 	config
 	ctx        *QueryContext
-	order      []usertweet.Order
+	order      []usertweet.OrderOption
 	inters     []Interceptor
 	predicates []predicate.UserTweet
 	withUser   *UserQuery
@@ -60,7 +60,7 @@ func (utq *UserTweetQuery) Unique(unique bool) *UserTweetQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (utq *UserTweetQuery) Order(o ...usertweet.Order) *UserTweetQuery {
+func (utq *UserTweetQuery) Order(o ...usertweet.OrderOption) *UserTweetQuery {
 	utq.order = append(utq.order, o...)
 	return utq
 }
@@ -298,7 +298,7 @@ func (utq *UserTweetQuery) Clone() *UserTweetQuery {
 	return &UserTweetQuery{
 		config:     utq.config,
 		ctx:        utq.ctx.Clone(),
-		order:      append([]usertweet.Order{}, utq.order...),
+		order:      append([]usertweet.OrderOption{}, utq.order...),
 		inters:     append([]Interceptor{}, utq.inters...),
 		predicates: append([]predicate.UserTweet{}, utq.predicates...),
 		withUser:   utq.withUser.Clone(),

--- a/entc/integration/ent/api/api.go
+++ b/entc/integration/ent/api/api.go
@@ -34,11 +34,11 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Api queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Api queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 

--- a/entc/integration/ent/api_query.go
+++ b/entc/integration/ent/api_query.go
@@ -23,7 +23,7 @@ import (
 type APIQuery struct {
 	config
 	ctx        *QueryContext
-	order      []api.Order
+	order      []api.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Api
 	modifiers  []func(*sql.Selector)
@@ -58,7 +58,7 @@ func (aq *APIQuery) Unique(unique bool) *APIQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (aq *APIQuery) Order(o ...api.Order) *APIQuery {
+func (aq *APIQuery) Order(o ...api.OrderOption) *APIQuery {
 	aq.order = append(aq.order, o...)
 	return aq
 }
@@ -252,7 +252,7 @@ func (aq *APIQuery) Clone() *APIQuery {
 	return &APIQuery{
 		config:     aq.config,
 		ctx:        aq.ctx.Clone(),
-		order:      append([]api.Order{}, aq.order...),
+		order:      append([]api.OrderOption{}, aq.order...),
 		inters:     append([]Interceptor{}, aq.inters...),
 		predicates: append([]predicate.Api{}, aq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/ent/card/card.go
+++ b/entc/integration/ent/card/card.go
@@ -100,55 +100,55 @@ var (
 	NameValidator func(string) error
 )
 
-// Order defines the ordering method for the Card queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Card queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByCreateTime orders the results by the create_time field.
-func ByCreateTime(opts ...sql.OrderTermOption) Order {
+func ByCreateTime(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCreateTime, opts...).ToFunc()
 }
 
 // ByUpdateTime orders the results by the update_time field.
-func ByUpdateTime(opts ...sql.OrderTermOption) Order {
+func ByUpdateTime(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUpdateTime, opts...).ToFunc()
 }
 
 // ByBalance orders the results by the balance field.
-func ByBalance(opts ...sql.OrderTermOption) Order {
+func ByBalance(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldBalance, opts...).ToFunc()
 }
 
 // ByNumber orders the results by the number field.
-func ByNumber(opts ...sql.OrderTermOption) Order {
+func ByNumber(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldNumber, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByOwnerField orders the results by owner field.
-func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+func ByOwnerField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // BySpecCount orders the results by spec count.
-func BySpecCount(opts ...sql.OrderTermOption) Order {
+func BySpecCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newSpecStep(), opts...)
 	}
 }
 
 // BySpec orders the results by spec terms.
-func BySpec(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func BySpec(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newSpecStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/entc/integration/ent/card_query.go
+++ b/entc/integration/ent/card_query.go
@@ -26,7 +26,7 @@ import (
 type CardQuery struct {
 	config
 	ctx           *QueryContext
-	order         []card.Order
+	order         []card.OrderOption
 	inters        []Interceptor
 	predicates    []predicate.Card
 	withOwner     *UserQuery
@@ -65,7 +65,7 @@ func (cq *CardQuery) Unique(unique bool) *CardQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *CardQuery) Order(o ...card.Order) *CardQuery {
+func (cq *CardQuery) Order(o ...card.OrderOption) *CardQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -303,7 +303,7 @@ func (cq *CardQuery) Clone() *CardQuery {
 	return &CardQuery{
 		config:     cq.config,
 		ctx:        cq.ctx.Clone(),
-		order:      append([]card.Order{}, cq.order...),
+		order:      append([]card.OrderOption{}, cq.order...),
 		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Card{}, cq.predicates...),
 		withOwner:  cq.withOwner.Clone(),

--- a/entc/integration/ent/comment/comment.go
+++ b/entc/integration/ent/comment/comment.go
@@ -52,36 +52,36 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Comment queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Comment queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByUniqueInt orders the results by the unique_int field.
-func ByUniqueInt(opts ...sql.OrderTermOption) Order {
+func ByUniqueInt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUniqueInt, opts...).ToFunc()
 }
 
 // ByUniqueFloat orders the results by the unique_float field.
-func ByUniqueFloat(opts ...sql.OrderTermOption) Order {
+func ByUniqueFloat(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUniqueFloat, opts...).ToFunc()
 }
 
 // ByNillableInt orders the results by the nillable_int field.
-func ByNillableInt(opts ...sql.OrderTermOption) Order {
+func ByNillableInt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldNillableInt, opts...).ToFunc()
 }
 
 // ByTable orders the results by the table field.
-func ByTable(opts ...sql.OrderTermOption) Order {
+func ByTable(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldTable, opts...).ToFunc()
 }
 
 // ByClient orders the results by the client field.
-func ByClient(opts ...sql.OrderTermOption) Order {
+func ByClient(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldClient, opts...).ToFunc()
 }
 

--- a/entc/integration/ent/comment_query.go
+++ b/entc/integration/ent/comment_query.go
@@ -23,7 +23,7 @@ import (
 type CommentQuery struct {
 	config
 	ctx        *QueryContext
-	order      []comment.Order
+	order      []comment.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Comment
 	modifiers  []func(*sql.Selector)
@@ -58,7 +58,7 @@ func (cq *CommentQuery) Unique(unique bool) *CommentQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *CommentQuery) Order(o ...comment.Order) *CommentQuery {
+func (cq *CommentQuery) Order(o ...comment.OrderOption) *CommentQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -252,7 +252,7 @@ func (cq *CommentQuery) Clone() *CommentQuery {
 	return &CommentQuery{
 		config:     cq.config,
 		ctx:        cq.ctx.Clone(),
-		order:      append([]comment.Order{}, cq.order...),
+		order:      append([]comment.OrderOption{}, cq.order...),
 		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Comment{}, cq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/ent/entql.go
+++ b/entc/integration/ent/entql.go
@@ -347,11 +347,13 @@ var schemaGraph = func() *sqlgraph.Schema {
 		},
 		Type: "Task",
 		Fields: map[string]*sqlgraph.FieldSpec{
-			enttask.FieldPriority:   {Type: field.TypeInt, Column: enttask.FieldPriority},
-			enttask.FieldPriorities: {Type: field.TypeJSON, Column: enttask.FieldPriorities},
-			enttask.FieldCreatedAt:  {Type: field.TypeTime, Column: enttask.FieldCreatedAt},
-			enttask.FieldName:       {Type: field.TypeString, Column: enttask.FieldName},
-			enttask.FieldOwner:      {Type: field.TypeString, Column: enttask.FieldOwner},
+			enttask.FieldPriority:    {Type: field.TypeInt, Column: enttask.FieldPriority},
+			enttask.FieldPriorities:  {Type: field.TypeJSON, Column: enttask.FieldPriorities},
+			enttask.FieldCreatedAt:   {Type: field.TypeTime, Column: enttask.FieldCreatedAt},
+			enttask.FieldName:        {Type: field.TypeString, Column: enttask.FieldName},
+			enttask.FieldOwner:       {Type: field.TypeString, Column: enttask.FieldOwner},
+			enttask.FieldOrder:       {Type: field.TypeInt, Column: enttask.FieldOrder},
+			enttask.FieldOrderOption: {Type: field.TypeInt, Column: enttask.FieldOrderOption},
 		},
 	}
 	graph.Nodes[16] = &sqlgraph.Node{
@@ -2143,6 +2145,16 @@ func (f *TaskFilter) WhereName(p entql.StringP) {
 // WhereOwner applies the entql string predicate on the owner field.
 func (f *TaskFilter) WhereOwner(p entql.StringP) {
 	f.Where(p.Field(enttask.FieldOwner))
+}
+
+// WhereOrder applies the entql int predicate on the order field.
+func (f *TaskFilter) WhereOrder(p entql.IntP) {
+	f.Where(p.Field(enttask.FieldOrder))
+}
+
+// WhereOrderOption applies the entql int predicate on the order_option field.
+func (f *TaskFilter) WhereOrderOption(p entql.IntP) {
+	f.Where(p.Field(enttask.FieldOrderOption))
 }
 
 // addPredicate implements the predicateAdder interface.

--- a/entc/integration/ent/exvaluescan/exvaluescan.go
+++ b/entc/integration/ent/exvaluescan/exvaluescan.go
@@ -72,46 +72,46 @@ var (
 	}
 )
 
-// Order defines the ordering method for the ExValueScan queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the ExValueScan queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByBinary orders the results by the binary field.
-func ByBinary(opts ...sql.OrderTermOption) Order {
+func ByBinary(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldBinary, opts...).ToFunc()
 }
 
 // ByBinaryOptional orders the results by the binary_optional field.
-func ByBinaryOptional(opts ...sql.OrderTermOption) Order {
+func ByBinaryOptional(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldBinaryOptional, opts...).ToFunc()
 }
 
 // ByText orders the results by the text field.
-func ByText(opts ...sql.OrderTermOption) Order {
+func ByText(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldText, opts...).ToFunc()
 }
 
 // ByTextOptional orders the results by the text_optional field.
-func ByTextOptional(opts ...sql.OrderTermOption) Order {
+func ByTextOptional(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldTextOptional, opts...).ToFunc()
 }
 
 // ByBase64 orders the results by the base64 field.
-func ByBase64(opts ...sql.OrderTermOption) Order {
+func ByBase64(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldBase64, opts...).ToFunc()
 }
 
 // ByCustom orders the results by the custom field.
-func ByCustom(opts ...sql.OrderTermOption) Order {
+func ByCustom(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCustom, opts...).ToFunc()
 }
 
 // ByCustomOptional orders the results by the custom_optional field.
-func ByCustomOptional(opts ...sql.OrderTermOption) Order {
+func ByCustomOptional(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCustomOptional, opts...).ToFunc()
 }
 

--- a/entc/integration/ent/exvaluescan_query.go
+++ b/entc/integration/ent/exvaluescan_query.go
@@ -23,7 +23,7 @@ import (
 type ExValueScanQuery struct {
 	config
 	ctx        *QueryContext
-	order      []exvaluescan.Order
+	order      []exvaluescan.OrderOption
 	inters     []Interceptor
 	predicates []predicate.ExValueScan
 	modifiers  []func(*sql.Selector)
@@ -58,7 +58,7 @@ func (evsq *ExValueScanQuery) Unique(unique bool) *ExValueScanQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (evsq *ExValueScanQuery) Order(o ...exvaluescan.Order) *ExValueScanQuery {
+func (evsq *ExValueScanQuery) Order(o ...exvaluescan.OrderOption) *ExValueScanQuery {
 	evsq.order = append(evsq.order, o...)
 	return evsq
 }
@@ -252,7 +252,7 @@ func (evsq *ExValueScanQuery) Clone() *ExValueScanQuery {
 	return &ExValueScanQuery{
 		config:     evsq.config,
 		ctx:        evsq.ctx.Clone(),
-		order:      append([]exvaluescan.Order{}, evsq.order...),
+		order:      append([]exvaluescan.OrderOption{}, evsq.order...),
 		inters:     append([]Interceptor{}, evsq.inters...),
 		predicates: append([]predicate.ExValueScan{}, evsq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/ent/fieldtype/fieldtype.go
+++ b/entc/integration/ent/fieldtype/fieldtype.go
@@ -333,306 +333,306 @@ func PriorityValidator(pr role.Priority) error {
 	}
 }
 
-// Order defines the ordering method for the FieldType queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the FieldType queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByInt orders the results by the int field.
-func ByInt(opts ...sql.OrderTermOption) Order {
+func ByInt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldInt, opts...).ToFunc()
 }
 
 // ByInt8 orders the results by the int8 field.
-func ByInt8(opts ...sql.OrderTermOption) Order {
+func ByInt8(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldInt8, opts...).ToFunc()
 }
 
 // ByInt16 orders the results by the int16 field.
-func ByInt16(opts ...sql.OrderTermOption) Order {
+func ByInt16(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldInt16, opts...).ToFunc()
 }
 
 // ByInt32 orders the results by the int32 field.
-func ByInt32(opts ...sql.OrderTermOption) Order {
+func ByInt32(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldInt32, opts...).ToFunc()
 }
 
 // ByInt64 orders the results by the int64 field.
-func ByInt64(opts ...sql.OrderTermOption) Order {
+func ByInt64(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldInt64, opts...).ToFunc()
 }
 
 // ByOptionalInt orders the results by the optional_int field.
-func ByOptionalInt(opts ...sql.OrderTermOption) Order {
+func ByOptionalInt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldOptionalInt, opts...).ToFunc()
 }
 
 // ByOptionalInt8 orders the results by the optional_int8 field.
-func ByOptionalInt8(opts ...sql.OrderTermOption) Order {
+func ByOptionalInt8(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldOptionalInt8, opts...).ToFunc()
 }
 
 // ByOptionalInt16 orders the results by the optional_int16 field.
-func ByOptionalInt16(opts ...sql.OrderTermOption) Order {
+func ByOptionalInt16(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldOptionalInt16, opts...).ToFunc()
 }
 
 // ByOptionalInt32 orders the results by the optional_int32 field.
-func ByOptionalInt32(opts ...sql.OrderTermOption) Order {
+func ByOptionalInt32(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldOptionalInt32, opts...).ToFunc()
 }
 
 // ByOptionalInt64 orders the results by the optional_int64 field.
-func ByOptionalInt64(opts ...sql.OrderTermOption) Order {
+func ByOptionalInt64(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldOptionalInt64, opts...).ToFunc()
 }
 
 // ByNillableInt orders the results by the nillable_int field.
-func ByNillableInt(opts ...sql.OrderTermOption) Order {
+func ByNillableInt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldNillableInt, opts...).ToFunc()
 }
 
 // ByNillableInt8 orders the results by the nillable_int8 field.
-func ByNillableInt8(opts ...sql.OrderTermOption) Order {
+func ByNillableInt8(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldNillableInt8, opts...).ToFunc()
 }
 
 // ByNillableInt16 orders the results by the nillable_int16 field.
-func ByNillableInt16(opts ...sql.OrderTermOption) Order {
+func ByNillableInt16(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldNillableInt16, opts...).ToFunc()
 }
 
 // ByNillableInt32 orders the results by the nillable_int32 field.
-func ByNillableInt32(opts ...sql.OrderTermOption) Order {
+func ByNillableInt32(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldNillableInt32, opts...).ToFunc()
 }
 
 // ByNillableInt64 orders the results by the nillable_int64 field.
-func ByNillableInt64(opts ...sql.OrderTermOption) Order {
+func ByNillableInt64(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldNillableInt64, opts...).ToFunc()
 }
 
 // ByValidateOptionalInt32 orders the results by the validate_optional_int32 field.
-func ByValidateOptionalInt32(opts ...sql.OrderTermOption) Order {
+func ByValidateOptionalInt32(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldValidateOptionalInt32, opts...).ToFunc()
 }
 
 // ByOptionalUint orders the results by the optional_uint field.
-func ByOptionalUint(opts ...sql.OrderTermOption) Order {
+func ByOptionalUint(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldOptionalUint, opts...).ToFunc()
 }
 
 // ByOptionalUint8 orders the results by the optional_uint8 field.
-func ByOptionalUint8(opts ...sql.OrderTermOption) Order {
+func ByOptionalUint8(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldOptionalUint8, opts...).ToFunc()
 }
 
 // ByOptionalUint16 orders the results by the optional_uint16 field.
-func ByOptionalUint16(opts ...sql.OrderTermOption) Order {
+func ByOptionalUint16(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldOptionalUint16, opts...).ToFunc()
 }
 
 // ByOptionalUint32 orders the results by the optional_uint32 field.
-func ByOptionalUint32(opts ...sql.OrderTermOption) Order {
+func ByOptionalUint32(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldOptionalUint32, opts...).ToFunc()
 }
 
 // ByOptionalUint64 orders the results by the optional_uint64 field.
-func ByOptionalUint64(opts ...sql.OrderTermOption) Order {
+func ByOptionalUint64(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldOptionalUint64, opts...).ToFunc()
 }
 
 // ByState orders the results by the state field.
-func ByState(opts ...sql.OrderTermOption) Order {
+func ByState(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldState, opts...).ToFunc()
 }
 
 // ByOptionalFloat orders the results by the optional_float field.
-func ByOptionalFloat(opts ...sql.OrderTermOption) Order {
+func ByOptionalFloat(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldOptionalFloat, opts...).ToFunc()
 }
 
 // ByOptionalFloat32 orders the results by the optional_float32 field.
-func ByOptionalFloat32(opts ...sql.OrderTermOption) Order {
+func ByOptionalFloat32(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldOptionalFloat32, opts...).ToFunc()
 }
 
 // ByText orders the results by the text field.
-func ByText(opts ...sql.OrderTermOption) Order {
+func ByText(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldText, opts...).ToFunc()
 }
 
 // ByDatetime orders the results by the datetime field.
-func ByDatetime(opts ...sql.OrderTermOption) Order {
+func ByDatetime(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDatetime, opts...).ToFunc()
 }
 
 // ByDecimal orders the results by the decimal field.
-func ByDecimal(opts ...sql.OrderTermOption) Order {
+func ByDecimal(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDecimal, opts...).ToFunc()
 }
 
 // ByLinkOther orders the results by the link_other field.
-func ByLinkOther(opts ...sql.OrderTermOption) Order {
+func ByLinkOther(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldLinkOther, opts...).ToFunc()
 }
 
 // ByLinkOtherFunc orders the results by the link_other_func field.
-func ByLinkOtherFunc(opts ...sql.OrderTermOption) Order {
+func ByLinkOtherFunc(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldLinkOtherFunc, opts...).ToFunc()
 }
 
 // ByMAC orders the results by the mac field.
-func ByMAC(opts ...sql.OrderTermOption) Order {
+func ByMAC(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldMAC, opts...).ToFunc()
 }
 
 // ByStringArray orders the results by the string_array field.
-func ByStringArray(opts ...sql.OrderTermOption) Order {
+func ByStringArray(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldStringArray, opts...).ToFunc()
 }
 
 // ByPassword orders the results by the password field.
-func ByPassword(opts ...sql.OrderTermOption) Order {
+func ByPassword(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldPassword, opts...).ToFunc()
 }
 
 // ByStringScanner orders the results by the string_scanner field.
-func ByStringScanner(opts ...sql.OrderTermOption) Order {
+func ByStringScanner(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldStringScanner, opts...).ToFunc()
 }
 
 // ByDuration orders the results by the duration field.
-func ByDuration(opts ...sql.OrderTermOption) Order {
+func ByDuration(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDuration, opts...).ToFunc()
 }
 
 // ByDir orders the results by the dir field.
-func ByDir(opts ...sql.OrderTermOption) Order {
+func ByDir(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDir, opts...).ToFunc()
 }
 
 // ByNdir orders the results by the ndir field.
-func ByNdir(opts ...sql.OrderTermOption) Order {
+func ByNdir(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldNdir, opts...).ToFunc()
 }
 
 // ByStr orders the results by the str field.
-func ByStr(opts ...sql.OrderTermOption) Order {
+func ByStr(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldStr, opts...).ToFunc()
 }
 
 // ByNullStr orders the results by the null_str field.
-func ByNullStr(opts ...sql.OrderTermOption) Order {
+func ByNullStr(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldNullStr, opts...).ToFunc()
 }
 
 // ByLink orders the results by the link field.
-func ByLink(opts ...sql.OrderTermOption) Order {
+func ByLink(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldLink, opts...).ToFunc()
 }
 
 // ByNullLink orders the results by the null_link field.
-func ByNullLink(opts ...sql.OrderTermOption) Order {
+func ByNullLink(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldNullLink, opts...).ToFunc()
 }
 
 // ByActive orders the results by the active field.
-func ByActive(opts ...sql.OrderTermOption) Order {
+func ByActive(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldActive, opts...).ToFunc()
 }
 
 // ByNullActive orders the results by the null_active field.
-func ByNullActive(opts ...sql.OrderTermOption) Order {
+func ByNullActive(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldNullActive, opts...).ToFunc()
 }
 
 // ByDeleted orders the results by the deleted field.
-func ByDeleted(opts ...sql.OrderTermOption) Order {
+func ByDeleted(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDeleted, opts...).ToFunc()
 }
 
 // ByDeletedAt orders the results by the deleted_at field.
-func ByDeletedAt(opts ...sql.OrderTermOption) Order {
+func ByDeletedAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDeletedAt, opts...).ToFunc()
 }
 
 // ByNullInt64 orders the results by the null_int64 field.
-func ByNullInt64(opts ...sql.OrderTermOption) Order {
+func ByNullInt64(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldNullInt64, opts...).ToFunc()
 }
 
 // BySchemaInt orders the results by the schema_int field.
-func BySchemaInt(opts ...sql.OrderTermOption) Order {
+func BySchemaInt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldSchemaInt, opts...).ToFunc()
 }
 
 // BySchemaInt8 orders the results by the schema_int8 field.
-func BySchemaInt8(opts ...sql.OrderTermOption) Order {
+func BySchemaInt8(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldSchemaInt8, opts...).ToFunc()
 }
 
 // BySchemaInt64 orders the results by the schema_int64 field.
-func BySchemaInt64(opts ...sql.OrderTermOption) Order {
+func BySchemaInt64(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldSchemaInt64, opts...).ToFunc()
 }
 
 // BySchemaFloat orders the results by the schema_float field.
-func BySchemaFloat(opts ...sql.OrderTermOption) Order {
+func BySchemaFloat(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldSchemaFloat, opts...).ToFunc()
 }
 
 // BySchemaFloat32 orders the results by the schema_float32 field.
-func BySchemaFloat32(opts ...sql.OrderTermOption) Order {
+func BySchemaFloat32(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldSchemaFloat32, opts...).ToFunc()
 }
 
 // ByNullFloat orders the results by the null_float field.
-func ByNullFloat(opts ...sql.OrderTermOption) Order {
+func ByNullFloat(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldNullFloat, opts...).ToFunc()
 }
 
 // ByRole orders the results by the role field.
-func ByRole(opts ...sql.OrderTermOption) Order {
+func ByRole(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldRole, opts...).ToFunc()
 }
 
 // ByPriority orders the results by the priority field.
-func ByPriority(opts ...sql.OrderTermOption) Order {
+func ByPriority(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldPriority, opts...).ToFunc()
 }
 
 // ByOptionalUUID orders the results by the optional_uuid field.
-func ByOptionalUUID(opts ...sql.OrderTermOption) Order {
+func ByOptionalUUID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldOptionalUUID, opts...).ToFunc()
 }
 
 // ByNillableUUID orders the results by the nillable_uuid field.
-func ByNillableUUID(opts ...sql.OrderTermOption) Order {
+func ByNillableUUID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldNillableUUID, opts...).ToFunc()
 }
 
 // ByVstring orders the results by the vstring field.
-func ByVstring(opts ...sql.OrderTermOption) Order {
+func ByVstring(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldVstring, opts...).ToFunc()
 }
 
 // ByTriple orders the results by the triple field.
-func ByTriple(opts ...sql.OrderTermOption) Order {
+func ByTriple(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldTriple, opts...).ToFunc()
 }
 
 // ByBigInt orders the results by the big_int field.
-func ByBigInt(opts ...sql.OrderTermOption) Order {
+func ByBigInt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldBigInt, opts...).ToFunc()
 }
 
 // ByPasswordOther orders the results by the password_other field.
-func ByPasswordOther(opts ...sql.OrderTermOption) Order {
+func ByPasswordOther(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldPasswordOther, opts...).ToFunc()
 }
 

--- a/entc/integration/ent/fieldtype_query.go
+++ b/entc/integration/ent/fieldtype_query.go
@@ -23,7 +23,7 @@ import (
 type FieldTypeQuery struct {
 	config
 	ctx        *QueryContext
-	order      []fieldtype.Order
+	order      []fieldtype.OrderOption
 	inters     []Interceptor
 	predicates []predicate.FieldType
 	withFKs    bool
@@ -59,7 +59,7 @@ func (ftq *FieldTypeQuery) Unique(unique bool) *FieldTypeQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (ftq *FieldTypeQuery) Order(o ...fieldtype.Order) *FieldTypeQuery {
+func (ftq *FieldTypeQuery) Order(o ...fieldtype.OrderOption) *FieldTypeQuery {
 	ftq.order = append(ftq.order, o...)
 	return ftq
 }
@@ -253,7 +253,7 @@ func (ftq *FieldTypeQuery) Clone() *FieldTypeQuery {
 	return &FieldTypeQuery{
 		config:     ftq.config,
 		ctx:        ftq.ctx.Clone(),
-		order:      append([]fieldtype.Order{}, ftq.order...),
+		order:      append([]fieldtype.OrderOption{}, ftq.order...),
 		inters:     append([]Interceptor{}, ftq.inters...),
 		predicates: append([]predicate.FieldType{}, ftq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/ent/file/file.go
+++ b/entc/integration/ent/file/file.go
@@ -100,67 +100,67 @@ var (
 	SizeValidator func(int) error
 )
 
-// Order defines the ordering method for the File queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the File queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // BySize orders the results by the size field.
-func BySize(opts ...sql.OrderTermOption) Order {
+func BySize(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldSize, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByUser orders the results by the user field.
-func ByUser(opts ...sql.OrderTermOption) Order {
+func ByUser(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUser, opts...).ToFunc()
 }
 
 // ByGroup orders the results by the group field.
-func ByGroup(opts ...sql.OrderTermOption) Order {
+func ByGroup(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldGroup, opts...).ToFunc()
 }
 
 // ByOp orders the results by the op field.
-func ByOp(opts ...sql.OrderTermOption) Order {
+func ByOp(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldOp, opts...).ToFunc()
 }
 
 // ByFieldID orders the results by the field_id field.
-func ByFieldID(opts ...sql.OrderTermOption) Order {
+func ByFieldID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldFieldID, opts...).ToFunc()
 }
 
 // ByOwnerField orders the results by owner field.
-func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+func ByOwnerField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByTypeField orders the results by type field.
-func ByTypeField(field string, opts ...sql.OrderTermOption) Order {
+func ByTypeField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newTypeStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByFieldCount orders the results by field count.
-func ByFieldCount(opts ...sql.OrderTermOption) Order {
+func ByFieldCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newFieldStep(), opts...)
 	}
 }
 
 // ByField orders the results by field terms.
-func ByField(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByField(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newFieldStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/entc/integration/ent/file_query.go
+++ b/entc/integration/ent/file_query.go
@@ -27,7 +27,7 @@ import (
 type FileQuery struct {
 	config
 	ctx            *QueryContext
-	order          []file.Order
+	order          []file.OrderOption
 	inters         []Interceptor
 	predicates     []predicate.File
 	withOwner      *UserQuery
@@ -67,7 +67,7 @@ func (fq *FileQuery) Unique(unique bool) *FileQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (fq *FileQuery) Order(o ...file.Order) *FileQuery {
+func (fq *FileQuery) Order(o ...file.OrderOption) *FileQuery {
 	fq.order = append(fq.order, o...)
 	return fq
 }
@@ -327,7 +327,7 @@ func (fq *FileQuery) Clone() *FileQuery {
 	return &FileQuery{
 		config:     fq.config,
 		ctx:        fq.ctx.Clone(),
-		order:      append([]file.Order{}, fq.order...),
+		order:      append([]file.OrderOption{}, fq.order...),
 		inters:     append([]Interceptor{}, fq.inters...),
 		predicates: append([]predicate.File{}, fq.predicates...),
 		withOwner:  fq.withOwner.Clone(),

--- a/entc/integration/ent/filetype/filetype.go
+++ b/entc/integration/ent/filetype/filetype.go
@@ -108,38 +108,38 @@ func StateValidator(s State) error {
 	}
 }
 
-// Order defines the ordering method for the FileType queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the FileType queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByType orders the results by the type field.
-func ByType(opts ...sql.OrderTermOption) Order {
+func ByType(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldType, opts...).ToFunc()
 }
 
 // ByState orders the results by the state field.
-func ByState(opts ...sql.OrderTermOption) Order {
+func ByState(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldState, opts...).ToFunc()
 }
 
 // ByFilesCount orders the results by files count.
-func ByFilesCount(opts ...sql.OrderTermOption) Order {
+func ByFilesCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newFilesStep(), opts...)
 	}
 }
 
 // ByFiles orders the results by files terms.
-func ByFiles(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByFiles(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newFilesStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/entc/integration/ent/filetype_query.go
+++ b/entc/integration/ent/filetype_query.go
@@ -25,7 +25,7 @@ import (
 type FileTypeQuery struct {
 	config
 	ctx            *QueryContext
-	order          []filetype.Order
+	order          []filetype.OrderOption
 	inters         []Interceptor
 	predicates     []predicate.FileType
 	withFiles      *FileQuery
@@ -62,7 +62,7 @@ func (ftq *FileTypeQuery) Unique(unique bool) *FileTypeQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (ftq *FileTypeQuery) Order(o ...filetype.Order) *FileTypeQuery {
+func (ftq *FileTypeQuery) Order(o ...filetype.OrderOption) *FileTypeQuery {
 	ftq.order = append(ftq.order, o...)
 	return ftq
 }
@@ -278,7 +278,7 @@ func (ftq *FileTypeQuery) Clone() *FileTypeQuery {
 	return &FileTypeQuery{
 		config:     ftq.config,
 		ctx:        ftq.ctx.Clone(),
-		order:      append([]filetype.Order{}, ftq.order...),
+		order:      append([]filetype.OrderOption{}, ftq.order...),
 		inters:     append([]Interceptor{}, ftq.inters...),
 		predicates: append([]predicate.FileType{}, ftq.predicates...),
 		withFiles:  ftq.withFiles.Clone(),

--- a/entc/integration/ent/goods/goods.go
+++ b/entc/integration/ent/goods/goods.go
@@ -34,11 +34,11 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Goods queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Goods queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 

--- a/entc/integration/ent/goods_query.go
+++ b/entc/integration/ent/goods_query.go
@@ -23,7 +23,7 @@ import (
 type GoodsQuery struct {
 	config
 	ctx        *QueryContext
-	order      []goods.Order
+	order      []goods.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Goods
 	modifiers  []func(*sql.Selector)
@@ -58,7 +58,7 @@ func (gq *GoodsQuery) Unique(unique bool) *GoodsQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (gq *GoodsQuery) Order(o ...goods.Order) *GoodsQuery {
+func (gq *GoodsQuery) Order(o ...goods.OrderOption) *GoodsQuery {
 	gq.order = append(gq.order, o...)
 	return gq
 }
@@ -252,7 +252,7 @@ func (gq *GoodsQuery) Clone() *GoodsQuery {
 	return &GoodsQuery{
 		config:     gq.config,
 		ctx:        gq.ctx.Clone(),
-		order:      append([]goods.Order{}, gq.order...),
+		order:      append([]goods.OrderOption{}, gq.order...),
 		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Goods{}, gq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/ent/group/group.go
+++ b/entc/integration/ent/group/group.go
@@ -114,83 +114,83 @@ var (
 	NameValidator func(string) error
 )
 
-// Order defines the ordering method for the Group queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Group queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByActive orders the results by the active field.
-func ByActive(opts ...sql.OrderTermOption) Order {
+func ByActive(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldActive, opts...).ToFunc()
 }
 
 // ByExpire orders the results by the expire field.
-func ByExpire(opts ...sql.OrderTermOption) Order {
+func ByExpire(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldExpire, opts...).ToFunc()
 }
 
 // ByType orders the results by the type field.
-func ByType(opts ...sql.OrderTermOption) Order {
+func ByType(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldType, opts...).ToFunc()
 }
 
 // ByMaxUsers orders the results by the max_users field.
-func ByMaxUsers(opts ...sql.OrderTermOption) Order {
+func ByMaxUsers(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldMaxUsers, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByFilesCount orders the results by files count.
-func ByFilesCount(opts ...sql.OrderTermOption) Order {
+func ByFilesCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newFilesStep(), opts...)
 	}
 }
 
 // ByFiles orders the results by files terms.
-func ByFiles(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByFiles(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newFilesStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByBlockedCount orders the results by blocked count.
-func ByBlockedCount(opts ...sql.OrderTermOption) Order {
+func ByBlockedCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newBlockedStep(), opts...)
 	}
 }
 
 // ByBlocked orders the results by blocked terms.
-func ByBlocked(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByBlocked(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newBlockedStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByUsersCount orders the results by users count.
-func ByUsersCount(opts ...sql.OrderTermOption) Order {
+func ByUsersCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newUsersStep(), opts...)
 	}
 }
 
 // ByUsers orders the results by users terms.
-func ByUsers(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByUsers(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newUsersStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByInfoField orders the results by info field.
-func ByInfoField(field string, opts ...sql.OrderTermOption) Order {
+func ByInfoField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newInfoStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/ent/group_query.go
+++ b/entc/integration/ent/group_query.go
@@ -27,7 +27,7 @@ import (
 type GroupQuery struct {
 	config
 	ctx              *QueryContext
-	order            []group.Order
+	order            []group.OrderOption
 	inters           []Interceptor
 	predicates       []predicate.Group
 	withFiles        *FileQuery
@@ -70,7 +70,7 @@ func (gq *GroupQuery) Unique(unique bool) *GroupQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (gq *GroupQuery) Order(o ...group.Order) *GroupQuery {
+func (gq *GroupQuery) Order(o ...group.OrderOption) *GroupQuery {
 	gq.order = append(gq.order, o...)
 	return gq
 }
@@ -352,7 +352,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 	return &GroupQuery{
 		config:      gq.config,
 		ctx:         gq.ctx.Clone(),
-		order:       append([]group.Order{}, gq.order...),
+		order:       append([]group.OrderOption{}, gq.order...),
 		inters:      append([]Interceptor{}, gq.inters...),
 		predicates:  append([]predicate.Group{}, gq.predicates...),
 		withFiles:   gq.withFiles.Clone(),

--- a/entc/integration/ent/groupinfo/groupinfo.go
+++ b/entc/integration/ent/groupinfo/groupinfo.go
@@ -55,33 +55,33 @@ var (
 	DefaultMaxUsers int
 )
 
-// Order defines the ordering method for the GroupInfo queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the GroupInfo queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByDesc orders the results by the desc field.
-func ByDesc(opts ...sql.OrderTermOption) Order {
+func ByDesc(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDesc, opts...).ToFunc()
 }
 
 // ByMaxUsers orders the results by the max_users field.
-func ByMaxUsers(opts ...sql.OrderTermOption) Order {
+func ByMaxUsers(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldMaxUsers, opts...).ToFunc()
 }
 
 // ByGroupsCount orders the results by groups count.
-func ByGroupsCount(opts ...sql.OrderTermOption) Order {
+func ByGroupsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newGroupsStep(), opts...)
 	}
 }
 
 // ByGroups orders the results by groups terms.
-func ByGroups(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByGroups(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newGroupsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/entc/integration/ent/groupinfo_query.go
+++ b/entc/integration/ent/groupinfo_query.go
@@ -25,7 +25,7 @@ import (
 type GroupInfoQuery struct {
 	config
 	ctx             *QueryContext
-	order           []groupinfo.Order
+	order           []groupinfo.OrderOption
 	inters          []Interceptor
 	predicates      []predicate.GroupInfo
 	withGroups      *GroupQuery
@@ -62,7 +62,7 @@ func (giq *GroupInfoQuery) Unique(unique bool) *GroupInfoQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (giq *GroupInfoQuery) Order(o ...groupinfo.Order) *GroupInfoQuery {
+func (giq *GroupInfoQuery) Order(o ...groupinfo.OrderOption) *GroupInfoQuery {
 	giq.order = append(giq.order, o...)
 	return giq
 }
@@ -278,7 +278,7 @@ func (giq *GroupInfoQuery) Clone() *GroupInfoQuery {
 	return &GroupInfoQuery{
 		config:     giq.config,
 		ctx:        giq.ctx.Clone(),
-		order:      append([]groupinfo.Order{}, giq.order...),
+		order:      append([]groupinfo.OrderOption{}, giq.order...),
 		inters:     append([]Interceptor{}, giq.inters...),
 		predicates: append([]predicate.GroupInfo{}, giq.predicates...),
 		withGroups: giq.withGroups.Clone(),

--- a/entc/integration/ent/item/item.go
+++ b/entc/integration/ent/item/item.go
@@ -46,16 +46,16 @@ var (
 	IDValidator func(string) error
 )
 
-// Order defines the ordering method for the Item queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Item queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByText orders the results by the text field.
-func ByText(opts ...sql.OrderTermOption) Order {
+func ByText(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldText, opts...).ToFunc()
 }
 

--- a/entc/integration/ent/item_query.go
+++ b/entc/integration/ent/item_query.go
@@ -23,7 +23,7 @@ import (
 type ItemQuery struct {
 	config
 	ctx        *QueryContext
-	order      []item.Order
+	order      []item.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Item
 	modifiers  []func(*sql.Selector)
@@ -58,7 +58,7 @@ func (iq *ItemQuery) Unique(unique bool) *ItemQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (iq *ItemQuery) Order(o ...item.Order) *ItemQuery {
+func (iq *ItemQuery) Order(o ...item.OrderOption) *ItemQuery {
 	iq.order = append(iq.order, o...)
 	return iq
 }
@@ -252,7 +252,7 @@ func (iq *ItemQuery) Clone() *ItemQuery {
 	return &ItemQuery{
 		config:     iq.config,
 		ctx:        iq.ctx.Clone(),
-		order:      append([]item.Order{}, iq.order...),
+		order:      append([]item.OrderOption{}, iq.order...),
 		inters:     append([]Interceptor{}, iq.inters...),
 		predicates: append([]predicate.Item{}, iq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/ent/license/license.go
+++ b/entc/integration/ent/license/license.go
@@ -51,21 +51,21 @@ var (
 	UpdateDefaultUpdateTime func() time.Time
 )
 
-// Order defines the ordering method for the License queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the License queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByCreateTime orders the results by the create_time field.
-func ByCreateTime(opts ...sql.OrderTermOption) Order {
+func ByCreateTime(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCreateTime, opts...).ToFunc()
 }
 
 // ByUpdateTime orders the results by the update_time field.
-func ByUpdateTime(opts ...sql.OrderTermOption) Order {
+func ByUpdateTime(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUpdateTime, opts...).ToFunc()
 }
 

--- a/entc/integration/ent/license_query.go
+++ b/entc/integration/ent/license_query.go
@@ -23,7 +23,7 @@ import (
 type LicenseQuery struct {
 	config
 	ctx        *QueryContext
-	order      []license.Order
+	order      []license.OrderOption
 	inters     []Interceptor
 	predicates []predicate.License
 	modifiers  []func(*sql.Selector)
@@ -58,7 +58,7 @@ func (lq *LicenseQuery) Unique(unique bool) *LicenseQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (lq *LicenseQuery) Order(o ...license.Order) *LicenseQuery {
+func (lq *LicenseQuery) Order(o ...license.OrderOption) *LicenseQuery {
 	lq.order = append(lq.order, o...)
 	return lq
 }
@@ -252,7 +252,7 @@ func (lq *LicenseQuery) Clone() *LicenseQuery {
 	return &LicenseQuery{
 		config:     lq.config,
 		ctx:        lq.ctx.Clone(),
-		order:      append([]license.Order{}, lq.order...),
+		order:      append([]license.OrderOption{}, lq.order...),
 		inters:     append([]Interceptor{}, lq.inters...),
 		predicates: append([]predicate.License{}, lq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/ent/migrate/schema.go
+++ b/entc/integration/ent/migrate/schema.go
@@ -411,6 +411,8 @@ var (
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "name", Type: field.TypeString, Nullable: true},
 		{Name: "owner", Type: field.TypeString, Nullable: true},
+		{Name: "order", Type: field.TypeInt, Nullable: true},
+		{Name: "order_option", Type: field.TypeInt, Nullable: true},
 	}
 	// TasksTable holds the schema information for the "tasks" table.
 	TasksTable = &schema.Table{

--- a/entc/integration/ent/mutation.go
+++ b/entc/integration/ent/mutation.go
@@ -14096,19 +14096,23 @@ func (m *SpecMutation) ResetEdge(name string) error {
 // TaskMutation represents an operation that mutates the Task nodes in the graph.
 type TaskMutation struct {
 	config
-	op            Op
-	typ           string
-	id            *int
-	priority      *task.Priority
-	addpriority   *task.Priority
-	priorities    *map[string]task.Priority
-	created_at    *time.Time
-	name          *string
-	owner         *string
-	clearedFields map[string]struct{}
-	done          bool
-	oldValue      func(context.Context) (*Task, error)
-	predicates    []predicate.Task
+	op              Op
+	typ             string
+	id              *int
+	priority        *task.Priority
+	addpriority     *task.Priority
+	priorities      *map[string]task.Priority
+	created_at      *time.Time
+	name            *string
+	owner           *string
+	_order          *int
+	add_order       *int
+	order_option    *int
+	addorder_option *int
+	clearedFields   map[string]struct{}
+	done            bool
+	oldValue        func(context.Context) (*Task, error)
+	predicates      []predicate.Task
 }
 
 var _ ent.Mutation = (*TaskMutation)(nil)
@@ -14448,6 +14452,146 @@ func (m *TaskMutation) ResetOwner() {
 	delete(m.clearedFields, enttask.FieldOwner)
 }
 
+// SetOrder sets the "order" field.
+func (m *TaskMutation) SetOrder(i int) {
+	m._order = &i
+	m.add_order = nil
+}
+
+// Order returns the value of the "order" field in the mutation.
+func (m *TaskMutation) Order() (r int, exists bool) {
+	v := m._order
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldOrder returns the old "order" field's value of the Task entity.
+// If the Task object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *TaskMutation) OldOrder(ctx context.Context) (v int, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldOrder is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldOrder requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldOrder: %w", err)
+	}
+	return oldValue.Order, nil
+}
+
+// AddOrder adds i to the "order" field.
+func (m *TaskMutation) AddOrder(i int) {
+	if m.add_order != nil {
+		*m.add_order += i
+	} else {
+		m.add_order = &i
+	}
+}
+
+// AddedOrder returns the value that was added to the "order" field in this mutation.
+func (m *TaskMutation) AddedOrder() (r int, exists bool) {
+	v := m.add_order
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ClearOrder clears the value of the "order" field.
+func (m *TaskMutation) ClearOrder() {
+	m._order = nil
+	m.add_order = nil
+	m.clearedFields[enttask.FieldOrder] = struct{}{}
+}
+
+// OrderCleared returns if the "order" field was cleared in this mutation.
+func (m *TaskMutation) OrderCleared() bool {
+	_, ok := m.clearedFields[enttask.FieldOrder]
+	return ok
+}
+
+// ResetOrder resets all changes to the "order" field.
+func (m *TaskMutation) ResetOrder() {
+	m._order = nil
+	m.add_order = nil
+	delete(m.clearedFields, enttask.FieldOrder)
+}
+
+// SetOrderOption sets the "order_option" field.
+func (m *TaskMutation) SetOrderOption(i int) {
+	m.order_option = &i
+	m.addorder_option = nil
+}
+
+// OrderOption returns the value of the "order_option" field in the mutation.
+func (m *TaskMutation) OrderOption() (r int, exists bool) {
+	v := m.order_option
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldOrderOption returns the old "order_option" field's value of the Task entity.
+// If the Task object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *TaskMutation) OldOrderOption(ctx context.Context) (v int, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldOrderOption is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldOrderOption requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldOrderOption: %w", err)
+	}
+	return oldValue.OrderOption, nil
+}
+
+// AddOrderOption adds i to the "order_option" field.
+func (m *TaskMutation) AddOrderOption(i int) {
+	if m.addorder_option != nil {
+		*m.addorder_option += i
+	} else {
+		m.addorder_option = &i
+	}
+}
+
+// AddedOrderOption returns the value that was added to the "order_option" field in this mutation.
+func (m *TaskMutation) AddedOrderOption() (r int, exists bool) {
+	v := m.addorder_option
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ClearOrderOption clears the value of the "order_option" field.
+func (m *TaskMutation) ClearOrderOption() {
+	m.order_option = nil
+	m.addorder_option = nil
+	m.clearedFields[enttask.FieldOrderOption] = struct{}{}
+}
+
+// OrderOptionCleared returns if the "order_option" field was cleared in this mutation.
+func (m *TaskMutation) OrderOptionCleared() bool {
+	_, ok := m.clearedFields[enttask.FieldOrderOption]
+	return ok
+}
+
+// ResetOrderOption resets all changes to the "order_option" field.
+func (m *TaskMutation) ResetOrderOption() {
+	m.order_option = nil
+	m.addorder_option = nil
+	delete(m.clearedFields, enttask.FieldOrderOption)
+}
+
 // Where appends a list predicates to the TaskMutation builder.
 func (m *TaskMutation) Where(ps ...predicate.Task) {
 	m.predicates = append(m.predicates, ps...)
@@ -14482,7 +14626,7 @@ func (m *TaskMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *TaskMutation) Fields() []string {
-	fields := make([]string, 0, 5)
+	fields := make([]string, 0, 7)
 	if m.priority != nil {
 		fields = append(fields, enttask.FieldPriority)
 	}
@@ -14497,6 +14641,12 @@ func (m *TaskMutation) Fields() []string {
 	}
 	if m.owner != nil {
 		fields = append(fields, enttask.FieldOwner)
+	}
+	if m._order != nil {
+		fields = append(fields, enttask.FieldOrder)
+	}
+	if m.order_option != nil {
+		fields = append(fields, enttask.FieldOrderOption)
 	}
 	return fields
 }
@@ -14516,6 +14666,10 @@ func (m *TaskMutation) Field(name string) (ent.Value, bool) {
 		return m.Name()
 	case enttask.FieldOwner:
 		return m.Owner()
+	case enttask.FieldOrder:
+		return m.Order()
+	case enttask.FieldOrderOption:
+		return m.OrderOption()
 	}
 	return nil, false
 }
@@ -14535,6 +14689,10 @@ func (m *TaskMutation) OldField(ctx context.Context, name string) (ent.Value, er
 		return m.OldName(ctx)
 	case enttask.FieldOwner:
 		return m.OldOwner(ctx)
+	case enttask.FieldOrder:
+		return m.OldOrder(ctx)
+	case enttask.FieldOrderOption:
+		return m.OldOrderOption(ctx)
 	}
 	return nil, fmt.Errorf("unknown Task field %s", name)
 }
@@ -14579,6 +14737,20 @@ func (m *TaskMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetOwner(v)
 		return nil
+	case enttask.FieldOrder:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetOrder(v)
+		return nil
+	case enttask.FieldOrderOption:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetOrderOption(v)
+		return nil
 	}
 	return fmt.Errorf("unknown Task field %s", name)
 }
@@ -14590,6 +14762,12 @@ func (m *TaskMutation) AddedFields() []string {
 	if m.addpriority != nil {
 		fields = append(fields, enttask.FieldPriority)
 	}
+	if m.add_order != nil {
+		fields = append(fields, enttask.FieldOrder)
+	}
+	if m.addorder_option != nil {
+		fields = append(fields, enttask.FieldOrderOption)
+	}
 	return fields
 }
 
@@ -14600,6 +14778,10 @@ func (m *TaskMutation) AddedField(name string) (ent.Value, bool) {
 	switch name {
 	case enttask.FieldPriority:
 		return m.AddedPriority()
+	case enttask.FieldOrder:
+		return m.AddedOrder()
+	case enttask.FieldOrderOption:
+		return m.AddedOrderOption()
 	}
 	return nil, false
 }
@@ -14615,6 +14797,20 @@ func (m *TaskMutation) AddField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.AddPriority(v)
+		return nil
+	case enttask.FieldOrder:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddOrder(v)
+		return nil
+	case enttask.FieldOrderOption:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddOrderOption(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Task numeric field %s", name)
@@ -14632,6 +14828,12 @@ func (m *TaskMutation) ClearedFields() []string {
 	}
 	if m.FieldCleared(enttask.FieldOwner) {
 		fields = append(fields, enttask.FieldOwner)
+	}
+	if m.FieldCleared(enttask.FieldOrder) {
+		fields = append(fields, enttask.FieldOrder)
+	}
+	if m.FieldCleared(enttask.FieldOrderOption) {
+		fields = append(fields, enttask.FieldOrderOption)
 	}
 	return fields
 }
@@ -14656,6 +14858,12 @@ func (m *TaskMutation) ClearField(name string) error {
 	case enttask.FieldOwner:
 		m.ClearOwner()
 		return nil
+	case enttask.FieldOrder:
+		m.ClearOrder()
+		return nil
+	case enttask.FieldOrderOption:
+		m.ClearOrderOption()
+		return nil
 	}
 	return fmt.Errorf("unknown Task nullable field %s", name)
 }
@@ -14678,6 +14886,12 @@ func (m *TaskMutation) ResetField(name string) error {
 		return nil
 	case enttask.FieldOwner:
 		m.ResetOwner()
+		return nil
+	case enttask.FieldOrder:
+		m.ResetOrder()
+		return nil
+	case enttask.FieldOrderOption:
+		m.ResetOrderOption()
 		return nil
 	}
 	return fmt.Errorf("unknown Task field %s", name)

--- a/entc/integration/ent/node/node.go
+++ b/entc/integration/ent/node/node.go
@@ -71,33 +71,33 @@ var (
 	UpdateDefaultUpdatedAt func() time.Time
 )
 
-// Order defines the ordering method for the Node queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Node queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByValue orders the results by the value field.
-func ByValue(opts ...sql.OrderTermOption) Order {
+func ByValue(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldValue, opts...).ToFunc()
 }
 
 // ByUpdatedAt orders the results by the updated_at field.
-func ByUpdatedAt(opts ...sql.OrderTermOption) Order {
+func ByUpdatedAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUpdatedAt, opts...).ToFunc()
 }
 
 // ByPrevField orders the results by prev field.
-func ByPrevField(field string, opts ...sql.OrderTermOption) Order {
+func ByPrevField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newPrevStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByNextField orders the results by next field.
-func ByNextField(field string, opts ...sql.OrderTermOption) Order {
+func ByNextField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newNextStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/ent/node_query.go
+++ b/entc/integration/ent/node_query.go
@@ -24,7 +24,7 @@ import (
 type NodeQuery struct {
 	config
 	ctx        *QueryContext
-	order      []node.Order
+	order      []node.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Node
 	withPrev   *NodeQuery
@@ -62,7 +62,7 @@ func (nq *NodeQuery) Unique(unique bool) *NodeQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (nq *NodeQuery) Order(o ...node.Order) *NodeQuery {
+func (nq *NodeQuery) Order(o ...node.OrderOption) *NodeQuery {
 	nq.order = append(nq.order, o...)
 	return nq
 }
@@ -300,7 +300,7 @@ func (nq *NodeQuery) Clone() *NodeQuery {
 	return &NodeQuery{
 		config:     nq.config,
 		ctx:        nq.ctx.Clone(),
-		order:      append([]node.Order{}, nq.order...),
+		order:      append([]node.OrderOption{}, nq.order...),
 		inters:     append([]Interceptor{}, nq.inters...),
 		predicates: append([]predicate.Node{}, nq.predicates...),
 		withPrev:   nq.withPrev.Clone(),

--- a/entc/integration/ent/pet/pet.go
+++ b/entc/integration/ent/pet/pet.go
@@ -87,48 +87,48 @@ var (
 	DefaultTrained bool
 )
 
-// Order defines the ordering method for the Pet queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Pet queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByAge orders the results by the age field.
-func ByAge(opts ...sql.OrderTermOption) Order {
+func ByAge(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAge, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByUUID orders the results by the uuid field.
-func ByUUID(opts ...sql.OrderTermOption) Order {
+func ByUUID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUUID, opts...).ToFunc()
 }
 
 // ByNickname orders the results by the nickname field.
-func ByNickname(opts ...sql.OrderTermOption) Order {
+func ByNickname(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldNickname, opts...).ToFunc()
 }
 
 // ByTrained orders the results by the trained field.
-func ByTrained(opts ...sql.OrderTermOption) Order {
+func ByTrained(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldTrained, opts...).ToFunc()
 }
 
 // ByTeamField orders the results by team field.
-func ByTeamField(field string, opts ...sql.OrderTermOption) Order {
+func ByTeamField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newTeamStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByOwnerField orders the results by owner field.
-func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+func ByOwnerField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/ent/pet_query.go
+++ b/entc/integration/ent/pet_query.go
@@ -24,7 +24,7 @@ import (
 type PetQuery struct {
 	config
 	ctx        *QueryContext
-	order      []pet.Order
+	order      []pet.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Pet
 	withTeam   *UserQuery
@@ -62,7 +62,7 @@ func (pq *PetQuery) Unique(unique bool) *PetQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (pq *PetQuery) Order(o ...pet.Order) *PetQuery {
+func (pq *PetQuery) Order(o ...pet.OrderOption) *PetQuery {
 	pq.order = append(pq.order, o...)
 	return pq
 }
@@ -300,7 +300,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 	return &PetQuery{
 		config:     pq.config,
 		ctx:        pq.ctx.Clone(),
-		order:      append([]pet.Order{}, pq.order...),
+		order:      append([]pet.OrderOption{}, pq.order...),
 		inters:     append([]Interceptor{}, pq.inters...),
 		predicates: append([]predicate.Pet{}, pq.predicates...),
 		withTeam:   pq.withTeam.Clone(),

--- a/entc/integration/ent/schema/task.go
+++ b/entc/integration/ent/schema/task.go
@@ -35,6 +35,10 @@ func (Task) Fields() []ent.Field {
 			Optional(),
 		field.String("owner").
 			Optional(),
+		field.Int("order").
+			Optional(),
+		field.Int("order_option").
+			Optional(),
 	}
 }
 

--- a/entc/integration/ent/spec/spec.go
+++ b/entc/integration/ent/spec/spec.go
@@ -48,23 +48,23 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Spec queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Spec queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByCardCount orders the results by card count.
-func ByCardCount(opts ...sql.OrderTermOption) Order {
+func ByCardCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newCardStep(), opts...)
 	}
 }
 
 // ByCard orders the results by card terms.
-func ByCard(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByCard(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newCardStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/entc/integration/ent/spec_query.go
+++ b/entc/integration/ent/spec_query.go
@@ -25,7 +25,7 @@ import (
 type SpecQuery struct {
 	config
 	ctx           *QueryContext
-	order         []spec.Order
+	order         []spec.OrderOption
 	inters        []Interceptor
 	predicates    []predicate.Spec
 	withCard      *CardQuery
@@ -62,7 +62,7 @@ func (sq *SpecQuery) Unique(unique bool) *SpecQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (sq *SpecQuery) Order(o ...spec.Order) *SpecQuery {
+func (sq *SpecQuery) Order(o ...spec.OrderOption) *SpecQuery {
 	sq.order = append(sq.order, o...)
 	return sq
 }
@@ -278,7 +278,7 @@ func (sq *SpecQuery) Clone() *SpecQuery {
 	return &SpecQuery{
 		config:     sq.config,
 		ctx:        sq.ctx.Clone(),
-		order:      append([]spec.Order{}, sq.order...),
+		order:      append([]spec.OrderOption{}, sq.order...),
 		inters:     append([]Interceptor{}, sq.inters...),
 		predicates: append([]predicate.Spec{}, sq.predicates...),
 		withCard:   sq.withCard.Clone(),

--- a/entc/integration/ent/task.go
+++ b/entc/integration/ent/task.go
@@ -32,7 +32,11 @@ type Task struct {
 	// Name holds the value of the "name" field.
 	Name string `json:"name,omitempty"`
 	// Owner holds the value of the "owner" field.
-	Owner        string `json:"owner,omitempty"`
+	Owner string `json:"owner,omitempty"`
+	// Order holds the value of the "order" field.
+	Order int `json:"order,omitempty"`
+	// OrderOption holds the value of the "order_option" field.
+	OrderOption  int `json:"order_option,omitempty"`
 	selectValues sql.SelectValues
 }
 
@@ -43,7 +47,7 @@ func (*Task) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case enttask.FieldPriorities:
 			values[i] = new([]byte)
-		case enttask.FieldID, enttask.FieldPriority:
+		case enttask.FieldID, enttask.FieldPriority, enttask.FieldOrder, enttask.FieldOrderOption:
 			values[i] = new(sql.NullInt64)
 		case enttask.FieldName, enttask.FieldOwner:
 			values[i] = new(sql.NullString)
@@ -103,6 +107,18 @@ func (t *Task) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				t.Owner = value.String
 			}
+		case enttask.FieldOrder:
+			if value, ok := values[i].(*sql.NullInt64); !ok {
+				return fmt.Errorf("unexpected type %T for field order", values[i])
+			} else if value.Valid {
+				t.Order = int(value.Int64)
+			}
+		case enttask.FieldOrderOption:
+			if value, ok := values[i].(*sql.NullInt64); !ok {
+				return fmt.Errorf("unexpected type %T for field order_option", values[i])
+			} else if value.Valid {
+				t.OrderOption = int(value.Int64)
+			}
 		default:
 			t.selectValues.Set(columns[i], values[i])
 		}
@@ -155,6 +171,12 @@ func (t *Task) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("owner=")
 	builder.WriteString(t.Owner)
+	builder.WriteString(", ")
+	builder.WriteString("order=")
+	builder.WriteString(fmt.Sprintf("%v", t.Order))
+	builder.WriteString(", ")
+	builder.WriteString("order_option=")
+	builder.WriteString(fmt.Sprintf("%v", t.OrderOption))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/entc/integration/ent/task/task.go
+++ b/entc/integration/ent/task/task.go
@@ -28,6 +28,10 @@ const (
 	FieldName = "name"
 	// FieldOwner holds the string denoting the owner field in the database.
 	FieldOwner = "owner"
+	// FieldOrder holds the string denoting the order field in the database.
+	FieldOrder = "order"
+	// FieldOrderOption holds the string denoting the order_option field in the database.
+	FieldOrderOption = "order_option"
 	// Table holds the table name of the task in the database.
 	Table = "tasks"
 )
@@ -40,6 +44,8 @@ var Columns = []string{
 	FieldCreatedAt,
 	FieldName,
 	FieldOwner,
+	FieldOrder,
+	FieldOrderOption,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -59,32 +65,42 @@ var (
 	DefaultCreatedAt func() time.Time
 )
 
-// Order defines the ordering method for the Task queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Task queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByPriority orders the results by the priority field.
-func ByPriority(opts ...sql.OrderTermOption) Order {
+func ByPriority(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldPriority, opts...).ToFunc()
 }
 
 // ByCreatedAt orders the results by the created_at field.
-func ByCreatedAt(opts ...sql.OrderTermOption) Order {
+func ByCreatedAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCreatedAt, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByOwner orders the results by the owner field.
-func ByOwner(opts ...sql.OrderTermOption) Order {
+func ByOwner(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldOwner, opts...).ToFunc()
+}
+
+// ByOrder orders the results by the order field.
+func ByOrder(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldOrder, opts...).ToFunc()
+}
+
+// ByOrderOption orders the results by the order_option field.
+func ByOrderOption(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldOrderOption, opts...).ToFunc()
 }
 
 // comment from another template.

--- a/entc/integration/ent/task/where.go
+++ b/entc/integration/ent/task/where.go
@@ -80,6 +80,11 @@ func Owner(v string) predicate.Task {
 	return predicate.Task(sql.FieldEQ(FieldOwner, v))
 }
 
+// Order applies equality check predicate on the "order" field. It's identical to OrderEQ.
+func Order(v int) predicate.Task {
+	return predicate.Task(sql.FieldEQ(FieldOrder, v))
+}
+
 // PriorityEQ applies the EQ predicate on the "priority" field.
 func PriorityEQ(v task.Priority) predicate.Task {
 	vc := int(v)
@@ -332,6 +337,106 @@ func OwnerEqualFold(v string) predicate.Task {
 // OwnerContainsFold applies the ContainsFold predicate on the "owner" field.
 func OwnerContainsFold(v string) predicate.Task {
 	return predicate.Task(sql.FieldContainsFold(FieldOwner, v))
+}
+
+// OrderEQ applies the EQ predicate on the "order" field.
+func OrderEQ(v int) predicate.Task {
+	return predicate.Task(sql.FieldEQ(FieldOrder, v))
+}
+
+// OrderNEQ applies the NEQ predicate on the "order" field.
+func OrderNEQ(v int) predicate.Task {
+	return predicate.Task(sql.FieldNEQ(FieldOrder, v))
+}
+
+// OrderIn applies the In predicate on the "order" field.
+func OrderIn(vs ...int) predicate.Task {
+	return predicate.Task(sql.FieldIn(FieldOrder, vs...))
+}
+
+// OrderNotIn applies the NotIn predicate on the "order" field.
+func OrderNotIn(vs ...int) predicate.Task {
+	return predicate.Task(sql.FieldNotIn(FieldOrder, vs...))
+}
+
+// OrderGT applies the GT predicate on the "order" field.
+func OrderGT(v int) predicate.Task {
+	return predicate.Task(sql.FieldGT(FieldOrder, v))
+}
+
+// OrderGTE applies the GTE predicate on the "order" field.
+func OrderGTE(v int) predicate.Task {
+	return predicate.Task(sql.FieldGTE(FieldOrder, v))
+}
+
+// OrderLT applies the LT predicate on the "order" field.
+func OrderLT(v int) predicate.Task {
+	return predicate.Task(sql.FieldLT(FieldOrder, v))
+}
+
+// OrderLTE applies the LTE predicate on the "order" field.
+func OrderLTE(v int) predicate.Task {
+	return predicate.Task(sql.FieldLTE(FieldOrder, v))
+}
+
+// OrderIsNil applies the IsNil predicate on the "order" field.
+func OrderIsNil() predicate.Task {
+	return predicate.Task(sql.FieldIsNull(FieldOrder))
+}
+
+// OrderNotNil applies the NotNil predicate on the "order" field.
+func OrderNotNil() predicate.Task {
+	return predicate.Task(sql.FieldNotNull(FieldOrder))
+}
+
+// OrderOptionEQ applies the EQ predicate on the "order_option" field.
+func OrderOptionEQ(v int) predicate.Task {
+	return predicate.Task(sql.FieldEQ(FieldOrderOption, v))
+}
+
+// OrderOptionNEQ applies the NEQ predicate on the "order_option" field.
+func OrderOptionNEQ(v int) predicate.Task {
+	return predicate.Task(sql.FieldNEQ(FieldOrderOption, v))
+}
+
+// OrderOptionIn applies the In predicate on the "order_option" field.
+func OrderOptionIn(vs ...int) predicate.Task {
+	return predicate.Task(sql.FieldIn(FieldOrderOption, vs...))
+}
+
+// OrderOptionNotIn applies the NotIn predicate on the "order_option" field.
+func OrderOptionNotIn(vs ...int) predicate.Task {
+	return predicate.Task(sql.FieldNotIn(FieldOrderOption, vs...))
+}
+
+// OrderOptionGT applies the GT predicate on the "order_option" field.
+func OrderOptionGT(v int) predicate.Task {
+	return predicate.Task(sql.FieldGT(FieldOrderOption, v))
+}
+
+// OrderOptionGTE applies the GTE predicate on the "order_option" field.
+func OrderOptionGTE(v int) predicate.Task {
+	return predicate.Task(sql.FieldGTE(FieldOrderOption, v))
+}
+
+// OrderOptionLT applies the LT predicate on the "order_option" field.
+func OrderOptionLT(v int) predicate.Task {
+	return predicate.Task(sql.FieldLT(FieldOrderOption, v))
+}
+
+// OrderOptionLTE applies the LTE predicate on the "order_option" field.
+func OrderOptionLTE(v int) predicate.Task {
+	return predicate.Task(sql.FieldLTE(FieldOrderOption, v))
+}
+
+// OrderOptionIsNil applies the IsNil predicate on the "order_option" field.
+func OrderOptionIsNil() predicate.Task {
+	return predicate.Task(sql.FieldIsNull(FieldOrderOption))
+}
+
+// OrderOptionNotNil applies the NotNil predicate on the "order_option" field.
+func OrderOptionNotNil() predicate.Task {
+	return predicate.Task(sql.FieldNotNull(FieldOrderOption))
 }
 
 // And groups predicates with the AND operator between them.

--- a/entc/integration/ent/task_create.go
+++ b/entc/integration/ent/task_create.go
@@ -89,6 +89,34 @@ func (tc *TaskCreate) SetNillableOwner(s *string) *TaskCreate {
 	return tc
 }
 
+// SetOrder sets the "order" field.
+func (tc *TaskCreate) SetOrder(i int) *TaskCreate {
+	tc.mutation.SetOrder(i)
+	return tc
+}
+
+// SetNillableOrder sets the "order" field if the given value is not nil.
+func (tc *TaskCreate) SetNillableOrder(i *int) *TaskCreate {
+	if i != nil {
+		tc.SetOrder(*i)
+	}
+	return tc
+}
+
+// SetOrderOption sets the "order_option" field.
+func (tc *TaskCreate) SetOrderOption(i int) *TaskCreate {
+	tc.mutation.SetOrderOption(i)
+	return tc
+}
+
+// SetNillableOrderOption sets the "order_option" field if the given value is not nil.
+func (tc *TaskCreate) SetNillableOrderOption(i *int) *TaskCreate {
+	if i != nil {
+		tc.SetOrderOption(*i)
+	}
+	return tc
+}
+
 // Mutation returns the TaskMutation object of the builder.
 func (tc *TaskCreate) Mutation() *TaskMutation {
 	return tc.mutation
@@ -193,6 +221,14 @@ func (tc *TaskCreate) createSpec() (*Task, *sqlgraph.CreateSpec) {
 	if value, ok := tc.mutation.Owner(); ok {
 		_spec.SetField(enttask.FieldOwner, field.TypeString, value)
 		_node.Owner = value
+	}
+	if value, ok := tc.mutation.Order(); ok {
+		_spec.SetField(enttask.FieldOrder, field.TypeInt, value)
+		_node.Order = value
+	}
+	if value, ok := tc.mutation.OrderOption(); ok {
+		_spec.SetField(enttask.FieldOrderOption, field.TypeInt, value)
+		_node.OrderOption = value
 	}
 	return _node, _spec
 }
@@ -315,6 +351,54 @@ func (u *TaskUpsert) UpdateOwner() *TaskUpsert {
 // ClearOwner clears the value of the "owner" field.
 func (u *TaskUpsert) ClearOwner() *TaskUpsert {
 	u.SetNull(enttask.FieldOwner)
+	return u
+}
+
+// SetOrder sets the "order" field.
+func (u *TaskUpsert) SetOrder(v int) *TaskUpsert {
+	u.Set(enttask.FieldOrder, v)
+	return u
+}
+
+// UpdateOrder sets the "order" field to the value that was provided on create.
+func (u *TaskUpsert) UpdateOrder() *TaskUpsert {
+	u.SetExcluded(enttask.FieldOrder)
+	return u
+}
+
+// AddOrder adds v to the "order" field.
+func (u *TaskUpsert) AddOrder(v int) *TaskUpsert {
+	u.Add(enttask.FieldOrder, v)
+	return u
+}
+
+// ClearOrder clears the value of the "order" field.
+func (u *TaskUpsert) ClearOrder() *TaskUpsert {
+	u.SetNull(enttask.FieldOrder)
+	return u
+}
+
+// SetOrderOption sets the "order_option" field.
+func (u *TaskUpsert) SetOrderOption(v int) *TaskUpsert {
+	u.Set(enttask.FieldOrderOption, v)
+	return u
+}
+
+// UpdateOrderOption sets the "order_option" field to the value that was provided on create.
+func (u *TaskUpsert) UpdateOrderOption() *TaskUpsert {
+	u.SetExcluded(enttask.FieldOrderOption)
+	return u
+}
+
+// AddOrderOption adds v to the "order_option" field.
+func (u *TaskUpsert) AddOrderOption(v int) *TaskUpsert {
+	u.Add(enttask.FieldOrderOption, v)
+	return u
+}
+
+// ClearOrderOption clears the value of the "order_option" field.
+func (u *TaskUpsert) ClearOrderOption() *TaskUpsert {
+	u.SetNull(enttask.FieldOrderOption)
 	return u
 }
 
@@ -444,6 +528,62 @@ func (u *TaskUpsertOne) UpdateOwner() *TaskUpsertOne {
 func (u *TaskUpsertOne) ClearOwner() *TaskUpsertOne {
 	return u.Update(func(s *TaskUpsert) {
 		s.ClearOwner()
+	})
+}
+
+// SetOrder sets the "order" field.
+func (u *TaskUpsertOne) SetOrder(v int) *TaskUpsertOne {
+	return u.Update(func(s *TaskUpsert) {
+		s.SetOrder(v)
+	})
+}
+
+// AddOrder adds v to the "order" field.
+func (u *TaskUpsertOne) AddOrder(v int) *TaskUpsertOne {
+	return u.Update(func(s *TaskUpsert) {
+		s.AddOrder(v)
+	})
+}
+
+// UpdateOrder sets the "order" field to the value that was provided on create.
+func (u *TaskUpsertOne) UpdateOrder() *TaskUpsertOne {
+	return u.Update(func(s *TaskUpsert) {
+		s.UpdateOrder()
+	})
+}
+
+// ClearOrder clears the value of the "order" field.
+func (u *TaskUpsertOne) ClearOrder() *TaskUpsertOne {
+	return u.Update(func(s *TaskUpsert) {
+		s.ClearOrder()
+	})
+}
+
+// SetOrderOption sets the "order_option" field.
+func (u *TaskUpsertOne) SetOrderOption(v int) *TaskUpsertOne {
+	return u.Update(func(s *TaskUpsert) {
+		s.SetOrderOption(v)
+	})
+}
+
+// AddOrderOption adds v to the "order_option" field.
+func (u *TaskUpsertOne) AddOrderOption(v int) *TaskUpsertOne {
+	return u.Update(func(s *TaskUpsert) {
+		s.AddOrderOption(v)
+	})
+}
+
+// UpdateOrderOption sets the "order_option" field to the value that was provided on create.
+func (u *TaskUpsertOne) UpdateOrderOption() *TaskUpsertOne {
+	return u.Update(func(s *TaskUpsert) {
+		s.UpdateOrderOption()
+	})
+}
+
+// ClearOrderOption clears the value of the "order_option" field.
+func (u *TaskUpsertOne) ClearOrderOption() *TaskUpsertOne {
+	return u.Update(func(s *TaskUpsert) {
+		s.ClearOrderOption()
 	})
 }
 
@@ -735,6 +875,62 @@ func (u *TaskUpsertBulk) UpdateOwner() *TaskUpsertBulk {
 func (u *TaskUpsertBulk) ClearOwner() *TaskUpsertBulk {
 	return u.Update(func(s *TaskUpsert) {
 		s.ClearOwner()
+	})
+}
+
+// SetOrder sets the "order" field.
+func (u *TaskUpsertBulk) SetOrder(v int) *TaskUpsertBulk {
+	return u.Update(func(s *TaskUpsert) {
+		s.SetOrder(v)
+	})
+}
+
+// AddOrder adds v to the "order" field.
+func (u *TaskUpsertBulk) AddOrder(v int) *TaskUpsertBulk {
+	return u.Update(func(s *TaskUpsert) {
+		s.AddOrder(v)
+	})
+}
+
+// UpdateOrder sets the "order" field to the value that was provided on create.
+func (u *TaskUpsertBulk) UpdateOrder() *TaskUpsertBulk {
+	return u.Update(func(s *TaskUpsert) {
+		s.UpdateOrder()
+	})
+}
+
+// ClearOrder clears the value of the "order" field.
+func (u *TaskUpsertBulk) ClearOrder() *TaskUpsertBulk {
+	return u.Update(func(s *TaskUpsert) {
+		s.ClearOrder()
+	})
+}
+
+// SetOrderOption sets the "order_option" field.
+func (u *TaskUpsertBulk) SetOrderOption(v int) *TaskUpsertBulk {
+	return u.Update(func(s *TaskUpsert) {
+		s.SetOrderOption(v)
+	})
+}
+
+// AddOrderOption adds v to the "order_option" field.
+func (u *TaskUpsertBulk) AddOrderOption(v int) *TaskUpsertBulk {
+	return u.Update(func(s *TaskUpsert) {
+		s.AddOrderOption(v)
+	})
+}
+
+// UpdateOrderOption sets the "order_option" field to the value that was provided on create.
+func (u *TaskUpsertBulk) UpdateOrderOption() *TaskUpsertBulk {
+	return u.Update(func(s *TaskUpsert) {
+		s.UpdateOrderOption()
+	})
+}
+
+// ClearOrderOption clears the value of the "order_option" field.
+func (u *TaskUpsertBulk) ClearOrderOption() *TaskUpsertBulk {
+	return u.Update(func(s *TaskUpsert) {
+		s.ClearOrderOption()
 	})
 }
 

--- a/entc/integration/ent/task_query.go
+++ b/entc/integration/ent/task_query.go
@@ -23,7 +23,7 @@ import (
 type TaskQuery struct {
 	config
 	ctx        *QueryContext
-	order      []enttask.Order
+	order      []enttask.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Task
 	modifiers  []func(*sql.Selector)
@@ -58,7 +58,7 @@ func (tq *TaskQuery) Unique(unique bool) *TaskQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (tq *TaskQuery) Order(o ...enttask.Order) *TaskQuery {
+func (tq *TaskQuery) Order(o ...enttask.OrderOption) *TaskQuery {
 	tq.order = append(tq.order, o...)
 	return tq
 }
@@ -252,7 +252,7 @@ func (tq *TaskQuery) Clone() *TaskQuery {
 	return &TaskQuery{
 		config:     tq.config,
 		ctx:        tq.ctx.Clone(),
-		order:      append([]enttask.Order{}, tq.order...),
+		order:      append([]enttask.OrderOption{}, tq.order...),
 		inters:     append([]Interceptor{}, tq.inters...),
 		predicates: append([]predicate.Task{}, tq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/ent/task_update.go
+++ b/entc/integration/ent/task_update.go
@@ -106,6 +106,60 @@ func (tu *TaskUpdate) ClearOwner() *TaskUpdate {
 	return tu
 }
 
+// SetOrder sets the "order" field.
+func (tu *TaskUpdate) SetOrder(i int) *TaskUpdate {
+	tu.mutation.ResetOrder()
+	tu.mutation.SetOrder(i)
+	return tu
+}
+
+// SetNillableOrder sets the "order" field if the given value is not nil.
+func (tu *TaskUpdate) SetNillableOrder(i *int) *TaskUpdate {
+	if i != nil {
+		tu.SetOrder(*i)
+	}
+	return tu
+}
+
+// AddOrder adds i to the "order" field.
+func (tu *TaskUpdate) AddOrder(i int) *TaskUpdate {
+	tu.mutation.AddOrder(i)
+	return tu
+}
+
+// ClearOrder clears the value of the "order" field.
+func (tu *TaskUpdate) ClearOrder() *TaskUpdate {
+	tu.mutation.ClearOrder()
+	return tu
+}
+
+// SetOrderOption sets the "order_option" field.
+func (tu *TaskUpdate) SetOrderOption(i int) *TaskUpdate {
+	tu.mutation.ResetOrderOption()
+	tu.mutation.SetOrderOption(i)
+	return tu
+}
+
+// SetNillableOrderOption sets the "order_option" field if the given value is not nil.
+func (tu *TaskUpdate) SetNillableOrderOption(i *int) *TaskUpdate {
+	if i != nil {
+		tu.SetOrderOption(*i)
+	}
+	return tu
+}
+
+// AddOrderOption adds i to the "order_option" field.
+func (tu *TaskUpdate) AddOrderOption(i int) *TaskUpdate {
+	tu.mutation.AddOrderOption(i)
+	return tu
+}
+
+// ClearOrderOption clears the value of the "order_option" field.
+func (tu *TaskUpdate) ClearOrderOption() *TaskUpdate {
+	tu.mutation.ClearOrderOption()
+	return tu
+}
+
 // Mutation returns the TaskMutation object of the builder.
 func (tu *TaskUpdate) Mutation() *TaskMutation {
 	return tu.mutation
@@ -176,6 +230,24 @@ func (tu *TaskUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if tu.mutation.OwnerCleared() {
 		_spec.ClearField(enttask.FieldOwner, field.TypeString)
+	}
+	if value, ok := tu.mutation.Order(); ok {
+		_spec.SetField(enttask.FieldOrder, field.TypeInt, value)
+	}
+	if value, ok := tu.mutation.AddedOrder(); ok {
+		_spec.AddField(enttask.FieldOrder, field.TypeInt, value)
+	}
+	if tu.mutation.OrderCleared() {
+		_spec.ClearField(enttask.FieldOrder, field.TypeInt)
+	}
+	if value, ok := tu.mutation.OrderOption(); ok {
+		_spec.SetField(enttask.FieldOrderOption, field.TypeInt, value)
+	}
+	if value, ok := tu.mutation.AddedOrderOption(); ok {
+		_spec.AddField(enttask.FieldOrderOption, field.TypeInt, value)
+	}
+	if tu.mutation.OrderOptionCleared() {
+		_spec.ClearField(enttask.FieldOrderOption, field.TypeInt)
 	}
 	_spec.AddModifiers(tu.modifiers...)
 	if n, err = sqlgraph.UpdateNodes(ctx, tu.driver, _spec); err != nil {
@@ -269,6 +341,60 @@ func (tuo *TaskUpdateOne) SetNillableOwner(s *string) *TaskUpdateOne {
 // ClearOwner clears the value of the "owner" field.
 func (tuo *TaskUpdateOne) ClearOwner() *TaskUpdateOne {
 	tuo.mutation.ClearOwner()
+	return tuo
+}
+
+// SetOrder sets the "order" field.
+func (tuo *TaskUpdateOne) SetOrder(i int) *TaskUpdateOne {
+	tuo.mutation.ResetOrder()
+	tuo.mutation.SetOrder(i)
+	return tuo
+}
+
+// SetNillableOrder sets the "order" field if the given value is not nil.
+func (tuo *TaskUpdateOne) SetNillableOrder(i *int) *TaskUpdateOne {
+	if i != nil {
+		tuo.SetOrder(*i)
+	}
+	return tuo
+}
+
+// AddOrder adds i to the "order" field.
+func (tuo *TaskUpdateOne) AddOrder(i int) *TaskUpdateOne {
+	tuo.mutation.AddOrder(i)
+	return tuo
+}
+
+// ClearOrder clears the value of the "order" field.
+func (tuo *TaskUpdateOne) ClearOrder() *TaskUpdateOne {
+	tuo.mutation.ClearOrder()
+	return tuo
+}
+
+// SetOrderOption sets the "order_option" field.
+func (tuo *TaskUpdateOne) SetOrderOption(i int) *TaskUpdateOne {
+	tuo.mutation.ResetOrderOption()
+	tuo.mutation.SetOrderOption(i)
+	return tuo
+}
+
+// SetNillableOrderOption sets the "order_option" field if the given value is not nil.
+func (tuo *TaskUpdateOne) SetNillableOrderOption(i *int) *TaskUpdateOne {
+	if i != nil {
+		tuo.SetOrderOption(*i)
+	}
+	return tuo
+}
+
+// AddOrderOption adds i to the "order_option" field.
+func (tuo *TaskUpdateOne) AddOrderOption(i int) *TaskUpdateOne {
+	tuo.mutation.AddOrderOption(i)
+	return tuo
+}
+
+// ClearOrderOption clears the value of the "order_option" field.
+func (tuo *TaskUpdateOne) ClearOrderOption() *TaskUpdateOne {
+	tuo.mutation.ClearOrderOption()
 	return tuo
 }
 
@@ -372,6 +498,24 @@ func (tuo *TaskUpdateOne) sqlSave(ctx context.Context) (_node *Task, err error) 
 	}
 	if tuo.mutation.OwnerCleared() {
 		_spec.ClearField(enttask.FieldOwner, field.TypeString)
+	}
+	if value, ok := tuo.mutation.Order(); ok {
+		_spec.SetField(enttask.FieldOrder, field.TypeInt, value)
+	}
+	if value, ok := tuo.mutation.AddedOrder(); ok {
+		_spec.AddField(enttask.FieldOrder, field.TypeInt, value)
+	}
+	if tuo.mutation.OrderCleared() {
+		_spec.ClearField(enttask.FieldOrder, field.TypeInt)
+	}
+	if value, ok := tuo.mutation.OrderOption(); ok {
+		_spec.SetField(enttask.FieldOrderOption, field.TypeInt, value)
+	}
+	if value, ok := tuo.mutation.AddedOrderOption(); ok {
+		_spec.AddField(enttask.FieldOrderOption, field.TypeInt, value)
+	}
+	if tuo.mutation.OrderOptionCleared() {
+		_spec.ClearField(enttask.FieldOrderOption, field.TypeInt)
 	}
 	_spec.AddModifiers(tuo.modifiers...)
 	_node = &Task{config: tuo.config}

--- a/entc/integration/ent/user/user.go
+++ b/entc/integration/ent/user/user.go
@@ -235,190 +235,190 @@ func EmploymentValidator(e Employment) error {
 	}
 }
 
-// Order defines the ordering method for the User queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the User queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByOptionalInt orders the results by the optional_int field.
-func ByOptionalInt(opts ...sql.OrderTermOption) Order {
+func ByOptionalInt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldOptionalInt, opts...).ToFunc()
 }
 
 // ByAge orders the results by the age field.
-func ByAge(opts ...sql.OrderTermOption) Order {
+func ByAge(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAge, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByLast orders the results by the last field.
-func ByLast(opts ...sql.OrderTermOption) Order {
+func ByLast(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldLast, opts...).ToFunc()
 }
 
 // ByNickname orders the results by the nickname field.
-func ByNickname(opts ...sql.OrderTermOption) Order {
+func ByNickname(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldNickname, opts...).ToFunc()
 }
 
 // ByAddress orders the results by the address field.
-func ByAddress(opts ...sql.OrderTermOption) Order {
+func ByAddress(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAddress, opts...).ToFunc()
 }
 
 // ByPhone orders the results by the phone field.
-func ByPhone(opts ...sql.OrderTermOption) Order {
+func ByPhone(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldPhone, opts...).ToFunc()
 }
 
 // ByPassword orders the results by the password field.
-func ByPassword(opts ...sql.OrderTermOption) Order {
+func ByPassword(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldPassword, opts...).ToFunc()
 }
 
 // ByRole orders the results by the role field.
-func ByRole(opts ...sql.OrderTermOption) Order {
+func ByRole(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldRole, opts...).ToFunc()
 }
 
 // ByEmployment orders the results by the employment field.
-func ByEmployment(opts ...sql.OrderTermOption) Order {
+func ByEmployment(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldEmployment, opts...).ToFunc()
 }
 
 // BySSOCert orders the results by the SSOCert field.
-func BySSOCert(opts ...sql.OrderTermOption) Order {
+func BySSOCert(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldSSOCert, opts...).ToFunc()
 }
 
 // ByCardField orders the results by card field.
-func ByCardField(field string, opts ...sql.OrderTermOption) Order {
+func ByCardField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newCardStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByPetsCount orders the results by pets count.
-func ByPetsCount(opts ...sql.OrderTermOption) Order {
+func ByPetsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newPetsStep(), opts...)
 	}
 }
 
 // ByPets orders the results by pets terms.
-func ByPets(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByPets(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newPetsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByFilesCount orders the results by files count.
-func ByFilesCount(opts ...sql.OrderTermOption) Order {
+func ByFilesCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newFilesStep(), opts...)
 	}
 }
 
 // ByFiles orders the results by files terms.
-func ByFiles(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByFiles(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newFilesStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByGroupsCount orders the results by groups count.
-func ByGroupsCount(opts ...sql.OrderTermOption) Order {
+func ByGroupsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newGroupsStep(), opts...)
 	}
 }
 
 // ByGroups orders the results by groups terms.
-func ByGroups(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByGroups(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newGroupsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByFriendsCount orders the results by friends count.
-func ByFriendsCount(opts ...sql.OrderTermOption) Order {
+func ByFriendsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newFriendsStep(), opts...)
 	}
 }
 
 // ByFriends orders the results by friends terms.
-func ByFriends(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByFriends(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newFriendsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByFollowersCount orders the results by followers count.
-func ByFollowersCount(opts ...sql.OrderTermOption) Order {
+func ByFollowersCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newFollowersStep(), opts...)
 	}
 }
 
 // ByFollowers orders the results by followers terms.
-func ByFollowers(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByFollowers(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newFollowersStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByFollowingCount orders the results by following count.
-func ByFollowingCount(opts ...sql.OrderTermOption) Order {
+func ByFollowingCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newFollowingStep(), opts...)
 	}
 }
 
 // ByFollowing orders the results by following terms.
-func ByFollowing(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByFollowing(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newFollowingStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByTeamField orders the results by team field.
-func ByTeamField(field string, opts ...sql.OrderTermOption) Order {
+func ByTeamField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newTeamStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // BySpouseField orders the results by spouse field.
-func BySpouseField(field string, opts ...sql.OrderTermOption) Order {
+func BySpouseField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newSpouseStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByChildrenCount orders the results by children count.
-func ByChildrenCount(opts ...sql.OrderTermOption) Order {
+func ByChildrenCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newChildrenStep(), opts...)
 	}
 }
 
 // ByChildren orders the results by children terms.
-func ByChildren(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByChildren(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newChildrenStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByParentField orders the results by parent field.
-func ByParentField(field string, opts ...sql.OrderTermOption) Order {
+func ByParentField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newParentStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/ent/user_query.go
+++ b/entc/integration/ent/user_query.go
@@ -28,7 +28,7 @@ import (
 type UserQuery struct {
 	config
 	ctx                *QueryContext
-	order              []user.Order
+	order              []user.OrderOption
 	inters             []Interceptor
 	predicates         []predicate.User
 	withCard           *CardQuery
@@ -82,7 +82,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
+func (uq *UserQuery) Order(o ...user.OrderOption) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -518,7 +518,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:        uq.config,
 		ctx:           uq.ctx.Clone(),
-		order:         append([]user.Order{}, uq.order...),
+		order:         append([]user.OrderOption{}, uq.order...),
 		inters:        append([]Interceptor{}, uq.inters...),
 		predicates:    append([]predicate.User{}, uq.predicates...),
 		withCard:      uq.withCard.Clone(),

--- a/entc/integration/gremlin/ent/api/api.go
+++ b/entc/integration/gremlin/ent/api/api.go
@@ -17,7 +17,7 @@ const (
 	FieldID = "id"
 )
 
-// Order defines the ordering method for the Api queries.
-type Order func(*dsl.Traversal)
+// OrderOption defines the ordering options for the Api queries.
+type OrderOption func(*dsl.Traversal)
 
 // comment from another template.

--- a/entc/integration/gremlin/ent/api_query.go
+++ b/entc/integration/gremlin/ent/api_query.go
@@ -23,7 +23,7 @@ import (
 type APIQuery struct {
 	config
 	ctx        *QueryContext
-	order      []api.Order
+	order      []api.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Api
 	// intermediate query (i.e. traversal path).
@@ -57,7 +57,7 @@ func (aq *APIQuery) Unique(unique bool) *APIQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (aq *APIQuery) Order(o ...api.Order) *APIQuery {
+func (aq *APIQuery) Order(o ...api.OrderOption) *APIQuery {
 	aq.order = append(aq.order, o...)
 	return aq
 }
@@ -251,7 +251,7 @@ func (aq *APIQuery) Clone() *APIQuery {
 	return &APIQuery{
 		config:     aq.config,
 		ctx:        aq.ctx.Clone(),
-		order:      append([]api.Order{}, aq.order...),
+		order:      append([]api.OrderOption{}, aq.order...),
 		inters:     append([]Interceptor{}, aq.inters...),
 		predicates: append([]predicate.Api{}, aq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/gremlin/ent/card/card.go
+++ b/entc/integration/gremlin/ent/card/card.go
@@ -52,7 +52,7 @@ var (
 	NameValidator func(string) error
 )
 
-// Order defines the ordering method for the Card queries.
-type Order func(*dsl.Traversal)
+// OrderOption defines the ordering options for the Card queries.
+type OrderOption func(*dsl.Traversal)
 
 // comment from another template.

--- a/entc/integration/gremlin/ent/card_query.go
+++ b/entc/integration/gremlin/ent/card_query.go
@@ -25,7 +25,7 @@ import (
 type CardQuery struct {
 	config
 	ctx        *QueryContext
-	order      []card.Order
+	order      []card.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Card
 	withOwner  *UserQuery
@@ -61,7 +61,7 @@ func (cq *CardQuery) Unique(unique bool) *CardQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *CardQuery) Order(o ...card.Order) *CardQuery {
+func (cq *CardQuery) Order(o ...card.OrderOption) *CardQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -283,7 +283,7 @@ func (cq *CardQuery) Clone() *CardQuery {
 	return &CardQuery{
 		config:     cq.config,
 		ctx:        cq.ctx.Clone(),
-		order:      append([]card.Order{}, cq.order...),
+		order:      append([]card.OrderOption{}, cq.order...),
 		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Card{}, cq.predicates...),
 		withOwner:  cq.withOwner.Clone(),

--- a/entc/integration/gremlin/ent/comment/comment.go
+++ b/entc/integration/gremlin/ent/comment/comment.go
@@ -29,7 +29,7 @@ const (
 	FieldClient = "client"
 )
 
-// Order defines the ordering method for the Comment queries.
-type Order func(*dsl.Traversal)
+// OrderOption defines the ordering options for the Comment queries.
+type OrderOption func(*dsl.Traversal)
 
 // comment from another template.

--- a/entc/integration/gremlin/ent/comment_query.go
+++ b/entc/integration/gremlin/ent/comment_query.go
@@ -23,7 +23,7 @@ import (
 type CommentQuery struct {
 	config
 	ctx        *QueryContext
-	order      []comment.Order
+	order      []comment.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Comment
 	// intermediate query (i.e. traversal path).
@@ -57,7 +57,7 @@ func (cq *CommentQuery) Unique(unique bool) *CommentQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *CommentQuery) Order(o ...comment.Order) *CommentQuery {
+func (cq *CommentQuery) Order(o ...comment.OrderOption) *CommentQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -251,7 +251,7 @@ func (cq *CommentQuery) Clone() *CommentQuery {
 	return &CommentQuery{
 		config:     cq.config,
 		ctx:        cq.ctx.Clone(),
-		order:      append([]comment.Order{}, cq.order...),
+		order:      append([]comment.OrderOption{}, cq.order...),
 		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Comment{}, cq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/gremlin/ent/exvaluescan/exvaluescan.go
+++ b/entc/integration/gremlin/ent/exvaluescan/exvaluescan.go
@@ -48,7 +48,7 @@ var (
 	}
 )
 
-// Order defines the ordering method for the ExValueScan queries.
-type Order func(*dsl.Traversal)
+// OrderOption defines the ordering options for the ExValueScan queries.
+type OrderOption func(*dsl.Traversal)
 
 // comment from another template.

--- a/entc/integration/gremlin/ent/exvaluescan_query.go
+++ b/entc/integration/gremlin/ent/exvaluescan_query.go
@@ -23,7 +23,7 @@ import (
 type ExValueScanQuery struct {
 	config
 	ctx        *QueryContext
-	order      []exvaluescan.Order
+	order      []exvaluescan.OrderOption
 	inters     []Interceptor
 	predicates []predicate.ExValueScan
 	// intermediate query (i.e. traversal path).
@@ -57,7 +57,7 @@ func (evsq *ExValueScanQuery) Unique(unique bool) *ExValueScanQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (evsq *ExValueScanQuery) Order(o ...exvaluescan.Order) *ExValueScanQuery {
+func (evsq *ExValueScanQuery) Order(o ...exvaluescan.OrderOption) *ExValueScanQuery {
 	evsq.order = append(evsq.order, o...)
 	return evsq
 }
@@ -251,7 +251,7 @@ func (evsq *ExValueScanQuery) Clone() *ExValueScanQuery {
 	return &ExValueScanQuery{
 		config:     evsq.config,
 		ctx:        evsq.ctx.Clone(),
-		order:      append([]exvaluescan.Order{}, evsq.order...),
+		order:      append([]exvaluescan.OrderOption{}, evsq.order...),
 		inters:     append([]Interceptor{}, evsq.inters...),
 		predicates: append([]predicate.ExValueScan{}, evsq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/gremlin/ent/fieldtype/fieldtype.go
+++ b/entc/integration/gremlin/ent/fieldtype/fieldtype.go
@@ -241,8 +241,8 @@ func PriorityValidator(pr role.Priority) error {
 	}
 }
 
-// Order defines the ordering method for the FieldType queries.
-type Order func(*dsl.Traversal)
+// OrderOption defines the ordering options for the FieldType queries.
+type OrderOption func(*dsl.Traversal)
 
 // Ptr returns a new pointer to the enum value.
 func (s State) Ptr() *State {

--- a/entc/integration/gremlin/ent/fieldtype_query.go
+++ b/entc/integration/gremlin/ent/fieldtype_query.go
@@ -23,7 +23,7 @@ import (
 type FieldTypeQuery struct {
 	config
 	ctx        *QueryContext
-	order      []fieldtype.Order
+	order      []fieldtype.OrderOption
 	inters     []Interceptor
 	predicates []predicate.FieldType
 	// intermediate query (i.e. traversal path).
@@ -57,7 +57,7 @@ func (ftq *FieldTypeQuery) Unique(unique bool) *FieldTypeQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (ftq *FieldTypeQuery) Order(o ...fieldtype.Order) *FieldTypeQuery {
+func (ftq *FieldTypeQuery) Order(o ...fieldtype.OrderOption) *FieldTypeQuery {
 	ftq.order = append(ftq.order, o...)
 	return ftq
 }
@@ -251,7 +251,7 @@ func (ftq *FieldTypeQuery) Clone() *FieldTypeQuery {
 	return &FieldTypeQuery{
 		config:     ftq.config,
 		ctx:        ftq.ctx.Clone(),
-		order:      append([]fieldtype.Order{}, ftq.order...),
+		order:      append([]fieldtype.OrderOption{}, ftq.order...),
 		inters:     append([]Interceptor{}, ftq.inters...),
 		predicates: append([]predicate.FieldType{}, ftq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/gremlin/ent/file/file.go
+++ b/entc/integration/gremlin/ent/file/file.go
@@ -48,7 +48,7 @@ var (
 	SizeValidator func(int) error
 )
 
-// Order defines the ordering method for the File queries.
-type Order func(*dsl.Traversal)
+// OrderOption defines the ordering options for the File queries.
+type OrderOption func(*dsl.Traversal)
 
 // comment from another template.

--- a/entc/integration/gremlin/ent/file_query.go
+++ b/entc/integration/gremlin/ent/file_query.go
@@ -25,7 +25,7 @@ import (
 type FileQuery struct {
 	config
 	ctx        *QueryContext
-	order      []file.Order
+	order      []file.OrderOption
 	inters     []Interceptor
 	predicates []predicate.File
 	withOwner  *UserQuery
@@ -62,7 +62,7 @@ func (fq *FileQuery) Unique(unique bool) *FileQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (fq *FileQuery) Order(o ...file.Order) *FileQuery {
+func (fq *FileQuery) Order(o ...file.OrderOption) *FileQuery {
 	fq.order = append(fq.order, o...)
 	return fq
 }
@@ -298,7 +298,7 @@ func (fq *FileQuery) Clone() *FileQuery {
 	return &FileQuery{
 		config:     fq.config,
 		ctx:        fq.ctx.Clone(),
-		order:      append([]file.Order{}, fq.order...),
+		order:      append([]file.OrderOption{}, fq.order...),
 		inters:     append([]Interceptor{}, fq.inters...),
 		predicates: append([]predicate.File{}, fq.predicates...),
 		withOwner:  fq.withOwner.Clone(),

--- a/entc/integration/gremlin/ent/filetype/filetype.go
+++ b/entc/integration/gremlin/ent/filetype/filetype.go
@@ -82,8 +82,8 @@ func StateValidator(s State) error {
 	}
 }
 
-// Order defines the ordering method for the FileType queries.
-type Order func(*dsl.Traversal)
+// OrderOption defines the ordering options for the FileType queries.
+type OrderOption func(*dsl.Traversal)
 
 // Ptr returns a new pointer to the enum value.
 func (_type Type) Ptr() *Type {

--- a/entc/integration/gremlin/ent/filetype_query.go
+++ b/entc/integration/gremlin/ent/filetype_query.go
@@ -23,7 +23,7 @@ import (
 type FileTypeQuery struct {
 	config
 	ctx        *QueryContext
-	order      []filetype.Order
+	order      []filetype.OrderOption
 	inters     []Interceptor
 	predicates []predicate.FileType
 	withFiles  *FileQuery
@@ -58,7 +58,7 @@ func (ftq *FileTypeQuery) Unique(unique bool) *FileTypeQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (ftq *FileTypeQuery) Order(o ...filetype.Order) *FileTypeQuery {
+func (ftq *FileTypeQuery) Order(o ...filetype.OrderOption) *FileTypeQuery {
 	ftq.order = append(ftq.order, o...)
 	return ftq
 }
@@ -266,7 +266,7 @@ func (ftq *FileTypeQuery) Clone() *FileTypeQuery {
 	return &FileTypeQuery{
 		config:     ftq.config,
 		ctx:        ftq.ctx.Clone(),
-		order:      append([]filetype.Order{}, ftq.order...),
+		order:      append([]filetype.OrderOption{}, ftq.order...),
 		inters:     append([]Interceptor{}, ftq.inters...),
 		predicates: append([]predicate.FileType{}, ftq.predicates...),
 		withFiles:  ftq.withFiles.Clone(),

--- a/entc/integration/gremlin/ent/goods/goods.go
+++ b/entc/integration/gremlin/ent/goods/goods.go
@@ -17,7 +17,7 @@ const (
 	FieldID = "id"
 )
 
-// Order defines the ordering method for the Goods queries.
-type Order func(*dsl.Traversal)
+// OrderOption defines the ordering options for the Goods queries.
+type OrderOption func(*dsl.Traversal)
 
 // comment from another template.

--- a/entc/integration/gremlin/ent/goods_query.go
+++ b/entc/integration/gremlin/ent/goods_query.go
@@ -23,7 +23,7 @@ import (
 type GoodsQuery struct {
 	config
 	ctx        *QueryContext
-	order      []goods.Order
+	order      []goods.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Goods
 	// intermediate query (i.e. traversal path).
@@ -57,7 +57,7 @@ func (gq *GoodsQuery) Unique(unique bool) *GoodsQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (gq *GoodsQuery) Order(o ...goods.Order) *GoodsQuery {
+func (gq *GoodsQuery) Order(o ...goods.OrderOption) *GoodsQuery {
 	gq.order = append(gq.order, o...)
 	return gq
 }
@@ -251,7 +251,7 @@ func (gq *GoodsQuery) Clone() *GoodsQuery {
 	return &GoodsQuery{
 		config:     gq.config,
 		ctx:        gq.ctx.Clone(),
-		order:      append([]goods.Order{}, gq.order...),
+		order:      append([]goods.OrderOption{}, gq.order...),
 		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Goods{}, gq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/gremlin/ent/group/group.go
+++ b/entc/integration/gremlin/ent/group/group.go
@@ -56,7 +56,7 @@ var (
 	NameValidator func(string) error
 )
 
-// Order defines the ordering method for the Group queries.
-type Order func(*dsl.Traversal)
+// OrderOption defines the ordering options for the Group queries.
+type OrderOption func(*dsl.Traversal)
 
 // comment from another template.

--- a/entc/integration/gremlin/ent/group_query.go
+++ b/entc/integration/gremlin/ent/group_query.go
@@ -24,7 +24,7 @@ import (
 type GroupQuery struct {
 	config
 	ctx         *QueryContext
-	order       []group.Order
+	order       []group.OrderOption
 	inters      []Interceptor
 	predicates  []predicate.Group
 	withFiles   *FileQuery
@@ -62,7 +62,7 @@ func (gq *GroupQuery) Unique(unique bool) *GroupQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (gq *GroupQuery) Order(o ...group.Order) *GroupQuery {
+func (gq *GroupQuery) Order(o ...group.OrderOption) *GroupQuery {
 	gq.order = append(gq.order, o...)
 	return gq
 }
@@ -312,7 +312,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 	return &GroupQuery{
 		config:      gq.config,
 		ctx:         gq.ctx.Clone(),
-		order:       append([]group.Order{}, gq.order...),
+		order:       append([]group.OrderOption{}, gq.order...),
 		inters:      append([]Interceptor{}, gq.inters...),
 		predicates:  append([]predicate.Group{}, gq.predicates...),
 		withFiles:   gq.withFiles.Clone(),

--- a/entc/integration/gremlin/ent/groupinfo/groupinfo.go
+++ b/entc/integration/gremlin/ent/groupinfo/groupinfo.go
@@ -30,7 +30,7 @@ var (
 	DefaultMaxUsers int
 )
 
-// Order defines the ordering method for the GroupInfo queries.
-type Order func(*dsl.Traversal)
+// OrderOption defines the ordering options for the GroupInfo queries.
+type OrderOption func(*dsl.Traversal)
 
 // comment from another template.

--- a/entc/integration/gremlin/ent/groupinfo_query.go
+++ b/entc/integration/gremlin/ent/groupinfo_query.go
@@ -24,7 +24,7 @@ import (
 type GroupInfoQuery struct {
 	config
 	ctx        *QueryContext
-	order      []groupinfo.Order
+	order      []groupinfo.OrderOption
 	inters     []Interceptor
 	predicates []predicate.GroupInfo
 	withGroups *GroupQuery
@@ -59,7 +59,7 @@ func (giq *GroupInfoQuery) Unique(unique bool) *GroupInfoQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (giq *GroupInfoQuery) Order(o ...groupinfo.Order) *GroupInfoQuery {
+func (giq *GroupInfoQuery) Order(o ...groupinfo.OrderOption) *GroupInfoQuery {
 	giq.order = append(giq.order, o...)
 	return giq
 }
@@ -267,7 +267,7 @@ func (giq *GroupInfoQuery) Clone() *GroupInfoQuery {
 	return &GroupInfoQuery{
 		config:     giq.config,
 		ctx:        giq.ctx.Clone(),
-		order:      append([]groupinfo.Order{}, giq.order...),
+		order:      append([]groupinfo.OrderOption{}, giq.order...),
 		inters:     append([]Interceptor{}, giq.inters...),
 		predicates: append([]predicate.GroupInfo{}, giq.predicates...),
 		withGroups: giq.withGroups.Clone(),

--- a/entc/integration/gremlin/ent/item/item.go
+++ b/entc/integration/gremlin/ent/item/item.go
@@ -28,7 +28,7 @@ var (
 	IDValidator func(string) error
 )
 
-// Order defines the ordering method for the Item queries.
-type Order func(*dsl.Traversal)
+// OrderOption defines the ordering options for the Item queries.
+type OrderOption func(*dsl.Traversal)
 
 // comment from another template.

--- a/entc/integration/gremlin/ent/item_query.go
+++ b/entc/integration/gremlin/ent/item_query.go
@@ -23,7 +23,7 @@ import (
 type ItemQuery struct {
 	config
 	ctx        *QueryContext
-	order      []item.Order
+	order      []item.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Item
 	// intermediate query (i.e. traversal path).
@@ -57,7 +57,7 @@ func (iq *ItemQuery) Unique(unique bool) *ItemQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (iq *ItemQuery) Order(o ...item.Order) *ItemQuery {
+func (iq *ItemQuery) Order(o ...item.OrderOption) *ItemQuery {
 	iq.order = append(iq.order, o...)
 	return iq
 }
@@ -251,7 +251,7 @@ func (iq *ItemQuery) Clone() *ItemQuery {
 	return &ItemQuery{
 		config:     iq.config,
 		ctx:        iq.ctx.Clone(),
-		order:      append([]item.Order{}, iq.order...),
+		order:      append([]item.OrderOption{}, iq.order...),
 		inters:     append([]Interceptor{}, iq.inters...),
 		predicates: append([]predicate.Item{}, iq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/gremlin/ent/license/license.go
+++ b/entc/integration/gremlin/ent/license/license.go
@@ -32,7 +32,7 @@ var (
 	UpdateDefaultUpdateTime func() time.Time
 )
 
-// Order defines the ordering method for the License queries.
-type Order func(*dsl.Traversal)
+// OrderOption defines the ordering options for the License queries.
+type OrderOption func(*dsl.Traversal)
 
 // comment from another template.

--- a/entc/integration/gremlin/ent/license_query.go
+++ b/entc/integration/gremlin/ent/license_query.go
@@ -23,7 +23,7 @@ import (
 type LicenseQuery struct {
 	config
 	ctx        *QueryContext
-	order      []license.Order
+	order      []license.OrderOption
 	inters     []Interceptor
 	predicates []predicate.License
 	// intermediate query (i.e. traversal path).
@@ -57,7 +57,7 @@ func (lq *LicenseQuery) Unique(unique bool) *LicenseQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (lq *LicenseQuery) Order(o ...license.Order) *LicenseQuery {
+func (lq *LicenseQuery) Order(o ...license.OrderOption) *LicenseQuery {
 	lq.order = append(lq.order, o...)
 	return lq
 }
@@ -251,7 +251,7 @@ func (lq *LicenseQuery) Clone() *LicenseQuery {
 	return &LicenseQuery{
 		config:     lq.config,
 		ctx:        lq.ctx.Clone(),
-		order:      append([]license.Order{}, lq.order...),
+		order:      append([]license.OrderOption{}, lq.order...),
 		inters:     append([]Interceptor{}, lq.inters...),
 		predicates: append([]predicate.License{}, lq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/gremlin/ent/mutation.go
+++ b/entc/integration/gremlin/ent/mutation.go
@@ -14097,19 +14097,23 @@ func (m *SpecMutation) ResetEdge(name string) error {
 // TaskMutation represents an operation that mutates the Task nodes in the graph.
 type TaskMutation struct {
 	config
-	op            Op
-	typ           string
-	id            *string
-	priority      *task.Priority
-	addpriority   *task.Priority
-	priorities    *map[string]task.Priority
-	created_at    *time.Time
-	name          *string
-	owner         *string
-	clearedFields map[string]struct{}
-	done          bool
-	oldValue      func(context.Context) (*Task, error)
-	predicates    []predicate.Task
+	op              Op
+	typ             string
+	id              *string
+	priority        *task.Priority
+	addpriority     *task.Priority
+	priorities      *map[string]task.Priority
+	created_at      *time.Time
+	name            *string
+	owner           *string
+	_order          *int
+	add_order       *int
+	order_option    *int
+	addorder_option *int
+	clearedFields   map[string]struct{}
+	done            bool
+	oldValue        func(context.Context) (*Task, error)
+	predicates      []predicate.Task
 }
 
 var _ ent.Mutation = (*TaskMutation)(nil)
@@ -14449,6 +14453,146 @@ func (m *TaskMutation) ResetOwner() {
 	delete(m.clearedFields, enttask.FieldOwner)
 }
 
+// SetOrder sets the "order" field.
+func (m *TaskMutation) SetOrder(i int) {
+	m._order = &i
+	m.add_order = nil
+}
+
+// Order returns the value of the "order" field in the mutation.
+func (m *TaskMutation) Order() (r int, exists bool) {
+	v := m._order
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldOrder returns the old "order" field's value of the Task entity.
+// If the Task object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *TaskMutation) OldOrder(ctx context.Context) (v int, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldOrder is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldOrder requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldOrder: %w", err)
+	}
+	return oldValue.Order, nil
+}
+
+// AddOrder adds i to the "order" field.
+func (m *TaskMutation) AddOrder(i int) {
+	if m.add_order != nil {
+		*m.add_order += i
+	} else {
+		m.add_order = &i
+	}
+}
+
+// AddedOrder returns the value that was added to the "order" field in this mutation.
+func (m *TaskMutation) AddedOrder() (r int, exists bool) {
+	v := m.add_order
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ClearOrder clears the value of the "order" field.
+func (m *TaskMutation) ClearOrder() {
+	m._order = nil
+	m.add_order = nil
+	m.clearedFields[enttask.FieldOrder] = struct{}{}
+}
+
+// OrderCleared returns if the "order" field was cleared in this mutation.
+func (m *TaskMutation) OrderCleared() bool {
+	_, ok := m.clearedFields[enttask.FieldOrder]
+	return ok
+}
+
+// ResetOrder resets all changes to the "order" field.
+func (m *TaskMutation) ResetOrder() {
+	m._order = nil
+	m.add_order = nil
+	delete(m.clearedFields, enttask.FieldOrder)
+}
+
+// SetOrderOption sets the "order_option" field.
+func (m *TaskMutation) SetOrderOption(i int) {
+	m.order_option = &i
+	m.addorder_option = nil
+}
+
+// OrderOption returns the value of the "order_option" field in the mutation.
+func (m *TaskMutation) OrderOption() (r int, exists bool) {
+	v := m.order_option
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldOrderOption returns the old "order_option" field's value of the Task entity.
+// If the Task object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *TaskMutation) OldOrderOption(ctx context.Context) (v int, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldOrderOption is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldOrderOption requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldOrderOption: %w", err)
+	}
+	return oldValue.OrderOption, nil
+}
+
+// AddOrderOption adds i to the "order_option" field.
+func (m *TaskMutation) AddOrderOption(i int) {
+	if m.addorder_option != nil {
+		*m.addorder_option += i
+	} else {
+		m.addorder_option = &i
+	}
+}
+
+// AddedOrderOption returns the value that was added to the "order_option" field in this mutation.
+func (m *TaskMutation) AddedOrderOption() (r int, exists bool) {
+	v := m.addorder_option
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ClearOrderOption clears the value of the "order_option" field.
+func (m *TaskMutation) ClearOrderOption() {
+	m.order_option = nil
+	m.addorder_option = nil
+	m.clearedFields[enttask.FieldOrderOption] = struct{}{}
+}
+
+// OrderOptionCleared returns if the "order_option" field was cleared in this mutation.
+func (m *TaskMutation) OrderOptionCleared() bool {
+	_, ok := m.clearedFields[enttask.FieldOrderOption]
+	return ok
+}
+
+// ResetOrderOption resets all changes to the "order_option" field.
+func (m *TaskMutation) ResetOrderOption() {
+	m.order_option = nil
+	m.addorder_option = nil
+	delete(m.clearedFields, enttask.FieldOrderOption)
+}
+
 // Where appends a list predicates to the TaskMutation builder.
 func (m *TaskMutation) Where(ps ...predicate.Task) {
 	m.predicates = append(m.predicates, ps...)
@@ -14483,7 +14627,7 @@ func (m *TaskMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *TaskMutation) Fields() []string {
-	fields := make([]string, 0, 5)
+	fields := make([]string, 0, 7)
 	if m.priority != nil {
 		fields = append(fields, enttask.FieldPriority)
 	}
@@ -14498,6 +14642,12 @@ func (m *TaskMutation) Fields() []string {
 	}
 	if m.owner != nil {
 		fields = append(fields, enttask.FieldOwner)
+	}
+	if m._order != nil {
+		fields = append(fields, enttask.FieldOrder)
+	}
+	if m.order_option != nil {
+		fields = append(fields, enttask.FieldOrderOption)
 	}
 	return fields
 }
@@ -14517,6 +14667,10 @@ func (m *TaskMutation) Field(name string) (ent.Value, bool) {
 		return m.Name()
 	case enttask.FieldOwner:
 		return m.Owner()
+	case enttask.FieldOrder:
+		return m.Order()
+	case enttask.FieldOrderOption:
+		return m.OrderOption()
 	}
 	return nil, false
 }
@@ -14536,6 +14690,10 @@ func (m *TaskMutation) OldField(ctx context.Context, name string) (ent.Value, er
 		return m.OldName(ctx)
 	case enttask.FieldOwner:
 		return m.OldOwner(ctx)
+	case enttask.FieldOrder:
+		return m.OldOrder(ctx)
+	case enttask.FieldOrderOption:
+		return m.OldOrderOption(ctx)
 	}
 	return nil, fmt.Errorf("unknown Task field %s", name)
 }
@@ -14580,6 +14738,20 @@ func (m *TaskMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetOwner(v)
 		return nil
+	case enttask.FieldOrder:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetOrder(v)
+		return nil
+	case enttask.FieldOrderOption:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetOrderOption(v)
+		return nil
 	}
 	return fmt.Errorf("unknown Task field %s", name)
 }
@@ -14591,6 +14763,12 @@ func (m *TaskMutation) AddedFields() []string {
 	if m.addpriority != nil {
 		fields = append(fields, enttask.FieldPriority)
 	}
+	if m.add_order != nil {
+		fields = append(fields, enttask.FieldOrder)
+	}
+	if m.addorder_option != nil {
+		fields = append(fields, enttask.FieldOrderOption)
+	}
 	return fields
 }
 
@@ -14601,6 +14779,10 @@ func (m *TaskMutation) AddedField(name string) (ent.Value, bool) {
 	switch name {
 	case enttask.FieldPriority:
 		return m.AddedPriority()
+	case enttask.FieldOrder:
+		return m.AddedOrder()
+	case enttask.FieldOrderOption:
+		return m.AddedOrderOption()
 	}
 	return nil, false
 }
@@ -14616,6 +14798,20 @@ func (m *TaskMutation) AddField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.AddPriority(v)
+		return nil
+	case enttask.FieldOrder:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddOrder(v)
+		return nil
+	case enttask.FieldOrderOption:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddOrderOption(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Task numeric field %s", name)
@@ -14633,6 +14829,12 @@ func (m *TaskMutation) ClearedFields() []string {
 	}
 	if m.FieldCleared(enttask.FieldOwner) {
 		fields = append(fields, enttask.FieldOwner)
+	}
+	if m.FieldCleared(enttask.FieldOrder) {
+		fields = append(fields, enttask.FieldOrder)
+	}
+	if m.FieldCleared(enttask.FieldOrderOption) {
+		fields = append(fields, enttask.FieldOrderOption)
 	}
 	return fields
 }
@@ -14657,6 +14859,12 @@ func (m *TaskMutation) ClearField(name string) error {
 	case enttask.FieldOwner:
 		m.ClearOwner()
 		return nil
+	case enttask.FieldOrder:
+		m.ClearOrder()
+		return nil
+	case enttask.FieldOrderOption:
+		m.ClearOrderOption()
+		return nil
 	}
 	return fmt.Errorf("unknown Task nullable field %s", name)
 }
@@ -14679,6 +14887,12 @@ func (m *TaskMutation) ResetField(name string) error {
 		return nil
 	case enttask.FieldOwner:
 		m.ResetOwner()
+		return nil
+	case enttask.FieldOrder:
+		m.ResetOrder()
+		return nil
+	case enttask.FieldOrderOption:
+		m.ResetOrderOption()
 		return nil
 	}
 	return fmt.Errorf("unknown Task field %s", name)

--- a/entc/integration/gremlin/ent/node/node.go
+++ b/entc/integration/gremlin/ent/node/node.go
@@ -36,7 +36,7 @@ var (
 	UpdateDefaultUpdatedAt func() time.Time
 )
 
-// Order defines the ordering method for the Node queries.
-type Order func(*dsl.Traversal)
+// OrderOption defines the ordering options for the Node queries.
+type OrderOption func(*dsl.Traversal)
 
 // comment from another template.

--- a/entc/integration/gremlin/ent/node_query.go
+++ b/entc/integration/gremlin/ent/node_query.go
@@ -23,7 +23,7 @@ import (
 type NodeQuery struct {
 	config
 	ctx        *QueryContext
-	order      []node.Order
+	order      []node.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Node
 	withPrev   *NodeQuery
@@ -59,7 +59,7 @@ func (nq *NodeQuery) Unique(unique bool) *NodeQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (nq *NodeQuery) Order(o ...node.Order) *NodeQuery {
+func (nq *NodeQuery) Order(o ...node.OrderOption) *NodeQuery {
 	nq.order = append(nq.order, o...)
 	return nq
 }
@@ -281,7 +281,7 @@ func (nq *NodeQuery) Clone() *NodeQuery {
 	return &NodeQuery{
 		config:     nq.config,
 		ctx:        nq.ctx.Clone(),
-		order:      append([]node.Order{}, nq.order...),
+		order:      append([]node.OrderOption{}, nq.order...),
 		inters:     append([]Interceptor{}, nq.inters...),
 		predicates: append([]predicate.Node{}, nq.predicates...),
 		withPrev:   nq.withPrev.Clone(),

--- a/entc/integration/gremlin/ent/pet/pet.go
+++ b/entc/integration/gremlin/ent/pet/pet.go
@@ -42,7 +42,7 @@ var (
 	DefaultTrained bool
 )
 
-// Order defines the ordering method for the Pet queries.
-type Order func(*dsl.Traversal)
+// OrderOption defines the ordering options for the Pet queries.
+type OrderOption func(*dsl.Traversal)
 
 // comment from another template.

--- a/entc/integration/gremlin/ent/pet_query.go
+++ b/entc/integration/gremlin/ent/pet_query.go
@@ -24,7 +24,7 @@ import (
 type PetQuery struct {
 	config
 	ctx        *QueryContext
-	order      []pet.Order
+	order      []pet.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Pet
 	withTeam   *UserQuery
@@ -60,7 +60,7 @@ func (pq *PetQuery) Unique(unique bool) *PetQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (pq *PetQuery) Order(o ...pet.Order) *PetQuery {
+func (pq *PetQuery) Order(o ...pet.OrderOption) *PetQuery {
 	pq.order = append(pq.order, o...)
 	return pq
 }
@@ -282,7 +282,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 	return &PetQuery{
 		config:     pq.config,
 		ctx:        pq.ctx.Clone(),
-		order:      append([]pet.Order{}, pq.order...),
+		order:      append([]pet.OrderOption{}, pq.order...),
 		inters:     append([]Interceptor{}, pq.inters...),
 		predicates: append([]predicate.Pet{}, pq.predicates...),
 		withTeam:   pq.withTeam.Clone(),

--- a/entc/integration/gremlin/ent/spec/spec.go
+++ b/entc/integration/gremlin/ent/spec/spec.go
@@ -21,7 +21,7 @@ const (
 	CardLabel = "spec_card"
 )
 
-// Order defines the ordering method for the Spec queries.
-type Order func(*dsl.Traversal)
+// OrderOption defines the ordering options for the Spec queries.
+type OrderOption func(*dsl.Traversal)
 
 // comment from another template.

--- a/entc/integration/gremlin/ent/spec_query.go
+++ b/entc/integration/gremlin/ent/spec_query.go
@@ -23,7 +23,7 @@ import (
 type SpecQuery struct {
 	config
 	ctx        *QueryContext
-	order      []spec.Order
+	order      []spec.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Spec
 	withCard   *CardQuery
@@ -58,7 +58,7 @@ func (sq *SpecQuery) Unique(unique bool) *SpecQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (sq *SpecQuery) Order(o ...spec.Order) *SpecQuery {
+func (sq *SpecQuery) Order(o ...spec.OrderOption) *SpecQuery {
 	sq.order = append(sq.order, o...)
 	return sq
 }
@@ -266,7 +266,7 @@ func (sq *SpecQuery) Clone() *SpecQuery {
 	return &SpecQuery{
 		config:     sq.config,
 		ctx:        sq.ctx.Clone(),
-		order:      append([]spec.Order{}, sq.order...),
+		order:      append([]spec.OrderOption{}, sq.order...),
 		inters:     append([]Interceptor{}, sq.inters...),
 		predicates: append([]predicate.Spec{}, sq.predicates...),
 		withCard:   sq.withCard.Clone(),

--- a/entc/integration/gremlin/ent/task.go
+++ b/entc/integration/gremlin/ent/task.go
@@ -30,6 +30,10 @@ type Task struct {
 	Name string `json:"name,omitempty"`
 	// Owner holds the value of the "owner" field.
 	Owner string `json:"owner,omitempty"`
+	// Order holds the value of the "order" field.
+	Order int `json:"order,omitempty"`
+	// OrderOption holds the value of the "order_option" field.
+	OrderOption int `json:"order_option,omitempty"`
 }
 
 // FromResponse scans the gremlin response data into Task.
@@ -39,12 +43,14 @@ func (t *Task) FromResponse(res *gremlin.Response) error {
 		return err
 	}
 	var scant struct {
-		ID         string                   `json:"id,omitempty"`
-		Priority   task.Priority            `json:"priority,omitempty"`
-		Priorities map[string]task.Priority `json:"priorities,omitempty"`
-		CreatedAt  int64                    `json:"created_at,omitempty"`
-		Name       string                   `json:"name,omitempty"`
-		Owner      string                   `json:"owner,omitempty"`
+		ID          string                   `json:"id,omitempty"`
+		Priority    task.Priority            `json:"priority,omitempty"`
+		Priorities  map[string]task.Priority `json:"priorities,omitempty"`
+		CreatedAt   int64                    `json:"created_at,omitempty"`
+		Name        string                   `json:"name,omitempty"`
+		Owner       string                   `json:"owner,omitempty"`
+		Order       int                      `json:"order,omitempty"`
+		OrderOption int                      `json:"order_option,omitempty"`
 	}
 	if err := vmap.Decode(&scant); err != nil {
 		return err
@@ -56,6 +62,8 @@ func (t *Task) FromResponse(res *gremlin.Response) error {
 	t.CreatedAt = &v2
 	t.Name = scant.Name
 	t.Owner = scant.Owner
+	t.Order = scant.Order
+	t.OrderOption = scant.OrderOption
 	return nil
 }
 
@@ -98,6 +106,12 @@ func (t *Task) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("owner=")
 	builder.WriteString(t.Owner)
+	builder.WriteString(", ")
+	builder.WriteString("order=")
+	builder.WriteString(fmt.Sprintf("%v", t.Order))
+	builder.WriteString(", ")
+	builder.WriteString("order_option=")
+	builder.WriteString(fmt.Sprintf("%v", t.OrderOption))
 	builder.WriteByte(')')
 	return builder.String()
 }
@@ -112,12 +126,14 @@ func (t *Tasks) FromResponse(res *gremlin.Response) error {
 		return err
 	}
 	var scant []struct {
-		ID         string                   `json:"id,omitempty"`
-		Priority   task.Priority            `json:"priority,omitempty"`
-		Priorities map[string]task.Priority `json:"priorities,omitempty"`
-		CreatedAt  int64                    `json:"created_at,omitempty"`
-		Name       string                   `json:"name,omitempty"`
-		Owner      string                   `json:"owner,omitempty"`
+		ID          string                   `json:"id,omitempty"`
+		Priority    task.Priority            `json:"priority,omitempty"`
+		Priorities  map[string]task.Priority `json:"priorities,omitempty"`
+		CreatedAt   int64                    `json:"created_at,omitempty"`
+		Name        string                   `json:"name,omitempty"`
+		Owner       string                   `json:"owner,omitempty"`
+		Order       int                      `json:"order,omitempty"`
+		OrderOption int                      `json:"order_option,omitempty"`
 	}
 	if err := vmap.Decode(&scant); err != nil {
 		return err
@@ -130,6 +146,8 @@ func (t *Tasks) FromResponse(res *gremlin.Response) error {
 		node.CreatedAt = &v2
 		node.Name = v.Name
 		node.Owner = v.Owner
+		node.Order = v.Order
+		node.OrderOption = v.OrderOption
 		*t = append(*t, node)
 	}
 	return nil

--- a/entc/integration/gremlin/ent/task/task.go
+++ b/entc/integration/gremlin/ent/task/task.go
@@ -28,6 +28,10 @@ const (
 	FieldName = "name"
 	// FieldOwner holds the string denoting the owner field in the database.
 	FieldOwner = "owner"
+	// FieldOrder holds the string denoting the order field in the database.
+	FieldOrder = "order"
+	// FieldOrderOption holds the string denoting the order_option field in the database.
+	FieldOrderOption = "order_option"
 )
 
 var (
@@ -37,7 +41,7 @@ var (
 	DefaultCreatedAt func() time.Time
 )
 
-// Order defines the ordering method for the Task queries.
-type Order func(*dsl.Traversal)
+// OrderOption defines the ordering options for the Task queries.
+type OrderOption func(*dsl.Traversal)
 
 // comment from another template.

--- a/entc/integration/gremlin/ent/task/where.go
+++ b/entc/integration/gremlin/ent/task/where.go
@@ -116,6 +116,13 @@ func Owner(v string) predicate.Task {
 	})
 }
 
+// Order applies equality check predicate on the "order" field. It's identical to OrderEQ.
+func Order(v int) predicate.Task {
+	return predicate.Task(func(t *dsl.Traversal) {
+		t.Has(Label, FieldOrder, p.EQ(v))
+	})
+}
+
 // PriorityEQ applies the EQ predicate on the "priority" field.
 func PriorityEQ(v task.Priority) predicate.Task {
 	vc := int(v)
@@ -435,6 +442,146 @@ func OwnerIsNil() predicate.Task {
 func OwnerNotNil() predicate.Task {
 	return predicate.Task(func(t *dsl.Traversal) {
 		t.HasLabel(Label).Has(FieldOwner)
+	})
+}
+
+// OrderEQ applies the EQ predicate on the "order" field.
+func OrderEQ(v int) predicate.Task {
+	return predicate.Task(func(t *dsl.Traversal) {
+		t.Has(Label, FieldOrder, p.EQ(v))
+	})
+}
+
+// OrderNEQ applies the NEQ predicate on the "order" field.
+func OrderNEQ(v int) predicate.Task {
+	return predicate.Task(func(t *dsl.Traversal) {
+		t.Has(Label, FieldOrder, p.NEQ(v))
+	})
+}
+
+// OrderIn applies the In predicate on the "order" field.
+func OrderIn(vs ...int) predicate.Task {
+	return predicate.Task(func(t *dsl.Traversal) {
+		t.Has(Label, FieldOrder, p.Within(vs...))
+	})
+}
+
+// OrderNotIn applies the NotIn predicate on the "order" field.
+func OrderNotIn(vs ...int) predicate.Task {
+	return predicate.Task(func(t *dsl.Traversal) {
+		t.Has(Label, FieldOrder, p.Without(vs...))
+	})
+}
+
+// OrderGT applies the GT predicate on the "order" field.
+func OrderGT(v int) predicate.Task {
+	return predicate.Task(func(t *dsl.Traversal) {
+		t.Has(Label, FieldOrder, p.GT(v))
+	})
+}
+
+// OrderGTE applies the GTE predicate on the "order" field.
+func OrderGTE(v int) predicate.Task {
+	return predicate.Task(func(t *dsl.Traversal) {
+		t.Has(Label, FieldOrder, p.GTE(v))
+	})
+}
+
+// OrderLT applies the LT predicate on the "order" field.
+func OrderLT(v int) predicate.Task {
+	return predicate.Task(func(t *dsl.Traversal) {
+		t.Has(Label, FieldOrder, p.LT(v))
+	})
+}
+
+// OrderLTE applies the LTE predicate on the "order" field.
+func OrderLTE(v int) predicate.Task {
+	return predicate.Task(func(t *dsl.Traversal) {
+		t.Has(Label, FieldOrder, p.LTE(v))
+	})
+}
+
+// OrderIsNil applies the IsNil predicate on the "order" field.
+func OrderIsNil() predicate.Task {
+	return predicate.Task(func(t *dsl.Traversal) {
+		t.HasLabel(Label).HasNot(FieldOrder)
+	})
+}
+
+// OrderNotNil applies the NotNil predicate on the "order" field.
+func OrderNotNil() predicate.Task {
+	return predicate.Task(func(t *dsl.Traversal) {
+		t.HasLabel(Label).Has(FieldOrder)
+	})
+}
+
+// OrderOptionEQ applies the EQ predicate on the "order_option" field.
+func OrderOptionEQ(v int) predicate.Task {
+	return predicate.Task(func(t *dsl.Traversal) {
+		t.Has(Label, FieldOrderOption, p.EQ(v))
+	})
+}
+
+// OrderOptionNEQ applies the NEQ predicate on the "order_option" field.
+func OrderOptionNEQ(v int) predicate.Task {
+	return predicate.Task(func(t *dsl.Traversal) {
+		t.Has(Label, FieldOrderOption, p.NEQ(v))
+	})
+}
+
+// OrderOptionIn applies the In predicate on the "order_option" field.
+func OrderOptionIn(vs ...int) predicate.Task {
+	return predicate.Task(func(t *dsl.Traversal) {
+		t.Has(Label, FieldOrderOption, p.Within(vs...))
+	})
+}
+
+// OrderOptionNotIn applies the NotIn predicate on the "order_option" field.
+func OrderOptionNotIn(vs ...int) predicate.Task {
+	return predicate.Task(func(t *dsl.Traversal) {
+		t.Has(Label, FieldOrderOption, p.Without(vs...))
+	})
+}
+
+// OrderOptionGT applies the GT predicate on the "order_option" field.
+func OrderOptionGT(v int) predicate.Task {
+	return predicate.Task(func(t *dsl.Traversal) {
+		t.Has(Label, FieldOrderOption, p.GT(v))
+	})
+}
+
+// OrderOptionGTE applies the GTE predicate on the "order_option" field.
+func OrderOptionGTE(v int) predicate.Task {
+	return predicate.Task(func(t *dsl.Traversal) {
+		t.Has(Label, FieldOrderOption, p.GTE(v))
+	})
+}
+
+// OrderOptionLT applies the LT predicate on the "order_option" field.
+func OrderOptionLT(v int) predicate.Task {
+	return predicate.Task(func(t *dsl.Traversal) {
+		t.Has(Label, FieldOrderOption, p.LT(v))
+	})
+}
+
+// OrderOptionLTE applies the LTE predicate on the "order_option" field.
+func OrderOptionLTE(v int) predicate.Task {
+	return predicate.Task(func(t *dsl.Traversal) {
+		t.Has(Label, FieldOrderOption, p.LTE(v))
+	})
+}
+
+// OrderOptionIsNil applies the IsNil predicate on the "order_option" field.
+func OrderOptionIsNil() predicate.Task {
+	return predicate.Task(func(t *dsl.Traversal) {
+		t.HasLabel(Label).HasNot(FieldOrderOption)
+	})
+}
+
+// OrderOptionNotNil applies the NotNil predicate on the "order_option" field.
+func OrderOptionNotNil() predicate.Task {
+	return predicate.Task(func(t *dsl.Traversal) {
+		t.HasLabel(Label).Has(FieldOrderOption)
 	})
 }
 

--- a/entc/integration/gremlin/ent/task_create.go
+++ b/entc/integration/gremlin/ent/task_create.go
@@ -88,6 +88,34 @@ func (tc *TaskCreate) SetNillableOwner(s *string) *TaskCreate {
 	return tc
 }
 
+// SetOrder sets the "order" field.
+func (tc *TaskCreate) SetOrder(i int) *TaskCreate {
+	tc.mutation.SetOrder(i)
+	return tc
+}
+
+// SetNillableOrder sets the "order" field if the given value is not nil.
+func (tc *TaskCreate) SetNillableOrder(i *int) *TaskCreate {
+	if i != nil {
+		tc.SetOrder(*i)
+	}
+	return tc
+}
+
+// SetOrderOption sets the "order_option" field.
+func (tc *TaskCreate) SetOrderOption(i int) *TaskCreate {
+	tc.mutation.SetOrderOption(i)
+	return tc
+}
+
+// SetNillableOrderOption sets the "order_option" field if the given value is not nil.
+func (tc *TaskCreate) SetNillableOrderOption(i *int) *TaskCreate {
+	if i != nil {
+		tc.SetOrderOption(*i)
+	}
+	return tc
+}
+
 // Mutation returns the TaskMutation object of the builder.
 func (tc *TaskCreate) Mutation() *TaskMutation {
 	return tc.mutation
@@ -186,6 +214,12 @@ func (tc *TaskCreate) gremlin() *dsl.Traversal {
 	}
 	if value, ok := tc.mutation.Owner(); ok {
 		v.Property(dsl.Single, enttask.FieldOwner, value)
+	}
+	if value, ok := tc.mutation.Order(); ok {
+		v.Property(dsl.Single, enttask.FieldOrder, value)
+	}
+	if value, ok := tc.mutation.OrderOption(); ok {
+		v.Property(dsl.Single, enttask.FieldOrderOption, value)
 	}
 	return v.ValueMap(true)
 }

--- a/entc/integration/gremlin/ent/task_query.go
+++ b/entc/integration/gremlin/ent/task_query.go
@@ -23,7 +23,7 @@ import (
 type TaskQuery struct {
 	config
 	ctx        *QueryContext
-	order      []enttask.Order
+	order      []enttask.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Task
 	// intermediate query (i.e. traversal path).
@@ -57,7 +57,7 @@ func (tq *TaskQuery) Unique(unique bool) *TaskQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (tq *TaskQuery) Order(o ...enttask.Order) *TaskQuery {
+func (tq *TaskQuery) Order(o ...enttask.OrderOption) *TaskQuery {
 	tq.order = append(tq.order, o...)
 	return tq
 }
@@ -251,7 +251,7 @@ func (tq *TaskQuery) Clone() *TaskQuery {
 	return &TaskQuery{
 		config:     tq.config,
 		ctx:        tq.ctx.Clone(),
-		order:      append([]enttask.Order{}, tq.order...),
+		order:      append([]enttask.OrderOption{}, tq.order...),
 		inters:     append([]Interceptor{}, tq.inters...),
 		predicates: append([]predicate.Task{}, tq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/gremlin/ent/task_update.go
+++ b/entc/integration/gremlin/ent/task_update.go
@@ -105,6 +105,60 @@ func (tu *TaskUpdate) ClearOwner() *TaskUpdate {
 	return tu
 }
 
+// SetOrder sets the "order" field.
+func (tu *TaskUpdate) SetOrder(i int) *TaskUpdate {
+	tu.mutation.ResetOrder()
+	tu.mutation.SetOrder(i)
+	return tu
+}
+
+// SetNillableOrder sets the "order" field if the given value is not nil.
+func (tu *TaskUpdate) SetNillableOrder(i *int) *TaskUpdate {
+	if i != nil {
+		tu.SetOrder(*i)
+	}
+	return tu
+}
+
+// AddOrder adds i to the "order" field.
+func (tu *TaskUpdate) AddOrder(i int) *TaskUpdate {
+	tu.mutation.AddOrder(i)
+	return tu
+}
+
+// ClearOrder clears the value of the "order" field.
+func (tu *TaskUpdate) ClearOrder() *TaskUpdate {
+	tu.mutation.ClearOrder()
+	return tu
+}
+
+// SetOrderOption sets the "order_option" field.
+func (tu *TaskUpdate) SetOrderOption(i int) *TaskUpdate {
+	tu.mutation.ResetOrderOption()
+	tu.mutation.SetOrderOption(i)
+	return tu
+}
+
+// SetNillableOrderOption sets the "order_option" field if the given value is not nil.
+func (tu *TaskUpdate) SetNillableOrderOption(i *int) *TaskUpdate {
+	if i != nil {
+		tu.SetOrderOption(*i)
+	}
+	return tu
+}
+
+// AddOrderOption adds i to the "order_option" field.
+func (tu *TaskUpdate) AddOrderOption(i int) *TaskUpdate {
+	tu.mutation.AddOrderOption(i)
+	return tu
+}
+
+// ClearOrderOption clears the value of the "order_option" field.
+func (tu *TaskUpdate) ClearOrderOption() *TaskUpdate {
+	tu.mutation.ClearOrderOption()
+	return tu
+}
+
 // Mutation returns the TaskMutation object of the builder.
 func (tu *TaskUpdate) Mutation() *TaskMutation {
 	return tu.mutation
@@ -173,6 +227,18 @@ func (tu *TaskUpdate) gremlin() *dsl.Traversal {
 	if value, ok := tu.mutation.Owner(); ok {
 		v.Property(dsl.Single, enttask.FieldOwner, value)
 	}
+	if value, ok := tu.mutation.Order(); ok {
+		v.Property(dsl.Single, enttask.FieldOrder, value)
+	}
+	if value, ok := tu.mutation.AddedOrder(); ok {
+		v.Property(dsl.Single, enttask.FieldOrder, __.Union(__.Values(enttask.FieldOrder), __.Constant(value)).Sum())
+	}
+	if value, ok := tu.mutation.OrderOption(); ok {
+		v.Property(dsl.Single, enttask.FieldOrderOption, value)
+	}
+	if value, ok := tu.mutation.AddedOrderOption(); ok {
+		v.Property(dsl.Single, enttask.FieldOrderOption, __.Union(__.Values(enttask.FieldOrderOption), __.Constant(value)).Sum())
+	}
 	var properties []any
 	if tu.mutation.PrioritiesCleared() {
 		properties = append(properties, enttask.FieldPriorities)
@@ -182,6 +248,12 @@ func (tu *TaskUpdate) gremlin() *dsl.Traversal {
 	}
 	if tu.mutation.OwnerCleared() {
 		properties = append(properties, enttask.FieldOwner)
+	}
+	if tu.mutation.OrderCleared() {
+		properties = append(properties, enttask.FieldOrder)
+	}
+	if tu.mutation.OrderOptionCleared() {
+		properties = append(properties, enttask.FieldOrderOption)
 	}
 	if len(properties) > 0 {
 		v.SideEffect(__.Properties(properties...).Drop())
@@ -272,6 +344,60 @@ func (tuo *TaskUpdateOne) ClearOwner() *TaskUpdateOne {
 	return tuo
 }
 
+// SetOrder sets the "order" field.
+func (tuo *TaskUpdateOne) SetOrder(i int) *TaskUpdateOne {
+	tuo.mutation.ResetOrder()
+	tuo.mutation.SetOrder(i)
+	return tuo
+}
+
+// SetNillableOrder sets the "order" field if the given value is not nil.
+func (tuo *TaskUpdateOne) SetNillableOrder(i *int) *TaskUpdateOne {
+	if i != nil {
+		tuo.SetOrder(*i)
+	}
+	return tuo
+}
+
+// AddOrder adds i to the "order" field.
+func (tuo *TaskUpdateOne) AddOrder(i int) *TaskUpdateOne {
+	tuo.mutation.AddOrder(i)
+	return tuo
+}
+
+// ClearOrder clears the value of the "order" field.
+func (tuo *TaskUpdateOne) ClearOrder() *TaskUpdateOne {
+	tuo.mutation.ClearOrder()
+	return tuo
+}
+
+// SetOrderOption sets the "order_option" field.
+func (tuo *TaskUpdateOne) SetOrderOption(i int) *TaskUpdateOne {
+	tuo.mutation.ResetOrderOption()
+	tuo.mutation.SetOrderOption(i)
+	return tuo
+}
+
+// SetNillableOrderOption sets the "order_option" field if the given value is not nil.
+func (tuo *TaskUpdateOne) SetNillableOrderOption(i *int) *TaskUpdateOne {
+	if i != nil {
+		tuo.SetOrderOption(*i)
+	}
+	return tuo
+}
+
+// AddOrderOption adds i to the "order_option" field.
+func (tuo *TaskUpdateOne) AddOrderOption(i int) *TaskUpdateOne {
+	tuo.mutation.AddOrderOption(i)
+	return tuo
+}
+
+// ClearOrderOption clears the value of the "order_option" field.
+func (tuo *TaskUpdateOne) ClearOrderOption() *TaskUpdateOne {
+	tuo.mutation.ClearOrderOption()
+	return tuo
+}
+
 // Mutation returns the TaskMutation object of the builder.
 func (tuo *TaskUpdateOne) Mutation() *TaskMutation {
 	return tuo.mutation
@@ -358,6 +484,18 @@ func (tuo *TaskUpdateOne) gremlin(id string) *dsl.Traversal {
 	if value, ok := tuo.mutation.Owner(); ok {
 		v.Property(dsl.Single, enttask.FieldOwner, value)
 	}
+	if value, ok := tuo.mutation.Order(); ok {
+		v.Property(dsl.Single, enttask.FieldOrder, value)
+	}
+	if value, ok := tuo.mutation.AddedOrder(); ok {
+		v.Property(dsl.Single, enttask.FieldOrder, __.Union(__.Values(enttask.FieldOrder), __.Constant(value)).Sum())
+	}
+	if value, ok := tuo.mutation.OrderOption(); ok {
+		v.Property(dsl.Single, enttask.FieldOrderOption, value)
+	}
+	if value, ok := tuo.mutation.AddedOrderOption(); ok {
+		v.Property(dsl.Single, enttask.FieldOrderOption, __.Union(__.Values(enttask.FieldOrderOption), __.Constant(value)).Sum())
+	}
 	var properties []any
 	if tuo.mutation.PrioritiesCleared() {
 		properties = append(properties, enttask.FieldPriorities)
@@ -367,6 +505,12 @@ func (tuo *TaskUpdateOne) gremlin(id string) *dsl.Traversal {
 	}
 	if tuo.mutation.OwnerCleared() {
 		properties = append(properties, enttask.FieldOwner)
+	}
+	if tuo.mutation.OrderCleared() {
+		properties = append(properties, enttask.FieldOrder)
+	}
+	if tuo.mutation.OrderOptionCleared() {
+		properties = append(properties, enttask.FieldOrderOption)
 	}
 	if len(properties) > 0 {
 		v.SideEffect(__.Properties(properties...).Drop())

--- a/entc/integration/gremlin/ent/user/user.go
+++ b/entc/integration/gremlin/ent/user/user.go
@@ -149,8 +149,8 @@ func EmploymentValidator(e Employment) error {
 	}
 }
 
-// Order defines the ordering method for the User queries.
-type Order func(*dsl.Traversal)
+// OrderOption defines the ordering options for the User queries.
+type OrderOption func(*dsl.Traversal)
 
 // Ptr returns a new pointer to the enum value.
 func (r Role) Ptr() *Role {

--- a/entc/integration/gremlin/ent/user_query.go
+++ b/entc/integration/gremlin/ent/user_query.go
@@ -23,7 +23,7 @@ import (
 type UserQuery struct {
 	config
 	ctx           *QueryContext
-	order         []user.Order
+	order         []user.OrderOption
 	inters        []Interceptor
 	predicates    []predicate.User
 	withCard      *CardQuery
@@ -68,7 +68,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
+func (uq *UserQuery) Order(o ...user.OrderOption) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -416,7 +416,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:        uq.config,
 		ctx:           uq.ctx.Clone(),
-		order:         append([]user.Order{}, uq.order...),
+		order:         append([]user.OrderOption{}, uq.order...),
 		inters:        append([]Interceptor{}, uq.inters...),
 		predicates:    append([]predicate.User{}, uq.predicates...),
 		withCard:      uq.withCard.Clone(),

--- a/entc/integration/hooks/ent/card/card.go
+++ b/entc/integration/hooks/ent/card/card.go
@@ -89,41 +89,41 @@ var (
 	DefaultCreatedAt func() time.Time
 )
 
-// Order defines the ordering method for the Card queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Card queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByNumber orders the results by the number field.
-func ByNumber(opts ...sql.OrderTermOption) Order {
+func ByNumber(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldNumber, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByCreatedAt orders the results by the created_at field.
-func ByCreatedAt(opts ...sql.OrderTermOption) Order {
+func ByCreatedAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCreatedAt, opts...).ToFunc()
 }
 
 // ByInHook orders the results by the in_hook field.
-func ByInHook(opts ...sql.OrderTermOption) Order {
+func ByInHook(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldInHook, opts...).ToFunc()
 }
 
 // ByExpiredAt orders the results by the expired_at field.
-func ByExpiredAt(opts ...sql.OrderTermOption) Order {
+func ByExpiredAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldExpiredAt, opts...).ToFunc()
 }
 
 // ByOwnerField orders the results by owner field.
-func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+func ByOwnerField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/hooks/ent/card_query.go
+++ b/entc/integration/hooks/ent/card_query.go
@@ -23,7 +23,7 @@ import (
 type CardQuery struct {
 	config
 	ctx        *QueryContext
-	order      []card.Order
+	order      []card.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Card
 	withOwner  *UserQuery
@@ -59,7 +59,7 @@ func (cq *CardQuery) Unique(unique bool) *CardQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *CardQuery) Order(o ...card.Order) *CardQuery {
+func (cq *CardQuery) Order(o ...card.OrderOption) *CardQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -275,7 +275,7 @@ func (cq *CardQuery) Clone() *CardQuery {
 	return &CardQuery{
 		config:     cq.config,
 		ctx:        cq.ctx.Clone(),
-		order:      append([]card.Order{}, cq.order...),
+		order:      append([]card.OrderOption{}, cq.order...),
 		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Card{}, cq.predicates...),
 		withOwner:  cq.withOwner.Clone(),

--- a/entc/integration/hooks/ent/intercept/intercept.go
+++ b/entc/integration/hooks/ent/intercept/intercept.go
@@ -159,11 +159,11 @@ func (f TraverseUser) Traverse(ctx context.Context, q ent.Query) error {
 func NewQuery(q ent.Query) (Query, error) {
 	switch q := q.(type) {
 	case *ent.CardQuery:
-		return &query[*ent.CardQuery, predicate.Card, card.Order]{typ: ent.TypeCard, tq: q}, nil
+		return &query[*ent.CardQuery, predicate.Card, card.OrderOption]{typ: ent.TypeCard, tq: q}, nil
 	case *ent.PetQuery:
-		return &query[*ent.PetQuery, predicate.Pet, pet.Order]{typ: ent.TypePet, tq: q}, nil
+		return &query[*ent.PetQuery, predicate.Pet, pet.OrderOption]{typ: ent.TypePet, tq: q}, nil
 	case *ent.UserQuery:
-		return &query[*ent.UserQuery, predicate.User, user.Order]{typ: ent.TypeUser, tq: q}, nil
+		return &query[*ent.UserQuery, predicate.User, user.OrderOption]{typ: ent.TypeUser, tq: q}, nil
 	default:
 		return nil, fmt.Errorf("unknown query type %T", q)
 	}

--- a/entc/integration/hooks/ent/pet/pet.go
+++ b/entc/integration/hooks/ent/pet/pet.go
@@ -72,26 +72,26 @@ var (
 	Interceptors [1]ent.Interceptor
 )
 
-// Order defines the ordering method for the Pet queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Pet queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByDeleteTime orders the results by the delete_time field.
-func ByDeleteTime(opts ...sql.OrderTermOption) Order {
+func ByDeleteTime(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDeleteTime, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByOwnerField orders the results by owner field.
-func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+func ByOwnerField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/hooks/ent/pet_query.go
+++ b/entc/integration/hooks/ent/pet_query.go
@@ -23,7 +23,7 @@ import (
 type PetQuery struct {
 	config
 	ctx        *QueryContext
-	order      []pet.Order
+	order      []pet.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Pet
 	withOwner  *UserQuery
@@ -59,7 +59,7 @@ func (pq *PetQuery) Unique(unique bool) *PetQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (pq *PetQuery) Order(o ...pet.Order) *PetQuery {
+func (pq *PetQuery) Order(o ...pet.OrderOption) *PetQuery {
 	pq.order = append(pq.order, o...)
 	return pq
 }
@@ -275,7 +275,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 	return &PetQuery{
 		config:     pq.config,
 		ctx:        pq.ctx.Clone(),
-		order:      append([]pet.Order{}, pq.order...),
+		order:      append([]pet.OrderOption{}, pq.order...),
 		inters:     append([]Interceptor{}, pq.inters...),
 		predicates: append([]predicate.Pet{}, pq.predicates...),
 		withOwner:  pq.withOwner.Clone(),

--- a/entc/integration/hooks/ent/user/user.go
+++ b/entc/integration/hooks/ent/user/user.go
@@ -109,83 +109,83 @@ var (
 	DefaultActive bool
 )
 
-// Order defines the ordering method for the User queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the User queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByVersion orders the results by the version field.
-func ByVersion(opts ...sql.OrderTermOption) Order {
+func ByVersion(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldVersion, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByWorth orders the results by the worth field.
-func ByWorth(opts ...sql.OrderTermOption) Order {
+func ByWorth(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldWorth, opts...).ToFunc()
 }
 
 // ByPassword orders the results by the password field.
-func ByPassword(opts ...sql.OrderTermOption) Order {
+func ByPassword(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldPassword, opts...).ToFunc()
 }
 
 // ByActive orders the results by the active field.
-func ByActive(opts ...sql.OrderTermOption) Order {
+func ByActive(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldActive, opts...).ToFunc()
 }
 
 // ByCardsCount orders the results by cards count.
-func ByCardsCount(opts ...sql.OrderTermOption) Order {
+func ByCardsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newCardsStep(), opts...)
 	}
 }
 
 // ByCards orders the results by cards terms.
-func ByCards(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByCards(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newCardsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByPetsCount orders the results by pets count.
-func ByPetsCount(opts ...sql.OrderTermOption) Order {
+func ByPetsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newPetsStep(), opts...)
 	}
 }
 
 // ByPets orders the results by pets terms.
-func ByPets(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByPets(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newPetsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByFriendsCount orders the results by friends count.
-func ByFriendsCount(opts ...sql.OrderTermOption) Order {
+func ByFriendsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newFriendsStep(), opts...)
 	}
 }
 
 // ByFriends orders the results by friends terms.
-func ByFriends(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByFriends(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newFriendsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByBestFriendField orders the results by best_friend field.
-func ByBestFriendField(field string, opts ...sql.OrderTermOption) Order {
+func ByBestFriendField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newBestFriendStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/hooks/ent/user_query.go
+++ b/entc/integration/hooks/ent/user_query.go
@@ -25,7 +25,7 @@ import (
 type UserQuery struct {
 	config
 	ctx            *QueryContext
-	order          []user.Order
+	order          []user.OrderOption
 	inters         []Interceptor
 	predicates     []predicate.User
 	withCards      *CardQuery
@@ -64,7 +64,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
+func (uq *UserQuery) Order(o ...user.OrderOption) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -346,7 +346,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:         uq.config,
 		ctx:            uq.ctx.Clone(),
-		order:          append([]user.Order{}, uq.order...),
+		order:          append([]user.OrderOption{}, uq.order...),
 		inters:         append([]Interceptor{}, uq.inters...),
 		predicates:     append([]predicate.User{}, uq.predicates...),
 		withCards:      uq.withCards.Clone(),

--- a/entc/integration/idtype/ent/user/user.go
+++ b/entc/integration/idtype/ent/user/user.go
@@ -72,49 +72,49 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the User queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the User queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // BySpouseField orders the results by spouse field.
-func BySpouseField(field string, opts ...sql.OrderTermOption) Order {
+func BySpouseField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newSpouseStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByFollowersCount orders the results by followers count.
-func ByFollowersCount(opts ...sql.OrderTermOption) Order {
+func ByFollowersCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newFollowersStep(), opts...)
 	}
 }
 
 // ByFollowers orders the results by followers terms.
-func ByFollowers(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByFollowers(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newFollowersStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByFollowingCount orders the results by following count.
-func ByFollowingCount(opts ...sql.OrderTermOption) Order {
+func ByFollowingCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newFollowingStep(), opts...)
 	}
 }
 
 // ByFollowing orders the results by following terms.
-func ByFollowing(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByFollowing(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newFollowingStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/entc/integration/idtype/ent/user_query.go
+++ b/entc/integration/idtype/ent/user_query.go
@@ -23,7 +23,7 @@ import (
 type UserQuery struct {
 	config
 	ctx           *QueryContext
-	order         []user.Order
+	order         []user.OrderOption
 	inters        []Interceptor
 	predicates    []predicate.User
 	withSpouse    *UserQuery
@@ -61,7 +61,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
+func (uq *UserQuery) Order(o ...user.OrderOption) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -321,7 +321,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:        uq.config,
 		ctx:           uq.ctx.Clone(),
-		order:         append([]user.Order{}, uq.order...),
+		order:         append([]user.OrderOption{}, uq.order...),
 		inters:        append([]Interceptor{}, uq.inters...),
 		predicates:    append([]predicate.User{}, uq.predicates...),
 		withSpouse:    uq.withSpouse.Clone(),

--- a/entc/integration/json/ent/user/user.go
+++ b/entc/integration/json/ent/user/user.go
@@ -73,10 +73,10 @@ var (
 	DefaultInts []int
 )
 
-// Order defines the ordering method for the User queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the User queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }

--- a/entc/integration/json/ent/user_query.go
+++ b/entc/integration/json/ent/user_query.go
@@ -22,7 +22,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []user.Order
+	order      []user.OrderOption
 	inters     []Interceptor
 	predicates []predicate.User
 	modifiers  []func(*sql.Selector)
@@ -57,7 +57,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
+func (uq *UserQuery) Order(o ...user.OrderOption) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -251,7 +251,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]user.Order{}, uq.order...),
+		order:      append([]user.OrderOption{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/migrate/entv1/car/car.go
+++ b/entc/integration/migrate/entv1/car/car.go
@@ -57,16 +57,16 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Car queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Car queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByOwnerField orders the results by owner field.
-func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+func ByOwnerField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/migrate/entv1/car_query.go
+++ b/entc/integration/migrate/entv1/car_query.go
@@ -23,7 +23,7 @@ import (
 type CarQuery struct {
 	config
 	ctx        *QueryContext
-	order      []car.Order
+	order      []car.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Car
 	withOwner  *UserQuery
@@ -59,7 +59,7 @@ func (cq *CarQuery) Unique(unique bool) *CarQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *CarQuery) Order(o ...car.Order) *CarQuery {
+func (cq *CarQuery) Order(o ...car.OrderOption) *CarQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -275,7 +275,7 @@ func (cq *CarQuery) Clone() *CarQuery {
 	return &CarQuery{
 		config:     cq.config,
 		ctx:        cq.ctx.Clone(),
-		order:      append([]car.Order{}, cq.order...),
+		order:      append([]car.OrderOption{}, cq.order...),
 		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Car{}, cq.predicates...),
 		withOwner:  cq.withOwner.Clone(),

--- a/entc/integration/migrate/entv1/conversion/conversion.go
+++ b/entc/integration/migrate/entv1/conversion/conversion.go
@@ -61,55 +61,55 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Conversion queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Conversion queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByInt8ToString orders the results by the int8_to_string field.
-func ByInt8ToString(opts ...sql.OrderTermOption) Order {
+func ByInt8ToString(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldInt8ToString, opts...).ToFunc()
 }
 
 // ByUint8ToString orders the results by the uint8_to_string field.
-func ByUint8ToString(opts ...sql.OrderTermOption) Order {
+func ByUint8ToString(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUint8ToString, opts...).ToFunc()
 }
 
 // ByInt16ToString orders the results by the int16_to_string field.
-func ByInt16ToString(opts ...sql.OrderTermOption) Order {
+func ByInt16ToString(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldInt16ToString, opts...).ToFunc()
 }
 
 // ByUint16ToString orders the results by the uint16_to_string field.
-func ByUint16ToString(opts ...sql.OrderTermOption) Order {
+func ByUint16ToString(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUint16ToString, opts...).ToFunc()
 }
 
 // ByInt32ToString orders the results by the int32_to_string field.
-func ByInt32ToString(opts ...sql.OrderTermOption) Order {
+func ByInt32ToString(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldInt32ToString, opts...).ToFunc()
 }
 
 // ByUint32ToString orders the results by the uint32_to_string field.
-func ByUint32ToString(opts ...sql.OrderTermOption) Order {
+func ByUint32ToString(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUint32ToString, opts...).ToFunc()
 }
 
 // ByInt64ToString orders the results by the int64_to_string field.
-func ByInt64ToString(opts ...sql.OrderTermOption) Order {
+func ByInt64ToString(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldInt64ToString, opts...).ToFunc()
 }
 
 // ByUint64ToString orders the results by the uint64_to_string field.
-func ByUint64ToString(opts ...sql.OrderTermOption) Order {
+func ByUint64ToString(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUint64ToString, opts...).ToFunc()
 }

--- a/entc/integration/migrate/entv1/conversion_query.go
+++ b/entc/integration/migrate/entv1/conversion_query.go
@@ -22,7 +22,7 @@ import (
 type ConversionQuery struct {
 	config
 	ctx        *QueryContext
-	order      []conversion.Order
+	order      []conversion.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Conversion
 	// intermediate query (i.e. traversal path).
@@ -56,7 +56,7 @@ func (cq *ConversionQuery) Unique(unique bool) *ConversionQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *ConversionQuery) Order(o ...conversion.Order) *ConversionQuery {
+func (cq *ConversionQuery) Order(o ...conversion.OrderOption) *ConversionQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -250,7 +250,7 @@ func (cq *ConversionQuery) Clone() *ConversionQuery {
 	return &ConversionQuery{
 		config:     cq.config,
 		ctx:        cq.ctx.Clone(),
-		order:      append([]conversion.Order{}, cq.order...),
+		order:      append([]conversion.OrderOption{}, cq.order...),
 		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Conversion{}, cq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/migrate/entv1/customtype/customtype.go
+++ b/entc/integration/migrate/entv1/customtype/customtype.go
@@ -37,15 +37,15 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the CustomType queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the CustomType queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByCustom orders the results by the custom field.
-func ByCustom(opts ...sql.OrderTermOption) Order {
+func ByCustom(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCustom, opts...).ToFunc()
 }

--- a/entc/integration/migrate/entv1/customtype_query.go
+++ b/entc/integration/migrate/entv1/customtype_query.go
@@ -22,7 +22,7 @@ import (
 type CustomTypeQuery struct {
 	config
 	ctx        *QueryContext
-	order      []customtype.Order
+	order      []customtype.OrderOption
 	inters     []Interceptor
 	predicates []predicate.CustomType
 	// intermediate query (i.e. traversal path).
@@ -56,7 +56,7 @@ func (ctq *CustomTypeQuery) Unique(unique bool) *CustomTypeQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (ctq *CustomTypeQuery) Order(o ...customtype.Order) *CustomTypeQuery {
+func (ctq *CustomTypeQuery) Order(o ...customtype.OrderOption) *CustomTypeQuery {
 	ctq.order = append(ctq.order, o...)
 	return ctq
 }
@@ -250,7 +250,7 @@ func (ctq *CustomTypeQuery) Clone() *CustomTypeQuery {
 	return &CustomTypeQuery{
 		config:     ctq.config,
 		ctx:        ctq.ctx.Clone(),
-		order:      append([]customtype.Order{}, ctq.order...),
+		order:      append([]customtype.OrderOption{}, ctq.order...),
 		inters:     append([]Interceptor{}, ctq.inters...),
 		predicates: append([]predicate.CustomType{}, ctq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/migrate/entv1/user/user.go
+++ b/entc/integration/migrate/entv1/user/user.go
@@ -151,99 +151,99 @@ func StateValidator(s State) error {
 	}
 }
 
-// Order defines the ordering method for the User queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the User queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByAge orders the results by the age field.
-func ByAge(opts ...sql.OrderTermOption) Order {
+func ByAge(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAge, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByDescription orders the results by the description field.
-func ByDescription(opts ...sql.OrderTermOption) Order {
+func ByDescription(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDescription, opts...).ToFunc()
 }
 
 // ByNickname orders the results by the nickname field.
-func ByNickname(opts ...sql.OrderTermOption) Order {
+func ByNickname(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldNickname, opts...).ToFunc()
 }
 
 // ByAddress orders the results by the address field.
-func ByAddress(opts ...sql.OrderTermOption) Order {
+func ByAddress(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAddress, opts...).ToFunc()
 }
 
 // ByRenamed orders the results by the renamed field.
-func ByRenamed(opts ...sql.OrderTermOption) Order {
+func ByRenamed(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldRenamed, opts...).ToFunc()
 }
 
 // ByOldToken orders the results by the old_token field.
-func ByOldToken(opts ...sql.OrderTermOption) Order {
+func ByOldToken(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldOldToken, opts...).ToFunc()
 }
 
 // ByState orders the results by the state field.
-func ByState(opts ...sql.OrderTermOption) Order {
+func ByState(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldState, opts...).ToFunc()
 }
 
 // ByStatus orders the results by the status field.
-func ByStatus(opts ...sql.OrderTermOption) Order {
+func ByStatus(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldStatus, opts...).ToFunc()
 }
 
 // ByWorkplace orders the results by the workplace field.
-func ByWorkplace(opts ...sql.OrderTermOption) Order {
+func ByWorkplace(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldWorkplace, opts...).ToFunc()
 }
 
 // ByDropOptional orders the results by the drop_optional field.
-func ByDropOptional(opts ...sql.OrderTermOption) Order {
+func ByDropOptional(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDropOptional, opts...).ToFunc()
 }
 
 // ByParentField orders the results by parent field.
-func ByParentField(field string, opts ...sql.OrderTermOption) Order {
+func ByParentField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newParentStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByChildrenCount orders the results by children count.
-func ByChildrenCount(opts ...sql.OrderTermOption) Order {
+func ByChildrenCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newChildrenStep(), opts...)
 	}
 }
 
 // ByChildren orders the results by children terms.
-func ByChildren(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByChildren(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newChildrenStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // BySpouseField orders the results by spouse field.
-func BySpouseField(field string, opts ...sql.OrderTermOption) Order {
+func BySpouseField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newSpouseStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByCarField orders the results by car field.
-func ByCarField(field string, opts ...sql.OrderTermOption) Order {
+func ByCarField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newCarStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/migrate/entv1/user_query.go
+++ b/entc/integration/migrate/entv1/user_query.go
@@ -24,7 +24,7 @@ import (
 type UserQuery struct {
 	config
 	ctx          *QueryContext
-	order        []user.Order
+	order        []user.OrderOption
 	inters       []Interceptor
 	predicates   []predicate.User
 	withParent   *UserQuery
@@ -63,7 +63,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
+func (uq *UserQuery) Order(o ...user.OrderOption) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -345,7 +345,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:       uq.config,
 		ctx:          uq.ctx.Clone(),
-		order:        append([]user.Order{}, uq.order...),
+		order:        append([]user.OrderOption{}, uq.order...),
 		inters:       append([]Interceptor{}, uq.inters...),
 		predicates:   append([]predicate.User{}, uq.predicates...),
 		withParent:   uq.withParent.Clone(),

--- a/entc/integration/migrate/entv2/blog/blog.go
+++ b/entc/integration/migrate/entv2/blog/blog.go
@@ -49,28 +49,28 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Blog queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Blog queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByOid orders the results by the oid field.
-func ByOid(opts ...sql.OrderTermOption) Order {
+func ByOid(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldOid, opts...).ToFunc()
 }
 
 // ByAdminsCount orders the results by admins count.
-func ByAdminsCount(opts ...sql.OrderTermOption) Order {
+func ByAdminsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newAdminsStep(), opts...)
 	}
 }
 
 // ByAdmins orders the results by admins terms.
-func ByAdmins(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByAdmins(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newAdminsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/entc/integration/migrate/entv2/blog_query.go
+++ b/entc/integration/migrate/entv2/blog_query.go
@@ -24,7 +24,7 @@ import (
 type BlogQuery struct {
 	config
 	ctx        *QueryContext
-	order      []blog.Order
+	order      []blog.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Blog
 	withAdmins *UserQuery
@@ -59,7 +59,7 @@ func (bq *BlogQuery) Unique(unique bool) *BlogQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (bq *BlogQuery) Order(o ...blog.Order) *BlogQuery {
+func (bq *BlogQuery) Order(o ...blog.OrderOption) *BlogQuery {
 	bq.order = append(bq.order, o...)
 	return bq
 }
@@ -275,7 +275,7 @@ func (bq *BlogQuery) Clone() *BlogQuery {
 	return &BlogQuery{
 		config:     bq.config,
 		ctx:        bq.ctx.Clone(),
-		order:      append([]blog.Order{}, bq.order...),
+		order:      append([]blog.OrderOption{}, bq.order...),
 		inters:     append([]Interceptor{}, bq.inters...),
 		predicates: append([]predicate.Blog{}, bq.predicates...),
 		withAdmins: bq.withAdmins.Clone(),

--- a/entc/integration/migrate/entv2/car/car.go
+++ b/entc/integration/migrate/entv2/car/car.go
@@ -60,21 +60,21 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Car queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Car queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByOwnerField orders the results by owner field.
-func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+func ByOwnerField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/migrate/entv2/car_query.go
+++ b/entc/integration/migrate/entv2/car_query.go
@@ -23,7 +23,7 @@ import (
 type CarQuery struct {
 	config
 	ctx        *QueryContext
-	order      []car.Order
+	order      []car.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Car
 	withOwner  *UserQuery
@@ -59,7 +59,7 @@ func (cq *CarQuery) Unique(unique bool) *CarQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *CarQuery) Order(o ...car.Order) *CarQuery {
+func (cq *CarQuery) Order(o ...car.OrderOption) *CarQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -275,7 +275,7 @@ func (cq *CarQuery) Clone() *CarQuery {
 	return &CarQuery{
 		config:     cq.config,
 		ctx:        cq.ctx.Clone(),
-		order:      append([]car.Order{}, cq.order...),
+		order:      append([]car.OrderOption{}, cq.order...),
 		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Car{}, cq.predicates...),
 		withOwner:  cq.withOwner.Clone(),

--- a/entc/integration/migrate/entv2/conversion/conversion.go
+++ b/entc/integration/migrate/entv2/conversion/conversion.go
@@ -61,55 +61,55 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Conversion queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Conversion queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByInt8ToString orders the results by the int8_to_string field.
-func ByInt8ToString(opts ...sql.OrderTermOption) Order {
+func ByInt8ToString(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldInt8ToString, opts...).ToFunc()
 }
 
 // ByUint8ToString orders the results by the uint8_to_string field.
-func ByUint8ToString(opts ...sql.OrderTermOption) Order {
+func ByUint8ToString(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUint8ToString, opts...).ToFunc()
 }
 
 // ByInt16ToString orders the results by the int16_to_string field.
-func ByInt16ToString(opts ...sql.OrderTermOption) Order {
+func ByInt16ToString(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldInt16ToString, opts...).ToFunc()
 }
 
 // ByUint16ToString orders the results by the uint16_to_string field.
-func ByUint16ToString(opts ...sql.OrderTermOption) Order {
+func ByUint16ToString(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUint16ToString, opts...).ToFunc()
 }
 
 // ByInt32ToString orders the results by the int32_to_string field.
-func ByInt32ToString(opts ...sql.OrderTermOption) Order {
+func ByInt32ToString(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldInt32ToString, opts...).ToFunc()
 }
 
 // ByUint32ToString orders the results by the uint32_to_string field.
-func ByUint32ToString(opts ...sql.OrderTermOption) Order {
+func ByUint32ToString(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUint32ToString, opts...).ToFunc()
 }
 
 // ByInt64ToString orders the results by the int64_to_string field.
-func ByInt64ToString(opts ...sql.OrderTermOption) Order {
+func ByInt64ToString(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldInt64ToString, opts...).ToFunc()
 }
 
 // ByUint64ToString orders the results by the uint64_to_string field.
-func ByUint64ToString(opts ...sql.OrderTermOption) Order {
+func ByUint64ToString(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUint64ToString, opts...).ToFunc()
 }

--- a/entc/integration/migrate/entv2/conversion_query.go
+++ b/entc/integration/migrate/entv2/conversion_query.go
@@ -22,7 +22,7 @@ import (
 type ConversionQuery struct {
 	config
 	ctx        *QueryContext
-	order      []conversion.Order
+	order      []conversion.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Conversion
 	// intermediate query (i.e. traversal path).
@@ -56,7 +56,7 @@ func (cq *ConversionQuery) Unique(unique bool) *ConversionQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *ConversionQuery) Order(o ...conversion.Order) *ConversionQuery {
+func (cq *ConversionQuery) Order(o ...conversion.OrderOption) *ConversionQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -250,7 +250,7 @@ func (cq *ConversionQuery) Clone() *ConversionQuery {
 	return &ConversionQuery{
 		config:     cq.config,
 		ctx:        cq.ctx.Clone(),
-		order:      append([]conversion.Order{}, cq.order...),
+		order:      append([]conversion.OrderOption{}, cq.order...),
 		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Conversion{}, cq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/migrate/entv2/customtype/customtype.go
+++ b/entc/integration/migrate/entv2/customtype/customtype.go
@@ -43,25 +43,25 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the CustomType queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the CustomType queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByCustom orders the results by the custom field.
-func ByCustom(opts ...sql.OrderTermOption) Order {
+func ByCustom(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCustom, opts...).ToFunc()
 }
 
 // ByTz0 orders the results by the tz0 field.
-func ByTz0(opts ...sql.OrderTermOption) Order {
+func ByTz0(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldTz0, opts...).ToFunc()
 }
 
 // ByTz3 orders the results by the tz3 field.
-func ByTz3(opts ...sql.OrderTermOption) Order {
+func ByTz3(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldTz3, opts...).ToFunc()
 }

--- a/entc/integration/migrate/entv2/customtype_query.go
+++ b/entc/integration/migrate/entv2/customtype_query.go
@@ -22,7 +22,7 @@ import (
 type CustomTypeQuery struct {
 	config
 	ctx        *QueryContext
-	order      []customtype.Order
+	order      []customtype.OrderOption
 	inters     []Interceptor
 	predicates []predicate.CustomType
 	// intermediate query (i.e. traversal path).
@@ -56,7 +56,7 @@ func (ctq *CustomTypeQuery) Unique(unique bool) *CustomTypeQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (ctq *CustomTypeQuery) Order(o ...customtype.Order) *CustomTypeQuery {
+func (ctq *CustomTypeQuery) Order(o ...customtype.OrderOption) *CustomTypeQuery {
 	ctq.order = append(ctq.order, o...)
 	return ctq
 }
@@ -250,7 +250,7 @@ func (ctq *CustomTypeQuery) Clone() *CustomTypeQuery {
 	return &CustomTypeQuery{
 		config:     ctq.config,
 		ctx:        ctq.ctx.Clone(),
-		order:      append([]customtype.Order{}, ctq.order...),
+		order:      append([]customtype.OrderOption{}, ctq.order...),
 		inters:     append([]Interceptor{}, ctq.inters...),
 		predicates: append([]predicate.CustomType{}, ctq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/migrate/entv2/group/group.go
+++ b/entc/integration/migrate/entv2/group/group.go
@@ -34,10 +34,10 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Group queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Group queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }

--- a/entc/integration/migrate/entv2/group_query.go
+++ b/entc/integration/migrate/entv2/group_query.go
@@ -22,7 +22,7 @@ import (
 type GroupQuery struct {
 	config
 	ctx        *QueryContext
-	order      []group.Order
+	order      []group.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Group
 	// intermediate query (i.e. traversal path).
@@ -56,7 +56,7 @@ func (gq *GroupQuery) Unique(unique bool) *GroupQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (gq *GroupQuery) Order(o ...group.Order) *GroupQuery {
+func (gq *GroupQuery) Order(o ...group.OrderOption) *GroupQuery {
 	gq.order = append(gq.order, o...)
 	return gq
 }
@@ -250,7 +250,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 	return &GroupQuery{
 		config:     gq.config,
 		ctx:        gq.ctx.Clone(),
-		order:      append([]group.Order{}, gq.order...),
+		order:      append([]group.OrderOption{}, gq.order...),
 		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Group{}, gq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/migrate/entv2/media/media.go
+++ b/entc/integration/migrate/entv2/media/media.go
@@ -43,25 +43,25 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Media queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Media queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // BySource orders the results by the source field.
-func BySource(opts ...sql.OrderTermOption) Order {
+func BySource(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldSource, opts...).ToFunc()
 }
 
 // BySourceURI orders the results by the source_uri field.
-func BySourceURI(opts ...sql.OrderTermOption) Order {
+func BySourceURI(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldSourceURI, opts...).ToFunc()
 }
 
 // ByText orders the results by the text field.
-func ByText(opts ...sql.OrderTermOption) Order {
+func ByText(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldText, opts...).ToFunc()
 }

--- a/entc/integration/migrate/entv2/media_query.go
+++ b/entc/integration/migrate/entv2/media_query.go
@@ -22,7 +22,7 @@ import (
 type MediaQuery struct {
 	config
 	ctx        *QueryContext
-	order      []media.Order
+	order      []media.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Media
 	// intermediate query (i.e. traversal path).
@@ -56,7 +56,7 @@ func (mq *MediaQuery) Unique(unique bool) *MediaQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (mq *MediaQuery) Order(o ...media.Order) *MediaQuery {
+func (mq *MediaQuery) Order(o ...media.OrderOption) *MediaQuery {
 	mq.order = append(mq.order, o...)
 	return mq
 }
@@ -250,7 +250,7 @@ func (mq *MediaQuery) Clone() *MediaQuery {
 	return &MediaQuery{
 		config:     mq.config,
 		ctx:        mq.ctx.Clone(),
-		order:      append([]media.Order{}, mq.order...),
+		order:      append([]media.OrderOption{}, mq.order...),
 		inters:     append([]Interceptor{}, mq.inters...),
 		predicates: append([]predicate.Media{}, mq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/migrate/entv2/pet/pet.go
+++ b/entc/integration/migrate/entv2/pet/pet.go
@@ -60,21 +60,21 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Pet queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Pet queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByOwnerField orders the results by owner field.
-func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+func ByOwnerField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/migrate/entv2/pet_query.go
+++ b/entc/integration/migrate/entv2/pet_query.go
@@ -23,7 +23,7 @@ import (
 type PetQuery struct {
 	config
 	ctx        *QueryContext
-	order      []pet.Order
+	order      []pet.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Pet
 	withOwner  *UserQuery
@@ -59,7 +59,7 @@ func (pq *PetQuery) Unique(unique bool) *PetQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (pq *PetQuery) Order(o ...pet.Order) *PetQuery {
+func (pq *PetQuery) Order(o ...pet.OrderOption) *PetQuery {
 	pq.order = append(pq.order, o...)
 	return pq
 }
@@ -275,7 +275,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 	return &PetQuery{
 		config:     pq.config,
 		ctx:        pq.ctx.Clone(),
-		order:      append([]pet.Order{}, pq.order...),
+		order:      append([]pet.OrderOption{}, pq.order...),
 		inters:     append([]Interceptor{}, pq.inters...),
 		predicates: append([]predicate.Pet{}, pq.predicates...),
 		withOwner:  pq.withOwner.Clone(),

--- a/entc/integration/migrate/entv2/user/user.go
+++ b/entc/integration/migrate/entv2/user/user.go
@@ -243,134 +243,134 @@ func StatusValidator(s Status) error {
 	}
 }
 
-// Order defines the ordering method for the User queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the User queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByMixedString orders the results by the mixed_string field.
-func ByMixedString(opts ...sql.OrderTermOption) Order {
+func ByMixedString(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldMixedString, opts...).ToFunc()
 }
 
 // ByMixedEnum orders the results by the mixed_enum field.
-func ByMixedEnum(opts ...sql.OrderTermOption) Order {
+func ByMixedEnum(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldMixedEnum, opts...).ToFunc()
 }
 
 // ByActive orders the results by the active field.
-func ByActive(opts ...sql.OrderTermOption) Order {
+func ByActive(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldActive, opts...).ToFunc()
 }
 
 // ByAge orders the results by the age field.
-func ByAge(opts ...sql.OrderTermOption) Order {
+func ByAge(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAge, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByDescription orders the results by the description field.
-func ByDescription(opts ...sql.OrderTermOption) Order {
+func ByDescription(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDescription, opts...).ToFunc()
 }
 
 // ByNickname orders the results by the nickname field.
-func ByNickname(opts ...sql.OrderTermOption) Order {
+func ByNickname(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldNickname, opts...).ToFunc()
 }
 
 // ByPhone orders the results by the phone field.
-func ByPhone(opts ...sql.OrderTermOption) Order {
+func ByPhone(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldPhone, opts...).ToFunc()
 }
 
 // ByTitle orders the results by the title field.
-func ByTitle(opts ...sql.OrderTermOption) Order {
+func ByTitle(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldTitle, opts...).ToFunc()
 }
 
 // ByNewName orders the results by the new_name field.
-func ByNewName(opts ...sql.OrderTermOption) Order {
+func ByNewName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldNewName, opts...).ToFunc()
 }
 
 // ByNewToken orders the results by the new_token field.
-func ByNewToken(opts ...sql.OrderTermOption) Order {
+func ByNewToken(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldNewToken, opts...).ToFunc()
 }
 
 // ByState orders the results by the state field.
-func ByState(opts ...sql.OrderTermOption) Order {
+func ByState(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldState, opts...).ToFunc()
 }
 
 // ByStatus orders the results by the status field.
-func ByStatus(opts ...sql.OrderTermOption) Order {
+func ByStatus(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldStatus, opts...).ToFunc()
 }
 
 // ByWorkplace orders the results by the workplace field.
-func ByWorkplace(opts ...sql.OrderTermOption) Order {
+func ByWorkplace(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldWorkplace, opts...).ToFunc()
 }
 
 // ByDefaultExpr orders the results by the default_expr field.
-func ByDefaultExpr(opts ...sql.OrderTermOption) Order {
+func ByDefaultExpr(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDefaultExpr, opts...).ToFunc()
 }
 
 // ByDefaultExprs orders the results by the default_exprs field.
-func ByDefaultExprs(opts ...sql.OrderTermOption) Order {
+func ByDefaultExprs(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDefaultExprs, opts...).ToFunc()
 }
 
 // ByCreatedAt orders the results by the created_at field.
-func ByCreatedAt(opts ...sql.OrderTermOption) Order {
+func ByCreatedAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCreatedAt, opts...).ToFunc()
 }
 
 // ByDropOptional orders the results by the drop_optional field.
-func ByDropOptional(opts ...sql.OrderTermOption) Order {
+func ByDropOptional(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDropOptional, opts...).ToFunc()
 }
 
 // ByCarCount orders the results by car count.
-func ByCarCount(opts ...sql.OrderTermOption) Order {
+func ByCarCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newCarStep(), opts...)
 	}
 }
 
 // ByCar orders the results by car terms.
-func ByCar(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByCar(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newCarStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByPetsField orders the results by pets field.
-func ByPetsField(field string, opts ...sql.OrderTermOption) Order {
+func ByPetsField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newPetsStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByFriendsCount orders the results by friends count.
-func ByFriendsCount(opts ...sql.OrderTermOption) Order {
+func ByFriendsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newFriendsStep(), opts...)
 	}
 }
 
 // ByFriends orders the results by friends terms.
-func ByFriends(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByFriends(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newFriendsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/entc/integration/migrate/entv2/user_query.go
+++ b/entc/integration/migrate/entv2/user_query.go
@@ -25,7 +25,7 @@ import (
 type UserQuery struct {
 	config
 	ctx         *QueryContext
-	order       []user.Order
+	order       []user.OrderOption
 	inters      []Interceptor
 	predicates  []predicate.User
 	withCar     *CarQuery
@@ -63,7 +63,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
+func (uq *UserQuery) Order(o ...user.OrderOption) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -323,7 +323,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:      uq.config,
 		ctx:         uq.ctx.Clone(),
-		order:       append([]user.Order{}, uq.order...),
+		order:       append([]user.OrderOption{}, uq.order...),
 		inters:      append([]Interceptor{}, uq.inters...),
 		predicates:  append([]predicate.User{}, uq.predicates...),
 		withCar:     uq.withCar.Clone(),

--- a/entc/integration/migrate/entv2/zoo/zoo.go
+++ b/entc/integration/migrate/entv2/zoo/zoo.go
@@ -34,10 +34,10 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Zoo queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Zoo queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }

--- a/entc/integration/migrate/entv2/zoo_query.go
+++ b/entc/integration/migrate/entv2/zoo_query.go
@@ -22,7 +22,7 @@ import (
 type ZooQuery struct {
 	config
 	ctx        *QueryContext
-	order      []zoo.Order
+	order      []zoo.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Zoo
 	// intermediate query (i.e. traversal path).
@@ -56,7 +56,7 @@ func (zq *ZooQuery) Unique(unique bool) *ZooQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (zq *ZooQuery) Order(o ...zoo.Order) *ZooQuery {
+func (zq *ZooQuery) Order(o ...zoo.OrderOption) *ZooQuery {
 	zq.order = append(zq.order, o...)
 	return zq
 }
@@ -250,7 +250,7 @@ func (zq *ZooQuery) Clone() *ZooQuery {
 	return &ZooQuery{
 		config:     zq.config,
 		ctx:        zq.ctx.Clone(),
-		order:      append([]zoo.Order{}, zq.order...),
+		order:      append([]zoo.OrderOption{}, zq.order...),
 		inters:     append([]Interceptor{}, zq.inters...),
 		predicates: append([]predicate.Zoo{}, zq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/migrate/versioned/group/group.go
+++ b/entc/integration/migrate/versioned/group/group.go
@@ -37,15 +37,15 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Group queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Group queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }

--- a/entc/integration/migrate/versioned/group_query.go
+++ b/entc/integration/migrate/versioned/group_query.go
@@ -22,7 +22,7 @@ import (
 type GroupQuery struct {
 	config
 	ctx        *QueryContext
-	order      []group.Order
+	order      []group.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Group
 	// intermediate query (i.e. traversal path).
@@ -56,7 +56,7 @@ func (gq *GroupQuery) Unique(unique bool) *GroupQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (gq *GroupQuery) Order(o ...group.Order) *GroupQuery {
+func (gq *GroupQuery) Order(o ...group.OrderOption) *GroupQuery {
 	gq.order = append(gq.order, o...)
 	return gq
 }
@@ -250,7 +250,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 	return &GroupQuery{
 		config:     gq.config,
 		ctx:        gq.ctx.Clone(),
-		order:      append([]group.Order{}, gq.order...),
+		order:      append([]group.OrderOption{}, gq.order...),
 		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Group{}, gq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/migrate/versioned/user/user.go
+++ b/entc/integration/migrate/versioned/user/user.go
@@ -48,25 +48,25 @@ var (
 	NameValidator func(string) error
 )
 
-// Order defines the ordering method for the User queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the User queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByAge orders the results by the age field.
-func ByAge(opts ...sql.OrderTermOption) Order {
+func ByAge(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAge, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByAddress orders the results by the address field.
-func ByAddress(opts ...sql.OrderTermOption) Order {
+func ByAddress(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAddress, opts...).ToFunc()
 }

--- a/entc/integration/migrate/versioned/user_query.go
+++ b/entc/integration/migrate/versioned/user_query.go
@@ -22,7 +22,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []user.Order
+	order      []user.OrderOption
 	inters     []Interceptor
 	predicates []predicate.User
 	// intermediate query (i.e. traversal path).
@@ -56,7 +56,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
+func (uq *UserQuery) Order(o ...user.OrderOption) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -250,7 +250,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]user.Order{}, uq.order...),
+		order:      append([]user.OrderOption{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/multischema/ent/friendship/friendship.go
+++ b/entc/integration/multischema/ent/friendship/friendship.go
@@ -74,43 +74,43 @@ var (
 	DefaultCreatedAt func() time.Time
 )
 
-// Order defines the ordering method for the Friendship queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Friendship queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByWeight orders the results by the weight field.
-func ByWeight(opts ...sql.OrderTermOption) Order {
+func ByWeight(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldWeight, opts...).ToFunc()
 }
 
 // ByCreatedAt orders the results by the created_at field.
-func ByCreatedAt(opts ...sql.OrderTermOption) Order {
+func ByCreatedAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCreatedAt, opts...).ToFunc()
 }
 
 // ByUserID orders the results by the user_id field.
-func ByUserID(opts ...sql.OrderTermOption) Order {
+func ByUserID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUserID, opts...).ToFunc()
 }
 
 // ByFriendID orders the results by the friend_id field.
-func ByFriendID(opts ...sql.OrderTermOption) Order {
+func ByFriendID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldFriendID, opts...).ToFunc()
 }
 
 // ByUserField orders the results by user field.
-func ByUserField(field string, opts ...sql.OrderTermOption) Order {
+func ByUserField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newUserStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByFriendField orders the results by friend field.
-func ByFriendField(field string, opts ...sql.OrderTermOption) Order {
+func ByFriendField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newFriendStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/multischema/ent/friendship_query.go
+++ b/entc/integration/multischema/ent/friendship_query.go
@@ -24,7 +24,7 @@ import (
 type FriendshipQuery struct {
 	config
 	ctx        *QueryContext
-	order      []friendship.Order
+	order      []friendship.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Friendship
 	withUser   *UserQuery
@@ -61,7 +61,7 @@ func (fq *FriendshipQuery) Unique(unique bool) *FriendshipQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (fq *FriendshipQuery) Order(o ...friendship.Order) *FriendshipQuery {
+func (fq *FriendshipQuery) Order(o ...friendship.OrderOption) *FriendshipQuery {
 	fq.order = append(fq.order, o...)
 	return fq
 }
@@ -305,7 +305,7 @@ func (fq *FriendshipQuery) Clone() *FriendshipQuery {
 	return &FriendshipQuery{
 		config:     fq.config,
 		ctx:        fq.ctx.Clone(),
-		order:      append([]friendship.Order{}, fq.order...),
+		order:      append([]friendship.OrderOption{}, fq.order...),
 		inters:     append([]Interceptor{}, fq.inters...),
 		predicates: append([]predicate.Friendship{}, fq.predicates...),
 		withUser:   fq.withUser.Clone(),

--- a/entc/integration/multischema/ent/group/group.go
+++ b/entc/integration/multischema/ent/group/group.go
@@ -56,28 +56,28 @@ var (
 	DefaultName string
 )
 
-// Order defines the ordering method for the Group queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Group queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByUsersCount orders the results by users count.
-func ByUsersCount(opts ...sql.OrderTermOption) Order {
+func ByUsersCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newUsersStep(), opts...)
 	}
 }
 
 // ByUsers orders the results by users terms.
-func ByUsers(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByUsers(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newUsersStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/entc/integration/multischema/ent/group_query.go
+++ b/entc/integration/multischema/ent/group_query.go
@@ -25,7 +25,7 @@ import (
 type GroupQuery struct {
 	config
 	ctx        *QueryContext
-	order      []group.Order
+	order      []group.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Group
 	withUsers  *UserQuery
@@ -61,7 +61,7 @@ func (gq *GroupQuery) Unique(unique bool) *GroupQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (gq *GroupQuery) Order(o ...group.Order) *GroupQuery {
+func (gq *GroupQuery) Order(o ...group.OrderOption) *GroupQuery {
 	gq.order = append(gq.order, o...)
 	return gq
 }
@@ -280,7 +280,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 	return &GroupQuery{
 		config:     gq.config,
 		ctx:        gq.ctx.Clone(),
-		order:      append([]group.Order{}, gq.order...),
+		order:      append([]group.OrderOption{}, gq.order...),
 		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Group{}, gq.predicates...),
 		withUsers:  gq.withUsers.Clone(),

--- a/entc/integration/multischema/ent/pet/pet.go
+++ b/entc/integration/multischema/ent/pet/pet.go
@@ -55,26 +55,26 @@ var (
 	DefaultName string
 )
 
-// Order defines the ordering method for the Pet queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Pet queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByOwnerID orders the results by the owner_id field.
-func ByOwnerID(opts ...sql.OrderTermOption) Order {
+func ByOwnerID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldOwnerID, opts...).ToFunc()
 }
 
 // ByOwnerField orders the results by owner field.
-func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+func ByOwnerField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/multischema/ent/pet_query.go
+++ b/entc/integration/multischema/ent/pet_query.go
@@ -24,7 +24,7 @@ import (
 type PetQuery struct {
 	config
 	ctx        *QueryContext
-	order      []pet.Order
+	order      []pet.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Pet
 	withOwner  *UserQuery
@@ -60,7 +60,7 @@ func (pq *PetQuery) Unique(unique bool) *PetQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (pq *PetQuery) Order(o ...pet.Order) *PetQuery {
+func (pq *PetQuery) Order(o ...pet.OrderOption) *PetQuery {
 	pq.order = append(pq.order, o...)
 	return pq
 }
@@ -279,7 +279,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 	return &PetQuery{
 		config:     pq.config,
 		ctx:        pq.ctx.Clone(),
-		order:      append([]pet.Order{}, pq.order...),
+		order:      append([]pet.OrderOption{}, pq.order...),
 		inters:     append([]Interceptor{}, pq.inters...),
 		predicates: append([]predicate.Pet{}, pq.predicates...),
 		withOwner:  pq.withOwner.Clone(),

--- a/entc/integration/multischema/ent/user/user.go
+++ b/entc/integration/multischema/ent/user/user.go
@@ -81,70 +81,70 @@ var (
 	DefaultName string
 )
 
-// Order defines the ordering method for the User queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the User queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByPetsCount orders the results by pets count.
-func ByPetsCount(opts ...sql.OrderTermOption) Order {
+func ByPetsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newPetsStep(), opts...)
 	}
 }
 
 // ByPets orders the results by pets terms.
-func ByPets(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByPets(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newPetsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByGroupsCount orders the results by groups count.
-func ByGroupsCount(opts ...sql.OrderTermOption) Order {
+func ByGroupsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newGroupsStep(), opts...)
 	}
 }
 
 // ByGroups orders the results by groups terms.
-func ByGroups(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByGroups(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newGroupsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByFriendsCount orders the results by friends count.
-func ByFriendsCount(opts ...sql.OrderTermOption) Order {
+func ByFriendsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newFriendsStep(), opts...)
 	}
 }
 
 // ByFriends orders the results by friends terms.
-func ByFriends(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByFriends(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newFriendsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByFriendshipsCount orders the results by friendships count.
-func ByFriendshipsCount(opts ...sql.OrderTermOption) Order {
+func ByFriendshipsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newFriendshipsStep(), opts...)
 	}
 }
 
 // ByFriendships orders the results by friendships terms.
-func ByFriendships(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByFriendships(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newFriendshipsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/entc/integration/multischema/ent/user_query.go
+++ b/entc/integration/multischema/ent/user_query.go
@@ -27,7 +27,7 @@ import (
 type UserQuery struct {
 	config
 	ctx             *QueryContext
-	order           []user.Order
+	order           []user.OrderOption
 	inters          []Interceptor
 	predicates      []predicate.User
 	withPets        *PetQuery
@@ -66,7 +66,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
+func (uq *UserQuery) Order(o ...user.OrderOption) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -360,7 +360,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:          uq.config,
 		ctx:             uq.ctx.Clone(),
-		order:           append([]user.Order{}, uq.order...),
+		order:           append([]user.OrderOption{}, uq.order...),
 		inters:          append([]Interceptor{}, uq.inters...),
 		predicates:      append([]predicate.User{}, uq.predicates...),
 		withPets:        uq.withPets.Clone(),

--- a/entc/integration/privacy/ent/task/task.go
+++ b/entc/integration/privacy/ent/task/task.go
@@ -122,50 +122,50 @@ func StatusValidator(s Status) error {
 	}
 }
 
-// Order defines the ordering method for the Task queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Task queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByTitle orders the results by the title field.
-func ByTitle(opts ...sql.OrderTermOption) Order {
+func ByTitle(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldTitle, opts...).ToFunc()
 }
 
 // ByDescription orders the results by the description field.
-func ByDescription(opts ...sql.OrderTermOption) Order {
+func ByDescription(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDescription, opts...).ToFunc()
 }
 
 // ByStatus orders the results by the status field.
-func ByStatus(opts ...sql.OrderTermOption) Order {
+func ByStatus(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldStatus, opts...).ToFunc()
 }
 
 // ByUUID orders the results by the uuid field.
-func ByUUID(opts ...sql.OrderTermOption) Order {
+func ByUUID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUUID, opts...).ToFunc()
 }
 
 // ByTeamsCount orders the results by teams count.
-func ByTeamsCount(opts ...sql.OrderTermOption) Order {
+func ByTeamsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newTeamsStep(), opts...)
 	}
 }
 
 // ByTeams orders the results by teams terms.
-func ByTeams(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByTeams(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newTeamsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByOwnerField orders the results by owner field.
-func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+func ByOwnerField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/privacy/ent/task_query.go
+++ b/entc/integration/privacy/ent/task_query.go
@@ -26,7 +26,7 @@ import (
 type TaskQuery struct {
 	config
 	ctx        *QueryContext
-	order      []task.Order
+	order      []task.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Task
 	withTeams  *TeamQuery
@@ -63,7 +63,7 @@ func (tq *TaskQuery) Unique(unique bool) *TaskQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (tq *TaskQuery) Order(o ...task.Order) *TaskQuery {
+func (tq *TaskQuery) Order(o ...task.OrderOption) *TaskQuery {
 	tq.order = append(tq.order, o...)
 	return tq
 }
@@ -301,7 +301,7 @@ func (tq *TaskQuery) Clone() *TaskQuery {
 	return &TaskQuery{
 		config:     tq.config,
 		ctx:        tq.ctx.Clone(),
-		order:      append([]task.Order{}, tq.order...),
+		order:      append([]task.OrderOption{}, tq.order...),
 		inters:     append([]Interceptor{}, tq.inters...),
 		predicates: append([]predicate.Task{}, tq.predicates...),
 		withTeams:  tq.withTeams.Clone(),

--- a/entc/integration/privacy/ent/team/team.go
+++ b/entc/integration/privacy/ent/team/team.go
@@ -74,42 +74,42 @@ var (
 	NameValidator func(string) error
 )
 
-// Order defines the ordering method for the Team queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Team queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByTasksCount orders the results by tasks count.
-func ByTasksCount(opts ...sql.OrderTermOption) Order {
+func ByTasksCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newTasksStep(), opts...)
 	}
 }
 
 // ByTasks orders the results by tasks terms.
-func ByTasks(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByTasks(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newTasksStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByUsersCount orders the results by users count.
-func ByUsersCount(opts ...sql.OrderTermOption) Order {
+func ByUsersCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newUsersStep(), opts...)
 	}
 }
 
 // ByUsers orders the results by users terms.
-func ByUsers(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByUsers(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newUsersStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/entc/integration/privacy/ent/team_query.go
+++ b/entc/integration/privacy/ent/team_query.go
@@ -26,7 +26,7 @@ import (
 type TeamQuery struct {
 	config
 	ctx        *QueryContext
-	order      []team.Order
+	order      []team.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Team
 	withTasks  *TaskQuery
@@ -62,7 +62,7 @@ func (tq *TeamQuery) Unique(unique bool) *TeamQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (tq *TeamQuery) Order(o ...team.Order) *TeamQuery {
+func (tq *TeamQuery) Order(o ...team.OrderOption) *TeamQuery {
 	tq.order = append(tq.order, o...)
 	return tq
 }
@@ -300,7 +300,7 @@ func (tq *TeamQuery) Clone() *TeamQuery {
 	return &TeamQuery{
 		config:     tq.config,
 		ctx:        tq.ctx.Clone(),
-		order:      append([]team.Order{}, tq.order...),
+		order:      append([]team.OrderOption{}, tq.order...),
 		inters:     append([]Interceptor{}, tq.inters...),
 		predicates: append([]predicate.Team{}, tq.predicates...),
 		withTasks:  tq.withTasks.Clone(),

--- a/entc/integration/privacy/ent/user/user.go
+++ b/entc/integration/privacy/ent/user/user.go
@@ -76,47 +76,47 @@ var (
 	NameValidator func(string) error
 )
 
-// Order defines the ordering method for the User queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the User queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByAge orders the results by the age field.
-func ByAge(opts ...sql.OrderTermOption) Order {
+func ByAge(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAge, opts...).ToFunc()
 }
 
 // ByTeamsCount orders the results by teams count.
-func ByTeamsCount(opts ...sql.OrderTermOption) Order {
+func ByTeamsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newTeamsStep(), opts...)
 	}
 }
 
 // ByTeams orders the results by teams terms.
-func ByTeams(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByTeams(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newTeamsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByTasksCount orders the results by tasks count.
-func ByTasksCount(opts ...sql.OrderTermOption) Order {
+func ByTasksCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newTasksStep(), opts...)
 	}
 }
 
 // ByTasks orders the results by tasks terms.
-func ByTasks(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByTasks(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newTasksStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/entc/integration/privacy/ent/user_query.go
+++ b/entc/integration/privacy/ent/user_query.go
@@ -26,7 +26,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []user.Order
+	order      []user.OrderOption
 	inters     []Interceptor
 	predicates []predicate.User
 	withTeams  *TeamQuery
@@ -62,7 +62,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
+func (uq *UserQuery) Order(o ...user.OrderOption) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -300,7 +300,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]user.Order{}, uq.order...),
+		order:      append([]user.OrderOption{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		withTeams:  uq.withTeams.Clone(),

--- a/entc/integration/template/ent/group/group.go
+++ b/entc/integration/template/ent/group/group.go
@@ -37,15 +37,15 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Group queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Group queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByMaxUsers orders the results by the max_users field.
-func ByMaxUsers(opts ...sql.OrderTermOption) Order {
+func ByMaxUsers(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldMaxUsers, opts...).ToFunc()
 }

--- a/entc/integration/template/ent/group_query.go
+++ b/entc/integration/template/ent/group_query.go
@@ -22,7 +22,7 @@ import (
 type GroupQuery struct {
 	config
 	ctx        *QueryContext
-	order      []group.Order
+	order      []group.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Group
 	// additional query fields.
@@ -59,7 +59,7 @@ func (gq *GroupQuery) Unique(unique bool) *GroupQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (gq *GroupQuery) Order(o ...group.Order) *GroupQuery {
+func (gq *GroupQuery) Order(o ...group.OrderOption) *GroupQuery {
 	gq.order = append(gq.order, o...)
 	return gq
 }
@@ -253,7 +253,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 	return &GroupQuery{
 		config:     gq.config,
 		ctx:        gq.ctx.Clone(),
-		order:      append([]group.Order{}, gq.order...),
+		order:      append([]group.OrderOption{}, gq.order...),
 		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Group{}, gq.predicates...),
 		// clone intermediate query.

--- a/entc/integration/template/ent/pet/pet.go
+++ b/entc/integration/template/ent/pet/pet.go
@@ -61,26 +61,26 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Pet queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Pet queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByAge orders the results by the age field.
-func ByAge(opts ...sql.OrderTermOption) Order {
+func ByAge(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAge, opts...).ToFunc()
 }
 
 // ByLicensedAt orders the results by the licensed_at field.
-func ByLicensedAt(opts ...sql.OrderTermOption) Order {
+func ByLicensedAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldLicensedAt, opts...).ToFunc()
 }
 
 // ByOwnerField orders the results by owner field.
-func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+func ByOwnerField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
 	}

--- a/entc/integration/template/ent/pet_query.go
+++ b/entc/integration/template/ent/pet_query.go
@@ -23,7 +23,7 @@ import (
 type PetQuery struct {
 	config
 	ctx        *QueryContext
-	order      []pet.Order
+	order      []pet.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Pet
 	withOwner  *UserQuery
@@ -62,7 +62,7 @@ func (pq *PetQuery) Unique(unique bool) *PetQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (pq *PetQuery) Order(o ...pet.Order) *PetQuery {
+func (pq *PetQuery) Order(o ...pet.OrderOption) *PetQuery {
 	pq.order = append(pq.order, o...)
 	return pq
 }
@@ -278,7 +278,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 	return &PetQuery{
 		config:     pq.config,
 		ctx:        pq.ctx.Clone(),
-		order:      append([]pet.Order{}, pq.order...),
+		order:      append([]pet.OrderOption{}, pq.order...),
 		inters:     append([]Interceptor{}, pq.inters...),
 		predicates: append([]predicate.Pet{}, pq.predicates...),
 		withOwner:  pq.withOwner.Clone(),

--- a/entc/integration/template/ent/user/user.go
+++ b/entc/integration/template/ent/user/user.go
@@ -57,42 +57,42 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the User queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the User queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByPetsCount orders the results by pets count.
-func ByPetsCount(opts ...sql.OrderTermOption) Order {
+func ByPetsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newPetsStep(), opts...)
 	}
 }
 
 // ByPets orders the results by pets terms.
-func ByPets(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByPets(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newPetsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByFriendsCount orders the results by friends count.
-func ByFriendsCount(opts ...sql.OrderTermOption) Order {
+func ByFriendsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newFriendsStep(), opts...)
 	}
 }
 
 // ByFriends orders the results by friends terms.
-func ByFriends(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByFriends(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newFriendsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/entc/integration/template/ent/user_query.go
+++ b/entc/integration/template/ent/user_query.go
@@ -24,7 +24,7 @@ import (
 type UserQuery struct {
 	config
 	ctx         *QueryContext
-	order       []user.Order
+	order       []user.OrderOption
 	inters      []Interceptor
 	predicates  []predicate.User
 	withPets    *PetQuery
@@ -63,7 +63,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
+func (uq *UserQuery) Order(o ...user.OrderOption) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -301,7 +301,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:      uq.config,
 		ctx:         uq.ctx.Clone(),
-		order:       append([]user.Order{}, uq.order...),
+		order:       append([]user.OrderOption{}, uq.order...),
 		inters:      append([]Interceptor{}, uq.inters...),
 		predicates:  append([]predicate.User{}, uq.predicates...),
 		withPets:    uq.withPets.Clone(),

--- a/examples/edgeindex/ent/city/city.go
+++ b/examples/edgeindex/ent/city/city.go
@@ -47,28 +47,28 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the City queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the City queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByStreetsCount orders the results by streets count.
-func ByStreetsCount(opts ...sql.OrderTermOption) Order {
+func ByStreetsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newStreetsStep(), opts...)
 	}
 }
 
 // ByStreets orders the results by streets terms.
-func ByStreets(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByStreets(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newStreetsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/examples/edgeindex/ent/city_query.go
+++ b/examples/edgeindex/ent/city_query.go
@@ -24,7 +24,7 @@ import (
 type CityQuery struct {
 	config
 	ctx         *QueryContext
-	order       []city.Order
+	order       []city.OrderOption
 	inters      []Interceptor
 	predicates  []predicate.City
 	withStreets *StreetQuery
@@ -59,7 +59,7 @@ func (cq *CityQuery) Unique(unique bool) *CityQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *CityQuery) Order(o ...city.Order) *CityQuery {
+func (cq *CityQuery) Order(o ...city.OrderOption) *CityQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -275,7 +275,7 @@ func (cq *CityQuery) Clone() *CityQuery {
 	return &CityQuery{
 		config:      cq.config,
 		ctx:         cq.ctx.Clone(),
-		order:       append([]city.Order{}, cq.order...),
+		order:       append([]city.OrderOption{}, cq.order...),
 		inters:      append([]Interceptor{}, cq.inters...),
 		predicates:  append([]predicate.City{}, cq.predicates...),
 		withStreets: cq.withStreets.Clone(),

--- a/examples/edgeindex/ent/street/street.go
+++ b/examples/edgeindex/ent/street/street.go
@@ -58,21 +58,21 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Street queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Street queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByCityField orders the results by city field.
-func ByCityField(field string, opts ...sql.OrderTermOption) Order {
+func ByCityField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newCityStep(), sql.OrderByField(field, opts...))
 	}

--- a/examples/edgeindex/ent/street_query.go
+++ b/examples/edgeindex/ent/street_query.go
@@ -23,7 +23,7 @@ import (
 type StreetQuery struct {
 	config
 	ctx        *QueryContext
-	order      []street.Order
+	order      []street.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Street
 	withCity   *CityQuery
@@ -59,7 +59,7 @@ func (sq *StreetQuery) Unique(unique bool) *StreetQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (sq *StreetQuery) Order(o ...street.Order) *StreetQuery {
+func (sq *StreetQuery) Order(o ...street.OrderOption) *StreetQuery {
 	sq.order = append(sq.order, o...)
 	return sq
 }
@@ -275,7 +275,7 @@ func (sq *StreetQuery) Clone() *StreetQuery {
 	return &StreetQuery{
 		config:     sq.config,
 		ctx:        sq.ctx.Clone(),
-		order:      append([]street.Order{}, sq.order...),
+		order:      append([]street.OrderOption{}, sq.order...),
 		inters:     append([]Interceptor{}, sq.inters...),
 		predicates: append([]predicate.Street{}, sq.predicates...),
 		withCity:   sq.withCity.Clone(),

--- a/examples/encryptfield/ent/intercept/intercept.go
+++ b/examples/encryptfield/ent/intercept/intercept.go
@@ -103,7 +103,7 @@ func (f TraverseUser) Traverse(ctx context.Context, q ent.Query) error {
 func NewQuery(q ent.Query) (Query, error) {
 	switch q := q.(type) {
 	case *ent.UserQuery:
-		return &query[*ent.UserQuery, predicate.User, user.Order]{typ: ent.TypeUser, tq: q}, nil
+		return &query[*ent.UserQuery, predicate.User, user.OrderOption]{typ: ent.TypeUser, tq: q}, nil
 	default:
 		return nil, fmt.Errorf("unknown query type %T", q)
 	}

--- a/examples/encryptfield/ent/user/user.go
+++ b/examples/encryptfield/ent/user/user.go
@@ -51,20 +51,20 @@ var (
 	Interceptors [1]ent.Interceptor
 )
 
-// Order defines the ordering method for the User queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the User queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByNickname orders the results by the nickname field.
-func ByNickname(opts ...sql.OrderTermOption) Order {
+func ByNickname(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldNickname, opts...).ToFunc()
 }

--- a/examples/encryptfield/ent/user_query.go
+++ b/examples/encryptfield/ent/user_query.go
@@ -22,7 +22,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []user.Order
+	order      []user.OrderOption
 	inters     []Interceptor
 	predicates []predicate.User
 	// intermediate query (i.e. traversal path).
@@ -56,7 +56,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
+func (uq *UserQuery) Order(o ...user.OrderOption) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -250,7 +250,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]user.Order{}, uq.order...),
+		order:      append([]user.OrderOption{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		// clone intermediate query.

--- a/examples/entcpkg/ent/user/user.go
+++ b/examples/entcpkg/ent/user/user.go
@@ -40,20 +40,20 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the User queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the User queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByAge orders the results by the age field.
-func ByAge(opts ...sql.OrderTermOption) Order {
+func ByAge(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAge, opts...).ToFunc()
 }

--- a/examples/entcpkg/ent/user_query.go
+++ b/examples/entcpkg/ent/user_query.go
@@ -22,7 +22,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []user.Order
+	order      []user.OrderOption
 	inters     []Interceptor
 	predicates []predicate.User
 	// intermediate query (i.e. traversal path).
@@ -56,7 +56,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
+func (uq *UserQuery) Order(o ...user.OrderOption) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -250,7 +250,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]user.Order{}, uq.order...),
+		order:      append([]user.OrderOption{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		// clone intermediate query.

--- a/examples/fs/ent/file/file.go
+++ b/examples/fs/ent/file/file.go
@@ -61,45 +61,45 @@ var (
 	DefaultDeleted bool
 )
 
-// Order defines the ordering method for the File queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the File queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByDeleted orders the results by the deleted field.
-func ByDeleted(opts ...sql.OrderTermOption) Order {
+func ByDeleted(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDeleted, opts...).ToFunc()
 }
 
 // ByParentID orders the results by the parent_id field.
-func ByParentID(opts ...sql.OrderTermOption) Order {
+func ByParentID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldParentID, opts...).ToFunc()
 }
 
 // ByParentField orders the results by parent field.
-func ByParentField(field string, opts ...sql.OrderTermOption) Order {
+func ByParentField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newParentStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByChildrenCount orders the results by children count.
-func ByChildrenCount(opts ...sql.OrderTermOption) Order {
+func ByChildrenCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newChildrenStep(), opts...)
 	}
 }
 
 // ByChildren orders the results by children terms.
-func ByChildren(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByChildren(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newChildrenStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/examples/fs/ent/file_query.go
+++ b/examples/fs/ent/file_query.go
@@ -23,7 +23,7 @@ import (
 type FileQuery struct {
 	config
 	ctx          *QueryContext
-	order        []file.Order
+	order        []file.OrderOption
 	inters       []Interceptor
 	predicates   []predicate.File
 	withParent   *FileQuery
@@ -59,7 +59,7 @@ func (fq *FileQuery) Unique(unique bool) *FileQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (fq *FileQuery) Order(o ...file.Order) *FileQuery {
+func (fq *FileQuery) Order(o ...file.OrderOption) *FileQuery {
 	fq.order = append(fq.order, o...)
 	return fq
 }
@@ -297,7 +297,7 @@ func (fq *FileQuery) Clone() *FileQuery {
 	return &FileQuery{
 		config:       fq.config,
 		ctx:          fq.ctx.Clone(),
-		order:        append([]file.Order{}, fq.order...),
+		order:        append([]file.OrderOption{}, fq.order...),
 		inters:       append([]Interceptor{}, fq.inters...),
 		predicates:   append([]predicate.File{}, fq.predicates...),
 		withParent:   fq.withParent.Clone(),

--- a/examples/jsonencode/ent/card/card.go
+++ b/examples/jsonencode/ent/card/card.go
@@ -37,15 +37,15 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Card queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Card queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByNumber orders the results by the number field.
-func ByNumber(opts ...sql.OrderTermOption) Order {
+func ByNumber(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldNumber, opts...).ToFunc()
 }

--- a/examples/jsonencode/ent/card_query.go
+++ b/examples/jsonencode/ent/card_query.go
@@ -22,7 +22,7 @@ import (
 type CardQuery struct {
 	config
 	ctx        *QueryContext
-	order      []card.Order
+	order      []card.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Card
 	// intermediate query (i.e. traversal path).
@@ -56,7 +56,7 @@ func (cq *CardQuery) Unique(unique bool) *CardQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *CardQuery) Order(o ...card.Order) *CardQuery {
+func (cq *CardQuery) Order(o ...card.OrderOption) *CardQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -250,7 +250,7 @@ func (cq *CardQuery) Clone() *CardQuery {
 	return &CardQuery{
 		config:     cq.config,
 		ctx:        cq.ctx.Clone(),
-		order:      append([]card.Order{}, cq.order...),
+		order:      append([]card.OrderOption{}, cq.order...),
 		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Card{}, cq.predicates...),
 		// clone intermediate query.

--- a/examples/jsonencode/ent/pet/pet.go
+++ b/examples/jsonencode/ent/pet/pet.go
@@ -53,31 +53,31 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Pet queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Pet queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByAge orders the results by the age field.
-func ByAge(opts ...sql.OrderTermOption) Order {
+func ByAge(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAge, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByOwnerID orders the results by the owner_id field.
-func ByOwnerID(opts ...sql.OrderTermOption) Order {
+func ByOwnerID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldOwnerID, opts...).ToFunc()
 }
 
 // ByOwnerField orders the results by owner field.
-func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+func ByOwnerField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
 	}

--- a/examples/jsonencode/ent/pet_query.go
+++ b/examples/jsonencode/ent/pet_query.go
@@ -23,7 +23,7 @@ import (
 type PetQuery struct {
 	config
 	ctx        *QueryContext
-	order      []pet.Order
+	order      []pet.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Pet
 	withOwner  *UserQuery
@@ -58,7 +58,7 @@ func (pq *PetQuery) Unique(unique bool) *PetQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (pq *PetQuery) Order(o ...pet.Order) *PetQuery {
+func (pq *PetQuery) Order(o ...pet.OrderOption) *PetQuery {
 	pq.order = append(pq.order, o...)
 	return pq
 }
@@ -274,7 +274,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 	return &PetQuery{
 		config:     pq.config,
 		ctx:        pq.ctx.Clone(),
-		order:      append([]pet.Order{}, pq.order...),
+		order:      append([]pet.OrderOption{}, pq.order...),
 		inters:     append([]Interceptor{}, pq.inters...),
 		predicates: append([]predicate.Pet{}, pq.predicates...),
 		withOwner:  pq.withOwner.Clone(),

--- a/examples/jsonencode/ent/user/user.go
+++ b/examples/jsonencode/ent/user/user.go
@@ -50,33 +50,33 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the User queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the User queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByAge orders the results by the age field.
-func ByAge(opts ...sql.OrderTermOption) Order {
+func ByAge(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAge, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByPetsCount orders the results by pets count.
-func ByPetsCount(opts ...sql.OrderTermOption) Order {
+func ByPetsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newPetsStep(), opts...)
 	}
 }
 
 // ByPets orders the results by pets terms.
-func ByPets(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByPets(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newPetsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/examples/jsonencode/ent/user_query.go
+++ b/examples/jsonencode/ent/user_query.go
@@ -24,7 +24,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []user.Order
+	order      []user.OrderOption
 	inters     []Interceptor
 	predicates []predicate.User
 	withPets   *PetQuery
@@ -59,7 +59,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
+func (uq *UserQuery) Order(o ...user.OrderOption) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -275,7 +275,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]user.Order{}, uq.order...),
+		order:      append([]user.OrderOption{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		withPets:   uq.withPets.Clone(),

--- a/examples/m2m2types/ent/group/group.go
+++ b/examples/m2m2types/ent/group/group.go
@@ -51,28 +51,28 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Group queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Group queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByUsersCount orders the results by users count.
-func ByUsersCount(opts ...sql.OrderTermOption) Order {
+func ByUsersCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newUsersStep(), opts...)
 	}
 }
 
 // ByUsers orders the results by users terms.
-func ByUsers(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByUsers(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newUsersStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/examples/m2m2types/ent/group_query.go
+++ b/examples/m2m2types/ent/group_query.go
@@ -24,7 +24,7 @@ import (
 type GroupQuery struct {
 	config
 	ctx        *QueryContext
-	order      []group.Order
+	order      []group.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Group
 	withUsers  *UserQuery
@@ -59,7 +59,7 @@ func (gq *GroupQuery) Unique(unique bool) *GroupQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (gq *GroupQuery) Order(o ...group.Order) *GroupQuery {
+func (gq *GroupQuery) Order(o ...group.OrderOption) *GroupQuery {
 	gq.order = append(gq.order, o...)
 	return gq
 }
@@ -275,7 +275,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 	return &GroupQuery{
 		config:     gq.config,
 		ctx:        gq.ctx.Clone(),
-		order:      append([]group.Order{}, gq.order...),
+		order:      append([]group.OrderOption{}, gq.order...),
 		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Group{}, gq.predicates...),
 		withUsers:  gq.withUsers.Clone(),

--- a/examples/m2m2types/ent/user/user.go
+++ b/examples/m2m2types/ent/user/user.go
@@ -54,33 +54,33 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the User queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the User queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByAge orders the results by the age field.
-func ByAge(opts ...sql.OrderTermOption) Order {
+func ByAge(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAge, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByGroupsCount orders the results by groups count.
-func ByGroupsCount(opts ...sql.OrderTermOption) Order {
+func ByGroupsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newGroupsStep(), opts...)
 	}
 }
 
 // ByGroups orders the results by groups terms.
-func ByGroups(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByGroups(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newGroupsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/examples/m2m2types/ent/user_query.go
+++ b/examples/m2m2types/ent/user_query.go
@@ -24,7 +24,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []user.Order
+	order      []user.OrderOption
 	inters     []Interceptor
 	predicates []predicate.User
 	withGroups *GroupQuery
@@ -59,7 +59,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
+func (uq *UserQuery) Order(o ...user.OrderOption) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -275,7 +275,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]user.Order{}, uq.order...),
+		order:      append([]user.OrderOption{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		withGroups: uq.withGroups.Clone(),

--- a/examples/m2mbidi/ent/user/user.go
+++ b/examples/m2mbidi/ent/user/user.go
@@ -51,33 +51,33 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the User queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the User queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByAge orders the results by the age field.
-func ByAge(opts ...sql.OrderTermOption) Order {
+func ByAge(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAge, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByFriendsCount orders the results by friends count.
-func ByFriendsCount(opts ...sql.OrderTermOption) Order {
+func ByFriendsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newFriendsStep(), opts...)
 	}
 }
 
 // ByFriends orders the results by friends terms.
-func ByFriends(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByFriends(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newFriendsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/examples/m2mbidi/ent/user_query.go
+++ b/examples/m2mbidi/ent/user_query.go
@@ -23,7 +23,7 @@ import (
 type UserQuery struct {
 	config
 	ctx         *QueryContext
-	order       []user.Order
+	order       []user.OrderOption
 	inters      []Interceptor
 	predicates  []predicate.User
 	withFriends *UserQuery
@@ -58,7 +58,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
+func (uq *UserQuery) Order(o ...user.OrderOption) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -274,7 +274,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:      uq.config,
 		ctx:         uq.ctx.Clone(),
-		order:       append([]user.Order{}, uq.order...),
+		order:       append([]user.OrderOption{}, uq.order...),
 		inters:      append([]Interceptor{}, uq.inters...),
 		predicates:  append([]predicate.User{}, uq.predicates...),
 		withFriends: uq.withFriends.Clone(),

--- a/examples/m2mrecur/ent/user/user.go
+++ b/examples/m2mrecur/ent/user/user.go
@@ -58,47 +58,47 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the User queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the User queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByAge orders the results by the age field.
-func ByAge(opts ...sql.OrderTermOption) Order {
+func ByAge(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAge, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByFollowersCount orders the results by followers count.
-func ByFollowersCount(opts ...sql.OrderTermOption) Order {
+func ByFollowersCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newFollowersStep(), opts...)
 	}
 }
 
 // ByFollowers orders the results by followers terms.
-func ByFollowers(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByFollowers(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newFollowersStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByFollowingCount orders the results by following count.
-func ByFollowingCount(opts ...sql.OrderTermOption) Order {
+func ByFollowingCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newFollowingStep(), opts...)
 	}
 }
 
 // ByFollowing orders the results by following terms.
-func ByFollowing(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByFollowing(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newFollowingStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/examples/m2mrecur/ent/user_query.go
+++ b/examples/m2mrecur/ent/user_query.go
@@ -23,7 +23,7 @@ import (
 type UserQuery struct {
 	config
 	ctx           *QueryContext
-	order         []user.Order
+	order         []user.OrderOption
 	inters        []Interceptor
 	predicates    []predicate.User
 	withFollowers *UserQuery
@@ -59,7 +59,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
+func (uq *UserQuery) Order(o ...user.OrderOption) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -297,7 +297,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:        uq.config,
 		ctx:           uq.ctx.Clone(),
-		order:         append([]user.Order{}, uq.order...),
+		order:         append([]user.OrderOption{}, uq.order...),
 		inters:        append([]Interceptor{}, uq.inters...),
 		predicates:    append([]predicate.User{}, uq.predicates...),
 		withFollowers: uq.withFollowers.Clone(),

--- a/examples/migration/ent/card/card.go
+++ b/examples/migration/ent/card/card.go
@@ -52,21 +52,21 @@ var (
 	DefaultOwnerID int
 )
 
-// Order defines the ordering method for the Card queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Card queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByOwnerID orders the results by the owner_id field.
-func ByOwnerID(opts ...sql.OrderTermOption) Order {
+func ByOwnerID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldOwnerID, opts...).ToFunc()
 }
 
 // ByOwnerField orders the results by owner field.
-func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+func ByOwnerField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
 	}

--- a/examples/migration/ent/card_query.go
+++ b/examples/migration/ent/card_query.go
@@ -23,7 +23,7 @@ import (
 type CardQuery struct {
 	config
 	ctx        *QueryContext
-	order      []card.Order
+	order      []card.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Card
 	withOwner  *UserQuery
@@ -58,7 +58,7 @@ func (cq *CardQuery) Unique(unique bool) *CardQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *CardQuery) Order(o ...card.Order) *CardQuery {
+func (cq *CardQuery) Order(o ...card.OrderOption) *CardQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -274,7 +274,7 @@ func (cq *CardQuery) Clone() *CardQuery {
 	return &CardQuery{
 		config:     cq.config,
 		ctx:        cq.ctx.Clone(),
-		order:      append([]card.Order{}, cq.order...),
+		order:      append([]card.OrderOption{}, cq.order...),
 		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Card{}, cq.predicates...),
 		withOwner:  cq.withOwner.Clone(),

--- a/examples/migration/ent/pet/pet.go
+++ b/examples/migration/ent/pet/pet.go
@@ -64,33 +64,33 @@ var (
 	DefaultID func() uuid.UUID
 )
 
-// Order defines the ordering method for the Pet queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Pet queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByBestFriendID orders the results by the best_friend_id field.
-func ByBestFriendID(opts ...sql.OrderTermOption) Order {
+func ByBestFriendID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldBestFriendID, opts...).ToFunc()
 }
 
 // ByOwnerID orders the results by the owner_id field.
-func ByOwnerID(opts ...sql.OrderTermOption) Order {
+func ByOwnerID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldOwnerID, opts...).ToFunc()
 }
 
 // ByBestFriendField orders the results by best_friend field.
-func ByBestFriendField(field string, opts ...sql.OrderTermOption) Order {
+func ByBestFriendField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newBestFriendStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByOwnerField orders the results by owner field.
-func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+func ByOwnerField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
 	}

--- a/examples/migration/ent/pet_query.go
+++ b/examples/migration/ent/pet_query.go
@@ -24,7 +24,7 @@ import (
 type PetQuery struct {
 	config
 	ctx            *QueryContext
-	order          []pet.Order
+	order          []pet.OrderOption
 	inters         []Interceptor
 	predicates     []predicate.Pet
 	withBestFriend *PetQuery
@@ -60,7 +60,7 @@ func (pq *PetQuery) Unique(unique bool) *PetQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (pq *PetQuery) Order(o ...pet.Order) *PetQuery {
+func (pq *PetQuery) Order(o ...pet.OrderOption) *PetQuery {
 	pq.order = append(pq.order, o...)
 	return pq
 }
@@ -298,7 +298,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 	return &PetQuery{
 		config:         pq.config,
 		ctx:            pq.ctx.Clone(),
-		order:          append([]pet.Order{}, pq.order...),
+		order:          append([]pet.OrderOption{}, pq.order...),
 		inters:         append([]Interceptor{}, pq.inters...),
 		predicates:     append([]predicate.Pet{}, pq.predicates...),
 		withBestFriend: pq.withBestFriend.Clone(),

--- a/examples/migration/ent/user/user.go
+++ b/examples/migration/ent/user/user.go
@@ -53,33 +53,33 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the User queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the User queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByAge orders the results by the age field.
-func ByAge(opts ...sql.OrderTermOption) Order {
+func ByAge(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAge, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByCardsCount orders the results by cards count.
-func ByCardsCount(opts ...sql.OrderTermOption) Order {
+func ByCardsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newCardsStep(), opts...)
 	}
 }
 
 // ByCards orders the results by cards terms.
-func ByCards(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByCards(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newCardsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/examples/migration/ent/user_query.go
+++ b/examples/migration/ent/user_query.go
@@ -24,7 +24,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []user.Order
+	order      []user.OrderOption
 	inters     []Interceptor
 	predicates []predicate.User
 	withCards  *CardQuery
@@ -59,7 +59,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
+func (uq *UserQuery) Order(o ...user.OrderOption) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -275,7 +275,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]user.Order{}, uq.order...),
+		order:      append([]user.OrderOption{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		withCards:  uq.withCards.Clone(),

--- a/examples/o2m2types/ent/pet/pet.go
+++ b/examples/o2m2types/ent/pet/pet.go
@@ -58,21 +58,21 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Pet queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Pet queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByOwnerField orders the results by owner field.
-func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+func ByOwnerField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
 	}

--- a/examples/o2m2types/ent/pet_query.go
+++ b/examples/o2m2types/ent/pet_query.go
@@ -23,7 +23,7 @@ import (
 type PetQuery struct {
 	config
 	ctx        *QueryContext
-	order      []pet.Order
+	order      []pet.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Pet
 	withOwner  *UserQuery
@@ -59,7 +59,7 @@ func (pq *PetQuery) Unique(unique bool) *PetQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (pq *PetQuery) Order(o ...pet.Order) *PetQuery {
+func (pq *PetQuery) Order(o ...pet.OrderOption) *PetQuery {
 	pq.order = append(pq.order, o...)
 	return pq
 }
@@ -275,7 +275,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 	return &PetQuery{
 		config:     pq.config,
 		ctx:        pq.ctx.Clone(),
-		order:      append([]pet.Order{}, pq.order...),
+		order:      append([]pet.OrderOption{}, pq.order...),
 		inters:     append([]Interceptor{}, pq.inters...),
 		predicates: append([]predicate.Pet{}, pq.predicates...),
 		withOwner:  pq.withOwner.Clone(),

--- a/examples/o2m2types/ent/user/user.go
+++ b/examples/o2m2types/ent/user/user.go
@@ -50,33 +50,33 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the User queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the User queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByAge orders the results by the age field.
-func ByAge(opts ...sql.OrderTermOption) Order {
+func ByAge(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAge, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByPetsCount orders the results by pets count.
-func ByPetsCount(opts ...sql.OrderTermOption) Order {
+func ByPetsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newPetsStep(), opts...)
 	}
 }
 
 // ByPets orders the results by pets terms.
-func ByPets(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByPets(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newPetsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/examples/o2m2types/ent/user_query.go
+++ b/examples/o2m2types/ent/user_query.go
@@ -24,7 +24,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []user.Order
+	order      []user.OrderOption
 	inters     []Interceptor
 	predicates []predicate.User
 	withPets   *PetQuery
@@ -59,7 +59,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
+func (uq *UserQuery) Order(o ...user.OrderOption) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -275,7 +275,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]user.Order{}, uq.order...),
+		order:      append([]user.OrderOption{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		withPets:   uq.withPets.Clone(),

--- a/examples/o2mrecur/ent/node/node.go
+++ b/examples/o2mrecur/ent/node/node.go
@@ -53,40 +53,40 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Node queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Node queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByValue orders the results by the value field.
-func ByValue(opts ...sql.OrderTermOption) Order {
+func ByValue(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldValue, opts...).ToFunc()
 }
 
 // ByParentID orders the results by the parent_id field.
-func ByParentID(opts ...sql.OrderTermOption) Order {
+func ByParentID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldParentID, opts...).ToFunc()
 }
 
 // ByParentField orders the results by parent field.
-func ByParentField(field string, opts ...sql.OrderTermOption) Order {
+func ByParentField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newParentStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByChildrenCount orders the results by children count.
-func ByChildrenCount(opts ...sql.OrderTermOption) Order {
+func ByChildrenCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newChildrenStep(), opts...)
 	}
 }
 
 // ByChildren orders the results by children terms.
-func ByChildren(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByChildren(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newChildrenStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/examples/o2mrecur/ent/node_query.go
+++ b/examples/o2mrecur/ent/node_query.go
@@ -23,7 +23,7 @@ import (
 type NodeQuery struct {
 	config
 	ctx          *QueryContext
-	order        []node.Order
+	order        []node.OrderOption
 	inters       []Interceptor
 	predicates   []predicate.Node
 	withParent   *NodeQuery
@@ -59,7 +59,7 @@ func (nq *NodeQuery) Unique(unique bool) *NodeQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (nq *NodeQuery) Order(o ...node.Order) *NodeQuery {
+func (nq *NodeQuery) Order(o ...node.OrderOption) *NodeQuery {
 	nq.order = append(nq.order, o...)
 	return nq
 }
@@ -297,7 +297,7 @@ func (nq *NodeQuery) Clone() *NodeQuery {
 	return &NodeQuery{
 		config:       nq.config,
 		ctx:          nq.ctx.Clone(),
-		order:        append([]node.Order{}, nq.order...),
+		order:        append([]node.OrderOption{}, nq.order...),
 		inters:       append([]Interceptor{}, nq.inters...),
 		predicates:   append([]predicate.Node{}, nq.predicates...),
 		withParent:   nq.withParent.Clone(),

--- a/examples/o2o2types/ent/card/card.go
+++ b/examples/o2o2types/ent/card/card.go
@@ -61,26 +61,26 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Card queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Card queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByExpired orders the results by the expired field.
-func ByExpired(opts ...sql.OrderTermOption) Order {
+func ByExpired(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldExpired, opts...).ToFunc()
 }
 
 // ByNumber orders the results by the number field.
-func ByNumber(opts ...sql.OrderTermOption) Order {
+func ByNumber(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldNumber, opts...).ToFunc()
 }
 
 // ByOwnerField orders the results by owner field.
-func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+func ByOwnerField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
 	}

--- a/examples/o2o2types/ent/card_query.go
+++ b/examples/o2o2types/ent/card_query.go
@@ -23,7 +23,7 @@ import (
 type CardQuery struct {
 	config
 	ctx        *QueryContext
-	order      []card.Order
+	order      []card.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Card
 	withOwner  *UserQuery
@@ -59,7 +59,7 @@ func (cq *CardQuery) Unique(unique bool) *CardQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *CardQuery) Order(o ...card.Order) *CardQuery {
+func (cq *CardQuery) Order(o ...card.OrderOption) *CardQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -275,7 +275,7 @@ func (cq *CardQuery) Clone() *CardQuery {
 	return &CardQuery{
 		config:     cq.config,
 		ctx:        cq.ctx.Clone(),
-		order:      append([]card.Order{}, cq.order...),
+		order:      append([]card.OrderOption{}, cq.order...),
 		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Card{}, cq.predicates...),
 		withOwner:  cq.withOwner.Clone(),

--- a/examples/o2o2types/ent/user/user.go
+++ b/examples/o2o2types/ent/user/user.go
@@ -50,26 +50,26 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the User queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the User queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByAge orders the results by the age field.
-func ByAge(opts ...sql.OrderTermOption) Order {
+func ByAge(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAge, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByCardField orders the results by card field.
-func ByCardField(field string, opts ...sql.OrderTermOption) Order {
+func ByCardField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newCardStep(), sql.OrderByField(field, opts...))
 	}

--- a/examples/o2o2types/ent/user_query.go
+++ b/examples/o2o2types/ent/user_query.go
@@ -24,7 +24,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []user.Order
+	order      []user.OrderOption
 	inters     []Interceptor
 	predicates []predicate.User
 	withCard   *CardQuery
@@ -59,7 +59,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
+func (uq *UserQuery) Order(o ...user.OrderOption) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -275,7 +275,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]user.Order{}, uq.order...),
+		order:      append([]user.OrderOption{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		withCard:   uq.withCard.Clone(),

--- a/examples/o2obidi/ent/user/user.go
+++ b/examples/o2obidi/ent/user/user.go
@@ -58,26 +58,26 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the User queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the User queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByAge orders the results by the age field.
-func ByAge(opts ...sql.OrderTermOption) Order {
+func ByAge(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAge, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // BySpouseField orders the results by spouse field.
-func BySpouseField(field string, opts ...sql.OrderTermOption) Order {
+func BySpouseField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newSpouseStep(), sql.OrderByField(field, opts...))
 	}

--- a/examples/o2obidi/ent/user_query.go
+++ b/examples/o2obidi/ent/user_query.go
@@ -22,7 +22,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []user.Order
+	order      []user.OrderOption
 	inters     []Interceptor
 	predicates []predicate.User
 	withSpouse *UserQuery
@@ -58,7 +58,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
+func (uq *UserQuery) Order(o ...user.OrderOption) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -274,7 +274,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]user.Order{}, uq.order...),
+		order:      append([]user.OrderOption{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		withSpouse: uq.withSpouse.Clone(),

--- a/examples/o2orecur/ent/node/node.go
+++ b/examples/o2orecur/ent/node/node.go
@@ -53,33 +53,33 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Node queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Node queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByValue orders the results by the value field.
-func ByValue(opts ...sql.OrderTermOption) Order {
+func ByValue(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldValue, opts...).ToFunc()
 }
 
 // ByPrevID orders the results by the prev_id field.
-func ByPrevID(opts ...sql.OrderTermOption) Order {
+func ByPrevID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldPrevID, opts...).ToFunc()
 }
 
 // ByPrevField orders the results by prev field.
-func ByPrevField(field string, opts ...sql.OrderTermOption) Order {
+func ByPrevField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newPrevStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByNextField orders the results by next field.
-func ByNextField(field string, opts ...sql.OrderTermOption) Order {
+func ByNextField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newNextStep(), sql.OrderByField(field, opts...))
 	}

--- a/examples/o2orecur/ent/node_query.go
+++ b/examples/o2orecur/ent/node_query.go
@@ -23,7 +23,7 @@ import (
 type NodeQuery struct {
 	config
 	ctx        *QueryContext
-	order      []node.Order
+	order      []node.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Node
 	withPrev   *NodeQuery
@@ -59,7 +59,7 @@ func (nq *NodeQuery) Unique(unique bool) *NodeQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (nq *NodeQuery) Order(o ...node.Order) *NodeQuery {
+func (nq *NodeQuery) Order(o ...node.OrderOption) *NodeQuery {
 	nq.order = append(nq.order, o...)
 	return nq
 }
@@ -297,7 +297,7 @@ func (nq *NodeQuery) Clone() *NodeQuery {
 	return &NodeQuery{
 		config:     nq.config,
 		ctx:        nq.ctx.Clone(),
-		order:      append([]node.Order{}, nq.order...),
+		order:      append([]node.OrderOption{}, nq.order...),
 		inters:     append([]Interceptor{}, nq.inters...),
 		predicates: append([]predicate.Node{}, nq.predicates...),
 		withPrev:   nq.withPrev.Clone(),

--- a/examples/privacyadmin/ent/user/user.go
+++ b/examples/privacyadmin/ent/user/user.go
@@ -50,15 +50,15 @@ var (
 	DefaultName string
 )
 
-// Order defines the ordering method for the User queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the User queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }

--- a/examples/privacyadmin/ent/user_query.go
+++ b/examples/privacyadmin/ent/user_query.go
@@ -23,7 +23,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []user.Order
+	order      []user.OrderOption
 	inters     []Interceptor
 	predicates []predicate.User
 	// intermediate query (i.e. traversal path).
@@ -57,7 +57,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
+func (uq *UserQuery) Order(o ...user.OrderOption) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -251,7 +251,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]user.Order{}, uq.order...),
+		order:      append([]user.OrderOption{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		// clone intermediate query.

--- a/examples/privacytenant/ent/group/group.go
+++ b/examples/privacytenant/ent/group/group.go
@@ -76,40 +76,40 @@ var (
 	DefaultName string
 )
 
-// Order defines the ordering method for the Group queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Group queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByTenantID orders the results by the tenant_id field.
-func ByTenantID(opts ...sql.OrderTermOption) Order {
+func ByTenantID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldTenantID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByTenantField orders the results by tenant field.
-func ByTenantField(field string, opts ...sql.OrderTermOption) Order {
+func ByTenantField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newTenantStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByUsersCount orders the results by users count.
-func ByUsersCount(opts ...sql.OrderTermOption) Order {
+func ByUsersCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newUsersStep(), opts...)
 	}
 }
 
 // ByUsers orders the results by users terms.
-func ByUsers(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByUsers(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newUsersStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/examples/privacytenant/ent/group_query.go
+++ b/examples/privacytenant/ent/group_query.go
@@ -26,7 +26,7 @@ import (
 type GroupQuery struct {
 	config
 	ctx        *QueryContext
-	order      []group.Order
+	order      []group.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Group
 	withTenant *TenantQuery
@@ -62,7 +62,7 @@ func (gq *GroupQuery) Unique(unique bool) *GroupQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (gq *GroupQuery) Order(o ...group.Order) *GroupQuery {
+func (gq *GroupQuery) Order(o ...group.OrderOption) *GroupQuery {
 	gq.order = append(gq.order, o...)
 	return gq
 }
@@ -300,7 +300,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 	return &GroupQuery{
 		config:     gq.config,
 		ctx:        gq.ctx.Clone(),
-		order:      append([]group.Order{}, gq.order...),
+		order:      append([]group.OrderOption{}, gq.order...),
 		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Group{}, gq.predicates...),
 		withTenant: gq.withTenant.Clone(),

--- a/examples/privacytenant/ent/tenant/tenant.go
+++ b/examples/privacytenant/ent/tenant/tenant.go
@@ -50,15 +50,15 @@ var (
 	NameValidator func(string) error
 )
 
-// Order defines the ordering method for the Tenant queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Tenant queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }

--- a/examples/privacytenant/ent/tenant_query.go
+++ b/examples/privacytenant/ent/tenant_query.go
@@ -23,7 +23,7 @@ import (
 type TenantQuery struct {
 	config
 	ctx        *QueryContext
-	order      []tenant.Order
+	order      []tenant.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Tenant
 	// intermediate query (i.e. traversal path).
@@ -57,7 +57,7 @@ func (tq *TenantQuery) Unique(unique bool) *TenantQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (tq *TenantQuery) Order(o ...tenant.Order) *TenantQuery {
+func (tq *TenantQuery) Order(o ...tenant.OrderOption) *TenantQuery {
 	tq.order = append(tq.order, o...)
 	return tq
 }
@@ -251,7 +251,7 @@ func (tq *TenantQuery) Clone() *TenantQuery {
 	return &TenantQuery{
 		config:     tq.config,
 		ctx:        tq.ctx.Clone(),
-		order:      append([]tenant.Order{}, tq.order...),
+		order:      append([]tenant.OrderOption{}, tq.order...),
 		inters:     append([]Interceptor{}, tq.inters...),
 		predicates: append([]predicate.Tenant{}, tq.predicates...),
 		// clone intermediate query.

--- a/examples/privacytenant/ent/user/user.go
+++ b/examples/privacytenant/ent/user/user.go
@@ -79,40 +79,40 @@ var (
 	DefaultName string
 )
 
-// Order defines the ordering method for the User queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the User queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByTenantID orders the results by the tenant_id field.
-func ByTenantID(opts ...sql.OrderTermOption) Order {
+func ByTenantID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldTenantID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByTenantField orders the results by tenant field.
-func ByTenantField(field string, opts ...sql.OrderTermOption) Order {
+func ByTenantField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newTenantStep(), sql.OrderByField(field, opts...))
 	}
 }
 
 // ByGroupsCount orders the results by groups count.
-func ByGroupsCount(opts ...sql.OrderTermOption) Order {
+func ByGroupsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newGroupsStep(), opts...)
 	}
 }
 
 // ByGroups orders the results by groups terms.
-func ByGroups(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByGroups(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newGroupsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/examples/privacytenant/ent/user_query.go
+++ b/examples/privacytenant/ent/user_query.go
@@ -26,7 +26,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []user.Order
+	order      []user.OrderOption
 	inters     []Interceptor
 	predicates []predicate.User
 	withTenant *TenantQuery
@@ -62,7 +62,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
+func (uq *UserQuery) Order(o ...user.OrderOption) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -300,7 +300,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]user.Order{}, uq.order...),
+		order:      append([]user.OrderOption{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		withTenant: uq.withTenant.Clone(),

--- a/examples/start/ent/car/car.go
+++ b/examples/start/ent/car/car.go
@@ -61,26 +61,26 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Car queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Car queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByModel orders the results by the model field.
-func ByModel(opts ...sql.OrderTermOption) Order {
+func ByModel(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldModel, opts...).ToFunc()
 }
 
 // ByRegisteredAt orders the results by the registered_at field.
-func ByRegisteredAt(opts ...sql.OrderTermOption) Order {
+func ByRegisteredAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldRegisteredAt, opts...).ToFunc()
 }
 
 // ByOwnerField orders the results by owner field.
-func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+func ByOwnerField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
 	}

--- a/examples/start/ent/car_query.go
+++ b/examples/start/ent/car_query.go
@@ -23,7 +23,7 @@ import (
 type CarQuery struct {
 	config
 	ctx        *QueryContext
-	order      []car.Order
+	order      []car.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Car
 	withOwner  *UserQuery
@@ -59,7 +59,7 @@ func (cq *CarQuery) Unique(unique bool) *CarQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (cq *CarQuery) Order(o ...car.Order) *CarQuery {
+func (cq *CarQuery) Order(o ...car.OrderOption) *CarQuery {
 	cq.order = append(cq.order, o...)
 	return cq
 }
@@ -275,7 +275,7 @@ func (cq *CarQuery) Clone() *CarQuery {
 	return &CarQuery{
 		config:     cq.config,
 		ctx:        cq.ctx.Clone(),
-		order:      append([]car.Order{}, cq.order...),
+		order:      append([]car.OrderOption{}, cq.order...),
 		inters:     append([]Interceptor{}, cq.inters...),
 		predicates: append([]predicate.Car{}, cq.predicates...),
 		withOwner:  cq.withOwner.Clone(),

--- a/examples/start/ent/group/group.go
+++ b/examples/start/ent/group/group.go
@@ -56,28 +56,28 @@ var (
 	NameValidator func(string) error
 )
 
-// Order defines the ordering method for the Group queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Group queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByUsersCount orders the results by users count.
-func ByUsersCount(opts ...sql.OrderTermOption) Order {
+func ByUsersCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newUsersStep(), opts...)
 	}
 }
 
 // ByUsers orders the results by users terms.
-func ByUsers(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByUsers(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newUsersStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/examples/start/ent/group_query.go
+++ b/examples/start/ent/group_query.go
@@ -24,7 +24,7 @@ import (
 type GroupQuery struct {
 	config
 	ctx        *QueryContext
-	order      []group.Order
+	order      []group.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Group
 	withUsers  *UserQuery
@@ -59,7 +59,7 @@ func (gq *GroupQuery) Unique(unique bool) *GroupQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (gq *GroupQuery) Order(o ...group.Order) *GroupQuery {
+func (gq *GroupQuery) Order(o ...group.OrderOption) *GroupQuery {
 	gq.order = append(gq.order, o...)
 	return gq
 }
@@ -275,7 +275,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 	return &GroupQuery{
 		config:     gq.config,
 		ctx:        gq.ctx.Clone(),
-		order:      append([]group.Order{}, gq.order...),
+		order:      append([]group.OrderOption{}, gq.order...),
 		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Group{}, gq.predicates...),
 		withUsers:  gq.withUsers.Clone(),

--- a/examples/start/ent/user/user.go
+++ b/examples/start/ent/user/user.go
@@ -70,47 +70,47 @@ var (
 	DefaultName string
 )
 
-// Order defines the ordering method for the User queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the User queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByAge orders the results by the age field.
-func ByAge(opts ...sql.OrderTermOption) Order {
+func ByAge(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAge, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByCarsCount orders the results by cars count.
-func ByCarsCount(opts ...sql.OrderTermOption) Order {
+func ByCarsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newCarsStep(), opts...)
 	}
 }
 
 // ByCars orders the results by cars terms.
-func ByCars(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByCars(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newCarsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByGroupsCount orders the results by groups count.
-func ByGroupsCount(opts ...sql.OrderTermOption) Order {
+func ByGroupsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newGroupsStep(), opts...)
 	}
 }
 
 // ByGroups orders the results by groups terms.
-func ByGroups(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByGroups(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newGroupsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/examples/start/ent/user_query.go
+++ b/examples/start/ent/user_query.go
@@ -25,7 +25,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []user.Order
+	order      []user.OrderOption
 	inters     []Interceptor
 	predicates []predicate.User
 	withCars   *CarQuery
@@ -61,7 +61,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
+func (uq *UserQuery) Order(o ...user.OrderOption) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -299,7 +299,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]user.Order{}, uq.order...),
+		order:      append([]user.OrderOption{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		withCars:   uq.withCars.Clone(),

--- a/examples/traversal/ent/group/group.go
+++ b/examples/traversal/ent/group/group.go
@@ -71,35 +71,35 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Group queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Group queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByUsersCount orders the results by users count.
-func ByUsersCount(opts ...sql.OrderTermOption) Order {
+func ByUsersCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newUsersStep(), opts...)
 	}
 }
 
 // ByUsers orders the results by users terms.
-func ByUsers(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByUsers(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newUsersStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByAdminField orders the results by admin field.
-func ByAdminField(field string, opts ...sql.OrderTermOption) Order {
+func ByAdminField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newAdminStep(), sql.OrderByField(field, opts...))
 	}

--- a/examples/traversal/ent/group_query.go
+++ b/examples/traversal/ent/group_query.go
@@ -24,7 +24,7 @@ import (
 type GroupQuery struct {
 	config
 	ctx        *QueryContext
-	order      []group.Order
+	order      []group.OrderOption
 	inters     []Interceptor
 	predicates []predicate.Group
 	withUsers  *UserQuery
@@ -61,7 +61,7 @@ func (gq *GroupQuery) Unique(unique bool) *GroupQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (gq *GroupQuery) Order(o ...group.Order) *GroupQuery {
+func (gq *GroupQuery) Order(o ...group.OrderOption) *GroupQuery {
 	gq.order = append(gq.order, o...)
 	return gq
 }
@@ -299,7 +299,7 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 	return &GroupQuery{
 		config:     gq.config,
 		ctx:        gq.ctx.Clone(),
-		order:      append([]group.Order{}, gq.order...),
+		order:      append([]group.OrderOption{}, gq.order...),
 		inters:     append([]Interceptor{}, gq.inters...),
 		predicates: append([]predicate.Group{}, gq.predicates...),
 		withUsers:  gq.withUsers.Clone(),

--- a/examples/traversal/ent/pet/pet.go
+++ b/examples/traversal/ent/pet/pet.go
@@ -68,35 +68,35 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the Pet queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the Pet queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByFriendsCount orders the results by friends count.
-func ByFriendsCount(opts ...sql.OrderTermOption) Order {
+func ByFriendsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newFriendsStep(), opts...)
 	}
 }
 
 // ByFriends orders the results by friends terms.
-func ByFriends(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByFriends(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newFriendsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByOwnerField orders the results by owner field.
-func ByOwnerField(field string, opts ...sql.OrderTermOption) Order {
+func ByOwnerField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
 	}

--- a/examples/traversal/ent/pet_query.go
+++ b/examples/traversal/ent/pet_query.go
@@ -24,7 +24,7 @@ import (
 type PetQuery struct {
 	config
 	ctx         *QueryContext
-	order       []pet.Order
+	order       []pet.OrderOption
 	inters      []Interceptor
 	predicates  []predicate.Pet
 	withFriends *PetQuery
@@ -61,7 +61,7 @@ func (pq *PetQuery) Unique(unique bool) *PetQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (pq *PetQuery) Order(o ...pet.Order) *PetQuery {
+func (pq *PetQuery) Order(o ...pet.OrderOption) *PetQuery {
 	pq.order = append(pq.order, o...)
 	return pq
 }
@@ -299,7 +299,7 @@ func (pq *PetQuery) Clone() *PetQuery {
 	return &PetQuery{
 		config:      pq.config,
 		ctx:         pq.ctx.Clone(),
-		order:       append([]pet.Order{}, pq.order...),
+		order:       append([]pet.OrderOption{}, pq.order...),
 		inters:      append([]Interceptor{}, pq.inters...),
 		predicates:  append([]predicate.Pet{}, pq.predicates...),
 		withFriends: pq.withFriends.Clone(),

--- a/examples/traversal/ent/user/user.go
+++ b/examples/traversal/ent/user/user.go
@@ -79,75 +79,75 @@ func ValidColumn(column string) bool {
 	return false
 }
 
-// Order defines the ordering method for the User queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the User queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByAge orders the results by the age field.
-func ByAge(opts ...sql.OrderTermOption) Order {
+func ByAge(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAge, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
-func ByName(opts ...sql.OrderTermOption) Order {
+func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
 }
 
 // ByPetsCount orders the results by pets count.
-func ByPetsCount(opts ...sql.OrderTermOption) Order {
+func ByPetsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newPetsStep(), opts...)
 	}
 }
 
 // ByPets orders the results by pets terms.
-func ByPets(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByPets(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newPetsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByFriendsCount orders the results by friends count.
-func ByFriendsCount(opts ...sql.OrderTermOption) Order {
+func ByFriendsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newFriendsStep(), opts...)
 	}
 }
 
 // ByFriends orders the results by friends terms.
-func ByFriends(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByFriends(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newFriendsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByGroupsCount orders the results by groups count.
-func ByGroupsCount(opts ...sql.OrderTermOption) Order {
+func ByGroupsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newGroupsStep(), opts...)
 	}
 }
 
 // ByGroups orders the results by groups terms.
-func ByGroups(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByGroups(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newGroupsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
 // ByManageCount orders the results by manage count.
-func ByManageCount(opts ...sql.OrderTermOption) Order {
+func ByManageCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborsCount(s, newManageStep(), opts...)
 	}
 }
 
 // ByManage orders the results by manage terms.
-func ByManage(term sql.OrderTerm, terms ...sql.OrderTerm) Order {
+func ByManage(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newManageStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}

--- a/examples/traversal/ent/user_query.go
+++ b/examples/traversal/ent/user_query.go
@@ -25,7 +25,7 @@ import (
 type UserQuery struct {
 	config
 	ctx         *QueryContext
-	order       []user.Order
+	order       []user.OrderOption
 	inters      []Interceptor
 	predicates  []predicate.User
 	withPets    *PetQuery
@@ -63,7 +63,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
+func (uq *UserQuery) Order(o ...user.OrderOption) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -345,7 +345,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:      uq.config,
 		ctx:         uq.ctx.Clone(),
-		order:       append([]user.Order{}, uq.order...),
+		order:       append([]user.OrderOption{}, uq.order...),
 		inters:      append([]Interceptor{}, uq.inters...),
 		predicates:  append([]predicate.User{}, uq.predicates...),
 		withPets:    uq.withPets.Clone(),

--- a/examples/version/ent/user/user.go
+++ b/examples/version/ent/user/user.go
@@ -70,20 +70,20 @@ func StatusValidator(s Status) error {
 	}
 }
 
-// Order defines the ordering method for the User queries.
-type Order func(*sql.Selector)
+// OrderOption defines the ordering options for the User queries.
+type OrderOption func(*sql.Selector)
 
 // ByID orders the results by the id field.
-func ByID(opts ...sql.OrderTermOption) Order {
+func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
 // ByVersion orders the results by the version field.
-func ByVersion(opts ...sql.OrderTermOption) Order {
+func ByVersion(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldVersion, opts...).ToFunc()
 }
 
 // ByStatus orders the results by the status field.
-func ByStatus(opts ...sql.OrderTermOption) Order {
+func ByStatus(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldStatus, opts...).ToFunc()
 }

--- a/examples/version/ent/user_query.go
+++ b/examples/version/ent/user_query.go
@@ -22,7 +22,7 @@ import (
 type UserQuery struct {
 	config
 	ctx        *QueryContext
-	order      []user.Order
+	order      []user.OrderOption
 	inters     []Interceptor
 	predicates []predicate.User
 	// intermediate query (i.e. traversal path).
@@ -56,7 +56,7 @@ func (uq *UserQuery) Unique(unique bool) *UserQuery {
 }
 
 // Order specifies how the records should be ordered.
-func (uq *UserQuery) Order(o ...user.Order) *UserQuery {
+func (uq *UserQuery) Order(o ...user.OrderOption) *UserQuery {
 	uq.order = append(uq.order, o...)
 	return uq
 }
@@ -250,7 +250,7 @@ func (uq *UserQuery) Clone() *UserQuery {
 	return &UserQuery{
 		config:     uq.config,
 		ctx:        uq.ctx.Clone(),
-		order:      append([]user.Order{}, uq.order...),
+		order:      append([]user.OrderOption{}, uq.order...),
 		inters:     append([]Interceptor{}, uq.inters...),
 		predicates: append([]predicate.User{}, uq.predicates...),
 		// clone intermediate query.


### PR DESCRIPTION
Also, avoid generting predicate without op in case a field named: order_option