### PR TITLE
schema/fields changed fieldBuilders to exported types

### DIFF
--- a/schema/field/field.go
+++ b/schema/field/field.go
@@ -20,8 +20,8 @@ import (
 )
 
 // String returns a new Field with type string.
-func String(name string) *stringBuilder {
-	return &stringBuilder{&Descriptor{
+func String(name string) *StringBuilder {
+	return &StringBuilder{&Descriptor{
 		Name: name,
 		Info: &TypeInfo{Type: TypeString},
 	}}
@@ -29,8 +29,8 @@ func String(name string) *stringBuilder {
 
 // Text returns a new string field without limitation on the size.
 // In MySQL, it is the "longtext" type, but in SQLite and Gremlin it has no effect.
-func Text(name string) *stringBuilder {
-	return &stringBuilder{&Descriptor{
+func Text(name string) *StringBuilder {
+	return &StringBuilder{&Descriptor{
 		Name: name,
 		Size: math.MaxInt32,
 		Info: &TypeInfo{Type: TypeString},
@@ -39,24 +39,24 @@ func Text(name string) *stringBuilder {
 
 // Bytes returns a new Field with type bytes/buffer.
 // In MySQL and SQLite, it is the "BLOB" type, and it does not support for Gremlin.
-func Bytes(name string) *bytesBuilder {
-	return &bytesBuilder{&Descriptor{
+func Bytes(name string) *BytesBuilder {
+	return &BytesBuilder{&Descriptor{
 		Name: name,
 		Info: &TypeInfo{Type: TypeBytes, Nillable: true},
 	}}
 }
 
 // Bool returns a new Field with type bool.
-func Bool(name string) *boolBuilder {
-	return &boolBuilder{&Descriptor{
+func Bool(name string) *BoolBuilder {
+	return &BoolBuilder{&Descriptor{
 		Name: name,
 		Info: &TypeInfo{Type: TypeBool},
 	}}
 }
 
 // Time returns a new Field with type timestamp.
-func Time(name string) *timeBuilder {
-	return &timeBuilder{&Descriptor{
+func Time(name string) *TimeBuilder {
+	return &TimeBuilder{&Descriptor{
 		Name: name,
 		Info: &TypeInfo{Type: TypeTime, PkgPath: "time"},
 	}}
@@ -71,8 +71,8 @@ func Time(name string) *timeBuilder {
 //
 //	field.JSON("info", &Info{}).
 //		Optional()
-func JSON(name string, typ any) *jsonBuilder {
-	b := &jsonBuilder{&Descriptor{
+func JSON(name string, typ any) *JsonBuilder {
+	b := &JsonBuilder{&Descriptor{
 		Name: name,
 		Info: &TypeInfo{
 			Type: TypeJSON,
@@ -96,26 +96,26 @@ func JSON(name string, typ any) *jsonBuilder {
 }
 
 // Strings returns a new JSON Field with type []string.
-func Strings(name string) *jsonBuilder {
+func Strings(name string) *JsonBuilder {
 	return JSON(name, []string{})
 }
 
 // Ints returns a new JSON Field with type []int.
-func Ints(name string) *jsonBuilder {
+func Ints(name string) *JsonBuilder {
 	return JSON(name, []int{})
 }
 
 // Floats returns a new JSON Field with type []float.
-func Floats(name string) *jsonBuilder {
+func Floats(name string) *JsonBuilder {
 	return JSON(name, []float64{})
 }
 
 // Any returns a new JSON Field with type any. Although this field type can be
 // useful for fields with dynamic data layout, it is strongly recommended to use
 // JSON with json.RawMessage instead and implement custom marshaling.
-func Any(name string) *jsonBuilder {
+func Any(name string) *JsonBuilder {
 	const t = "any"
-	return &jsonBuilder{&Descriptor{
+	return &JsonBuilder{&Descriptor{
 		Name: name,
 		Info: &TypeInfo{
 			Type:     TypeJSON,
@@ -138,8 +138,8 @@ func Any(name string) *jsonBuilder {
 //			"off",
 //		).
 //		Default("on")
-func Enum(name string) *enumBuilder {
-	return &enumBuilder{&Descriptor{
+func Enum(name string) *EnumBuilder {
+	return &EnumBuilder{&Descriptor{
 		Name: name,
 		Info: &TypeInfo{Type: TypeEnum},
 	}}
@@ -148,9 +148,9 @@ func Enum(name string) *enumBuilder {
 // UUID returns a new Field with type UUID. An example for defining UUID field is as follows:
 //
 //	field.UUID("id", uuid.New())
-func UUID(name string, typ driver.Valuer) *uuidBuilder {
+func UUID(name string, typ driver.Valuer) *UuidBuilder {
 	rt := reflect.TypeOf(typ)
-	b := &uuidBuilder{&Descriptor{
+	b := &UuidBuilder{&Descriptor{
 		Name: name,
 		Info: &TypeInfo{
 			Type:    TypeUUID,
@@ -173,8 +173,8 @@ func UUID(name string, typ driver.Valuer) *uuidBuilder {
 //			dialect.MySQL:    "text",
 //			dialect.Postgres: "varchar",
 //		})
-func Other(name string, typ driver.Valuer) *otherBuilder {
-	ob := &otherBuilder{&Descriptor{
+func Other(name string, typ driver.Valuer) *OtherBuilder {
+	ob := &OtherBuilder{&Descriptor{
 		Name: name,
 		Info: &TypeInfo{Type: TypeOther},
 	}}
@@ -182,25 +182,25 @@ func Other(name string, typ driver.Valuer) *otherBuilder {
 	return ob
 }
 
-// stringBuilder is the builder for string fields.
-type stringBuilder struct {
+// StringBuilder is the builder for string fields.
+type StringBuilder struct {
 	desc *Descriptor
 }
 
 // Unique makes the field unique within all vertices of this type.
-func (b *stringBuilder) Unique() *stringBuilder {
+func (b *StringBuilder) Unique() *StringBuilder {
 	b.desc.Unique = true
 	return b
 }
 
 // Sensitive fields not printable and not serializable.
-func (b *stringBuilder) Sensitive() *stringBuilder {
+func (b *StringBuilder) Sensitive() *StringBuilder {
 	b.desc.Sensitive = true
 	return b
 }
 
 // Match adds a regex matcher for this field. Operation fails if the regex fails.
-func (b *stringBuilder) Match(re *regexp.Regexp) *stringBuilder {
+func (b *StringBuilder) Match(re *regexp.Regexp) *StringBuilder {
 	b.desc.Validators = append(b.desc.Validators, func(v string) error {
 		if !re.MatchString(v) {
 			return errors.New("value does not match validation")
@@ -212,7 +212,7 @@ func (b *stringBuilder) Match(re *regexp.Regexp) *stringBuilder {
 
 // MinLen adds a length validator for this field.
 // Operation fails if the length of the string is less than the given value.
-func (b *stringBuilder) MinLen(i int) *stringBuilder {
+func (b *StringBuilder) MinLen(i int) *StringBuilder {
 	b.desc.Validators = append(b.desc.Validators, func(v string) error {
 		if len(v) < i {
 			return errors.New("value is less than the required length")
@@ -224,13 +224,13 @@ func (b *stringBuilder) MinLen(i int) *stringBuilder {
 
 // NotEmpty adds a length validator for this field.
 // Operation fails if the length of the string is zero.
-func (b *stringBuilder) NotEmpty() *stringBuilder {
+func (b *StringBuilder) NotEmpty() *StringBuilder {
 	return b.MinLen(1)
 }
 
 // MaxLen adds a length validator for this field.
 // Operation fails if the length of the string is greater than the given value.
-func (b *stringBuilder) MaxLen(i int) *stringBuilder {
+func (b *StringBuilder) MaxLen(i int) *StringBuilder {
 	b.desc.Size = i
 	b.desc.Validators = append(b.desc.Validators, func(v string) error {
 		if len(v) > i {
@@ -242,13 +242,13 @@ func (b *stringBuilder) MaxLen(i int) *stringBuilder {
 }
 
 // Validate adds a validator for this field. Operation fails if the validation fails.
-func (b *stringBuilder) Validate(fn func(string) error) *stringBuilder {
+func (b *StringBuilder) Validate(fn func(string) error) *StringBuilder {
 	b.desc.Validators = append(b.desc.Validators, fn)
 	return b
 }
 
 // Default sets the default value of the field.
-func (b *stringBuilder) Default(s string) *stringBuilder {
+func (b *StringBuilder) Default(s string) *StringBuilder {
 	b.desc.Default = s
 	return b
 }
@@ -258,7 +258,7 @@ func (b *stringBuilder) Default(s string) *stringBuilder {
 //
 //	field.String("cuid").
 //		DefaultFunc(cuid.New)
-func (b *stringBuilder) DefaultFunc(fn any) *stringBuilder {
+func (b *StringBuilder) DefaultFunc(fn any) *StringBuilder {
 	if t := reflect.TypeOf(fn); t.Kind() != reflect.Func {
 		b.desc.Err = fmt.Errorf("field.String(%q).DefaultFunc expects func but got %s", b.desc.Name, t.Kind())
 	}
@@ -268,39 +268,39 @@ func (b *stringBuilder) DefaultFunc(fn any) *stringBuilder {
 
 // Nillable indicates that this field is a nillable.
 // Unlike "Optional" only fields, "Nillable" fields are pointers in the generated struct.
-func (b *stringBuilder) Nillable() *stringBuilder {
+func (b *StringBuilder) Nillable() *StringBuilder {
 	b.desc.Nillable = true
 	return b
 }
 
 // Optional indicates that this field is optional on create.
 // Unlike edges, fields are required by default.
-func (b *stringBuilder) Optional() *stringBuilder {
+func (b *StringBuilder) Optional() *StringBuilder {
 	b.desc.Optional = true
 	return b
 }
 
 // Immutable indicates that this field cannot be updated.
-func (b *stringBuilder) Immutable() *stringBuilder {
+func (b *StringBuilder) Immutable() *StringBuilder {
 	b.desc.Immutable = true
 	return b
 }
 
 // Comment sets the comment of the field.
-func (b *stringBuilder) Comment(c string) *stringBuilder {
+func (b *StringBuilder) Comment(c string) *StringBuilder {
 	b.desc.Comment = c
 	return b
 }
 
 // StructTag sets the struct tag of the field.
-func (b *stringBuilder) StructTag(s string) *stringBuilder {
+func (b *StringBuilder) StructTag(s string) *StringBuilder {
 	b.desc.Tag = s
 	return b
 }
 
 // StorageKey sets the storage key of the field.
 // In SQL dialects is the column name and Gremlin is the property.
-func (b *stringBuilder) StorageKey(key string) *stringBuilder {
+func (b *StringBuilder) StorageKey(key string) *StringBuilder {
 	b.desc.StorageKey = key
 	return b
 }
@@ -313,7 +313,7 @@ func (b *stringBuilder) StorageKey(key string) *stringBuilder {
 //			dialect.MySQL:    "text",
 //			dialect.Postgres: "varchar",
 //		})
-func (b *stringBuilder) SchemaType(types map[string]string) *stringBuilder {
+func (b *StringBuilder) SchemaType(types map[string]string) *StringBuilder {
 	b.desc.SchemaType = types
 	return b
 }
@@ -325,7 +325,7 @@ func (b *stringBuilder) SchemaType(types map[string]string) *stringBuilder {
 //
 //	field.String("dir").
 //		GoType(http.Dir("dir"))
-func (b *stringBuilder) GoType(typ any) *stringBuilder {
+func (b *StringBuilder) GoType(typ any) *StringBuilder {
 	b.desc.goType(typ)
 	return b
 }
@@ -334,7 +334,7 @@ func (b *stringBuilder) GoType(typ any) *stringBuilder {
 // Using this option allow users to use field types that do not implement
 // the sql.Scanner and driver.Valuer interfaces, such as slices and maps
 // or types exist in external packages (e.g., url.URL).
-func (b *stringBuilder) ValueScanner(vs any) *stringBuilder {
+func (b *StringBuilder) ValueScanner(vs any) *StringBuilder {
 	b.desc.ValueScanner = vs
 	return b
 }
@@ -346,13 +346,13 @@ func (b *stringBuilder) ValueScanner(vs any) *stringBuilder {
 //		Annotations(
 //			entgql.OrderField("DIR"),
 //		)
-func (b *stringBuilder) Annotations(annotations ...schema.Annotation) *stringBuilder {
+func (b *StringBuilder) Annotations(annotations ...schema.Annotation) *StringBuilder {
 	b.desc.Annotations = append(b.desc.Annotations, annotations...)
 	return b
 }
 
 // Descriptor implements the ent.Field interface by returning its descriptor.
-func (b *stringBuilder) Descriptor() *Descriptor {
+func (b *StringBuilder) Descriptor() *Descriptor {
 	if b.desc.Default != nil {
 		b.desc.checkDefaultFunc(stringType)
 	}
@@ -360,40 +360,40 @@ func (b *stringBuilder) Descriptor() *Descriptor {
 	return b.desc
 }
 
-// timeBuilder is the builder for time fields.
-type timeBuilder struct {
+// TimeBuilder is the builder for time fields.
+type TimeBuilder struct {
 	desc *Descriptor
 }
 
 // Nillable indicates that this field is a nillable.
 // Unlike "Optional" only fields, "Nillable" fields are pointers in the generated struct.
-func (b *timeBuilder) Nillable() *timeBuilder {
+func (b *TimeBuilder) Nillable() *TimeBuilder {
 	b.desc.Nillable = true
 	return b
 }
 
 // Optional indicates that this field is optional on create.
 // Unlike edges, fields are required by default.
-func (b *timeBuilder) Optional() *timeBuilder {
+func (b *TimeBuilder) Optional() *TimeBuilder {
 	b.desc.Optional = true
 	return b
 }
 
 // Immutable fields are fields that can be set only in the creation of the entity.
 // i.e., no setters will be generated for the entity updaters (one and many).
-func (b *timeBuilder) Immutable() *timeBuilder {
+func (b *TimeBuilder) Immutable() *TimeBuilder {
 	b.desc.Immutable = true
 	return b
 }
 
 // Comment sets the comment of the field.
-func (b *timeBuilder) Comment(c string) *timeBuilder {
+func (b *TimeBuilder) Comment(c string) *TimeBuilder {
 	b.desc.Comment = c
 	return b
 }
 
 // StructTag sets the struct tag of the field.
-func (b *timeBuilder) StructTag(s string) *timeBuilder {
+func (b *TimeBuilder) StructTag(s string) *TimeBuilder {
 	b.desc.Tag = s
 	return b
 }
@@ -403,7 +403,7 @@ func (b *timeBuilder) StructTag(s string) *timeBuilder {
 //
 //	field.Time("created_at").
 //		Default(time.Now)
-func (b *timeBuilder) Default(fn any) *timeBuilder {
+func (b *TimeBuilder) Default(fn any) *TimeBuilder {
 	b.desc.Default = fn
 	return b
 }
@@ -419,14 +419,14 @@ func (b *timeBuilder) Default(fn any) *timeBuilder {
 //		Optional().
 //		GoType(&sql.NullTime{}).
 //		UpdateDefault(NewNullTime),
-func (b *timeBuilder) UpdateDefault(fn any) *timeBuilder {
+func (b *TimeBuilder) UpdateDefault(fn any) *TimeBuilder {
 	b.desc.UpdateDefault = fn
 	return b
 }
 
 // StorageKey sets the storage key of the field.
 // In SQL dialects is the column name and Gremlin is the property.
-func (b *timeBuilder) StorageKey(key string) *timeBuilder {
+func (b *TimeBuilder) StorageKey(key string) *TimeBuilder {
 	b.desc.StorageKey = key
 	return b
 }
@@ -438,7 +438,7 @@ func (b *timeBuilder) StorageKey(key string) *timeBuilder {
 //
 //	field.Time("deleted_at").
 //		GoType(&sql.NullTime{})
-func (b *timeBuilder) GoType(typ any) *timeBuilder {
+func (b *TimeBuilder) GoType(typ any) *TimeBuilder {
 	b.desc.goType(typ)
 	return b
 }
@@ -450,13 +450,13 @@ func (b *timeBuilder) GoType(typ any) *timeBuilder {
 //		Annotations(
 //			entgql.OrderField("DELETED_AT"),
 //		)
-func (b *timeBuilder) Annotations(annotations ...schema.Annotation) *timeBuilder {
+func (b *TimeBuilder) Annotations(annotations ...schema.Annotation) *TimeBuilder {
 	b.desc.Annotations = append(b.desc.Annotations, annotations...)
 	return b
 }
 
 // Descriptor implements the ent.Field interface by returning its descriptor.
-func (b *timeBuilder) Descriptor() *Descriptor {
+func (b *TimeBuilder) Descriptor() *Descriptor {
 	if b.desc.Default != nil {
 		b.desc.checkDefaultFunc(timeType)
 	}
@@ -472,57 +472,57 @@ func (b *timeBuilder) Descriptor() *Descriptor {
 //			dialect.MySQL:    "datetime",
 //			dialect.Postgres: "time with time zone",
 //		})
-func (b *timeBuilder) SchemaType(types map[string]string) *timeBuilder {
+func (b *TimeBuilder) SchemaType(types map[string]string) *TimeBuilder {
 	b.desc.SchemaType = types
 	return b
 }
 
-// boolBuilder is the builder for boolean fields.
-type boolBuilder struct {
+// BoolBuilder is the builder for boolean fields.
+type BoolBuilder struct {
 	desc *Descriptor
 }
 
 // Default sets the default value of the field.
-func (b *boolBuilder) Default(v bool) *boolBuilder {
+func (b *BoolBuilder) Default(v bool) *BoolBuilder {
 	b.desc.Default = v
 	return b
 }
 
 // Nillable indicates that this field is a nillable.
 // Unlike "Optional" only fields, "Nillable" fields are pointers in the generated struct.
-func (b *boolBuilder) Nillable() *boolBuilder {
+func (b *BoolBuilder) Nillable() *BoolBuilder {
 	b.desc.Nillable = true
 	return b
 }
 
 // Optional indicates that this field is optional on create.
 // Unlike edges, fields are required by default.
-func (b *boolBuilder) Optional() *boolBuilder {
+func (b *BoolBuilder) Optional() *BoolBuilder {
 	b.desc.Optional = true
 	return b
 }
 
 // Immutable indicates that this field cannot be updated.
-func (b *boolBuilder) Immutable() *boolBuilder {
+func (b *BoolBuilder) Immutable() *BoolBuilder {
 	b.desc.Immutable = true
 	return b
 }
 
 // Comment sets the comment of the field.
-func (b *boolBuilder) Comment(c string) *boolBuilder {
+func (b *BoolBuilder) Comment(c string) *BoolBuilder {
 	b.desc.Comment = c
 	return b
 }
 
 // StructTag sets the struct tag of the field.
-func (b *boolBuilder) StructTag(s string) *boolBuilder {
+func (b *BoolBuilder) StructTag(s string) *BoolBuilder {
 	b.desc.Tag = s
 	return b
 }
 
 // StorageKey sets the storage key of the field.
 // In SQL dialects is the column name and Gremlin is the property.
-func (b *boolBuilder) StorageKey(key string) *boolBuilder {
+func (b *BoolBuilder) StorageKey(key string) *BoolBuilder {
 	b.desc.StorageKey = key
 	return b
 }
@@ -534,7 +534,7 @@ func (b *boolBuilder) StorageKey(key string) *boolBuilder {
 //
 //	field.Bool("deleted").
 //		GoType(&sql.NullBool{})
-func (b *boolBuilder) GoType(typ any) *boolBuilder {
+func (b *BoolBuilder) GoType(typ any) *BoolBuilder {
 	b.desc.goType(typ)
 	return b
 }
@@ -546,24 +546,24 @@ func (b *boolBuilder) GoType(typ any) *boolBuilder {
 //		Annotations(
 //			entgql.OrderField("DELETED"),
 //		)
-func (b *boolBuilder) Annotations(annotations ...schema.Annotation) *boolBuilder {
+func (b *BoolBuilder) Annotations(annotations ...schema.Annotation) *BoolBuilder {
 	b.desc.Annotations = append(b.desc.Annotations, annotations...)
 	return b
 }
 
 // Descriptor implements the ent.Field interface by returning its descriptor.
-func (b *boolBuilder) Descriptor() *Descriptor {
+func (b *BoolBuilder) Descriptor() *Descriptor {
 	b.desc.checkGoType(boolType)
 	return b.desc
 }
 
-// bytesBuilder is the builder for bytes fields.
-type bytesBuilder struct {
+// BytesBuilder is the builder for bytes fields.
+type BytesBuilder struct {
 	desc *Descriptor
 }
 
 // Default sets the default value of the field.
-func (b *bytesBuilder) Default(v []byte) *bytesBuilder {
+func (b *BytesBuilder) Default(v []byte) *BytesBuilder {
 	b.desc.Default = v
 	return b
 }
@@ -573,7 +573,7 @@ func (b *bytesBuilder) Default(v []byte) *bytesBuilder {
 //
 //	field.Bytes("cuid").
 //		DefaultFunc(cuid.New)
-func (b *bytesBuilder) DefaultFunc(fn any) *bytesBuilder {
+func (b *BytesBuilder) DefaultFunc(fn any) *BytesBuilder {
 	if t := reflect.TypeOf(fn); t.Kind() != reflect.Func {
 		b.desc.Err = fmt.Errorf("field.Bytes(%q).DefaultFunc expects func but got %s", b.desc.Name, t.Kind())
 	}
@@ -583,45 +583,45 @@ func (b *bytesBuilder) DefaultFunc(fn any) *bytesBuilder {
 
 // Nillable indicates that this field is a nillable.
 // Unlike "Optional" only fields, "Nillable" fields are pointers in the generated struct.
-func (b *bytesBuilder) Nillable() *bytesBuilder {
+func (b *BytesBuilder) Nillable() *BytesBuilder {
 	b.desc.Nillable = true
 	return b
 }
 
 // Optional indicates that this field is optional on create.
 // Unlike edges, fields are required by default.
-func (b *bytesBuilder) Optional() *bytesBuilder {
+func (b *BytesBuilder) Optional() *BytesBuilder {
 	b.desc.Optional = true
 	return b
 }
 
 // Sensitive fields not printable and not serializable.
-func (b *bytesBuilder) Sensitive() *bytesBuilder {
+func (b *BytesBuilder) Sensitive() *BytesBuilder {
 	b.desc.Sensitive = true
 	return b
 }
 
 // Unique makes the field unique within all vertices of this type.
 // Only supported in PostgreSQL.
-func (b *bytesBuilder) Unique() *bytesBuilder {
+func (b *BytesBuilder) Unique() *BytesBuilder {
 	b.desc.Unique = true
 	return b
 }
 
 // Immutable indicates that this field cannot be updated.
-func (b *bytesBuilder) Immutable() *bytesBuilder {
+func (b *BytesBuilder) Immutable() *BytesBuilder {
 	b.desc.Immutable = true
 	return b
 }
 
 // Comment sets the comment of the field.
-func (b *bytesBuilder) Comment(c string) *bytesBuilder {
+func (b *BytesBuilder) Comment(c string) *BytesBuilder {
 	b.desc.Comment = c
 	return b
 }
 
 // StructTag sets the struct tag of the field.
-func (b *bytesBuilder) StructTag(s string) *bytesBuilder {
+func (b *BytesBuilder) StructTag(s string) *BytesBuilder {
 	b.desc.Tag = s
 	return b
 }
@@ -629,7 +629,7 @@ func (b *bytesBuilder) StructTag(s string) *bytesBuilder {
 // MaxLen sets the max-length of the bytes type in the database.
 // In MySQL, this affects the BLOB type (tiny 2^8-1, regular 2^16-1, medium 2^24-1, long 2^32-1).
 // In SQLite, it does not have any effect on the type size, which is default to 1B bytes.
-func (b *bytesBuilder) MaxLen(i int) *bytesBuilder {
+func (b *BytesBuilder) MaxLen(i int) *BytesBuilder {
 	b.desc.Size = i
 	b.desc.Validators = append(b.desc.Validators, func(buf []byte) error {
 		if len(buf) > i {
@@ -642,7 +642,7 @@ func (b *bytesBuilder) MaxLen(i int) *bytesBuilder {
 
 // MinLen adds a length validator for this field.
 // Operation fails if the length of the buffer is less than the given value.
-func (b *bytesBuilder) MinLen(i int) *bytesBuilder {
+func (b *BytesBuilder) MinLen(i int) *BytesBuilder {
 	b.desc.Validators = append(b.desc.Validators, func(b []byte) error {
 		if len(b) < i {
 			return errors.New("value is less than the required length")
@@ -654,7 +654,7 @@ func (b *bytesBuilder) MinLen(i int) *bytesBuilder {
 
 // NotEmpty adds a length validator for this field.
 // Operation fails if the length of the buffer is zero.
-func (b *bytesBuilder) NotEmpty() *bytesBuilder {
+func (b *BytesBuilder) NotEmpty() *BytesBuilder {
 	return b.MinLen(1)
 }
 
@@ -667,14 +667,14 @@ func (b *bytesBuilder) NotEmpty() *bytesBuilder {
 //			}
 //			return nil
 //		})
-func (b *bytesBuilder) Validate(fn func([]byte) error) *bytesBuilder {
+func (b *BytesBuilder) Validate(fn func([]byte) error) *BytesBuilder {
 	b.desc.Validators = append(b.desc.Validators, fn)
 	return b
 }
 
 // StorageKey sets the storage key of the field.
 // In SQL dialects is the column name and Gremlin is the property.
-func (b *bytesBuilder) StorageKey(key string) *bytesBuilder {
+func (b *BytesBuilder) StorageKey(key string) *BytesBuilder {
 	b.desc.StorageKey = key
 	return b
 }
@@ -686,14 +686,14 @@ func (b *bytesBuilder) StorageKey(key string) *bytesBuilder {
 //
 //	field.Bytes("ip").
 //		GoType(net.IP("127.0.0.1"))
-func (b *bytesBuilder) GoType(typ any) *bytesBuilder {
+func (b *BytesBuilder) GoType(typ any) *BytesBuilder {
 	b.desc.goType(typ)
 	return b
 }
 
 // Annotations adds a list of annotations to the field object to be used by
 // codegen extensions.
-func (b *bytesBuilder) Annotations(annotations ...schema.Annotation) *bytesBuilder {
+func (b *BytesBuilder) Annotations(annotations ...schema.Annotation) *BytesBuilder {
 	b.desc.Annotations = append(b.desc.Annotations, annotations...)
 	return b
 }
@@ -706,13 +706,13 @@ func (b *bytesBuilder) Annotations(annotations ...schema.Annotation) *bytesBuild
 //			dialect.MySQL:	"tinyblob",
 //			dialect.SQLite:	"tinyblob",
 //		})
-func (b *bytesBuilder) SchemaType(types map[string]string) *bytesBuilder {
+func (b *BytesBuilder) SchemaType(types map[string]string) *BytesBuilder {
 	b.desc.SchemaType = types
 	return b
 }
 
 // Descriptor implements the ent.Field interface by returning its descriptor.
-func (b *bytesBuilder) Descriptor() *Descriptor {
+func (b *BytesBuilder) Descriptor() *Descriptor {
 	if b.desc.Default != nil {
 		b.desc.checkDefaultFunc(bytesType)
 	}
@@ -720,45 +720,45 @@ func (b *bytesBuilder) Descriptor() *Descriptor {
 	return b.desc
 }
 
-// jsonBuilder is the builder for json fields.
-type jsonBuilder struct {
+// JsonBuilder is the builder for json fields.
+type JsonBuilder struct {
 	desc *Descriptor
 }
 
 // StorageKey sets the storage key of the field.
 // In SQL dialects is the column name and Gremlin is the property.
-func (b *jsonBuilder) StorageKey(key string) *jsonBuilder {
+func (b *JsonBuilder) StorageKey(key string) *JsonBuilder {
 	b.desc.StorageKey = key
 	return b
 }
 
 // Optional indicates that this field is optional on create.
 // Unlike edges, fields are required by default.
-func (b *jsonBuilder) Optional() *jsonBuilder {
+func (b *JsonBuilder) Optional() *JsonBuilder {
 	b.desc.Optional = true
 	return b
 }
 
 // Immutable indicates that this field cannot be updated.
-func (b *jsonBuilder) Immutable() *jsonBuilder {
+func (b *JsonBuilder) Immutable() *JsonBuilder {
 	b.desc.Immutable = true
 	return b
 }
 
 // Comment sets the comment of the field.
-func (b *jsonBuilder) Comment(c string) *jsonBuilder {
+func (b *JsonBuilder) Comment(c string) *JsonBuilder {
 	b.desc.Comment = c
 	return b
 }
 
 // Sensitive fields not printable and not serializable.
-func (b *jsonBuilder) Sensitive() *jsonBuilder {
+func (b *JsonBuilder) Sensitive() *JsonBuilder {
 	b.desc.Sensitive = true
 	return b
 }
 
 // StructTag sets the struct tag of the field.
-func (b *jsonBuilder) StructTag(s string) *jsonBuilder {
+func (b *JsonBuilder) StructTag(s string) *JsonBuilder {
 	b.desc.Tag = s
 	return b
 }
@@ -771,14 +771,14 @@ func (b *jsonBuilder) StructTag(s string) *jsonBuilder {
 //			dialect.MySQL:		"json",
 //			dialect.Postgres:	"jsonb",
 //		})
-func (b *jsonBuilder) SchemaType(types map[string]string) *jsonBuilder {
+func (b *JsonBuilder) SchemaType(types map[string]string) *JsonBuilder {
 	b.desc.SchemaType = types
 	return b
 }
 
 // Annotations adds a list of annotations to the field object to be used by
 // codegen extensions.
-func (b *jsonBuilder) Annotations(annotations ...schema.Annotation) *jsonBuilder {
+func (b *JsonBuilder) Annotations(annotations ...schema.Annotation) *JsonBuilder {
 	b.desc.Annotations = append(b.desc.Annotations, annotations...)
 	return b
 }
@@ -792,7 +792,7 @@ func (b *jsonBuilder) Annotations(annotations ...schema.Annotation) *jsonBuilder
 //	field.JSON("dirs", []http.Dir{}).
 //		// A function for generating the default value.
 //		Default(DefaultDirs)
-func (b *jsonBuilder) Default(v any) *jsonBuilder {
+func (b *JsonBuilder) Default(v any) *JsonBuilder {
 	b.desc.Default = v
 	switch fieldT, defaultT := b.desc.Info.RType.rtype, reflect.TypeOf(v); {
 	case fieldT == defaultT:
@@ -805,12 +805,12 @@ func (b *jsonBuilder) Default(v any) *jsonBuilder {
 }
 
 // Descriptor implements the ent.Field interface by returning its descriptor.
-func (b *jsonBuilder) Descriptor() *Descriptor {
+func (b *JsonBuilder) Descriptor() *Descriptor {
 	return b.desc
 }
 
-// enumBuilder is the builder for enum fields.
-type enumBuilder struct {
+// EnumBuilder is the builder for enum fields.
+type EnumBuilder struct {
 	desc *Descriptor
 }
 
@@ -818,7 +818,7 @@ type enumBuilder struct {
 //
 //	field.Enum("priority").
 //		Values("low", "mid", "high")
-func (b *enumBuilder) Values(values ...string) *enumBuilder {
+func (b *EnumBuilder) Values(values ...string) *EnumBuilder {
 	for _, v := range values {
 		b.desc.Enums = append(b.desc.Enums, struct{ N, V string }{N: v, V: v})
 	}
@@ -837,7 +837,7 @@ func (b *enumBuilder) Values(values ...string) *enumBuilder {
 //			"Mid", "MID",
 //			"High", "HIGH",
 //		)
-func (b *enumBuilder) NamedValues(namevalue ...string) *enumBuilder {
+func (b *EnumBuilder) NamedValues(namevalue ...string) *EnumBuilder {
 	if len(namevalue)%2 == 1 {
 		b.desc.Err = fmt.Errorf("Enum.NamedValues: odd argument count")
 		return b
@@ -849,46 +849,46 @@ func (b *enumBuilder) NamedValues(namevalue ...string) *enumBuilder {
 }
 
 // Default sets the default value of the field.
-func (b *enumBuilder) Default(value string) *enumBuilder {
+func (b *EnumBuilder) Default(value string) *EnumBuilder {
 	b.desc.Default = value
 	return b
 }
 
 // StorageKey sets the storage key of the field.
 // In SQL dialects is the column name and Gremlin is the property.
-func (b *enumBuilder) StorageKey(key string) *enumBuilder {
+func (b *EnumBuilder) StorageKey(key string) *EnumBuilder {
 	b.desc.StorageKey = key
 	return b
 }
 
 // Optional indicates that this field is optional on create.
 // Unlike edges, fields are required by default.
-func (b *enumBuilder) Optional() *enumBuilder {
+func (b *EnumBuilder) Optional() *EnumBuilder {
 	b.desc.Optional = true
 	return b
 }
 
 // Immutable indicates that this field cannot be updated.
-func (b *enumBuilder) Immutable() *enumBuilder {
+func (b *EnumBuilder) Immutable() *EnumBuilder {
 	b.desc.Immutable = true
 	return b
 }
 
 // Comment sets the comment of the field.
-func (b *enumBuilder) Comment(c string) *enumBuilder {
+func (b *EnumBuilder) Comment(c string) *EnumBuilder {
 	b.desc.Comment = c
 	return b
 }
 
 // Nillable indicates that this field is a nillable.
 // Unlike "Optional" only fields, "Nillable" fields are pointers in the generated struct.
-func (b *enumBuilder) Nillable() *enumBuilder {
+func (b *EnumBuilder) Nillable() *EnumBuilder {
 	b.desc.Nillable = true
 	return b
 }
 
 // StructTag sets the struct tag of the field.
-func (b *enumBuilder) StructTag(s string) *enumBuilder {
+func (b *EnumBuilder) StructTag(s string) *EnumBuilder {
 	b.desc.Tag = s
 	return b
 }
@@ -900,7 +900,7 @@ func (b *enumBuilder) StructTag(s string) *enumBuilder {
 //		SchemaType(map[string]string{
 //			dialect.Postgres: "EnumType",
 //		})
-func (b *enumBuilder) SchemaType(types map[string]string) *enumBuilder {
+func (b *EnumBuilder) SchemaType(types map[string]string) *EnumBuilder {
 	b.desc.SchemaType = types
 	return b
 }
@@ -912,7 +912,7 @@ func (b *enumBuilder) SchemaType(types map[string]string) *enumBuilder {
 //		Annotations(
 //			entgql.OrderField("ENUM"),
 //		)
-func (b *enumBuilder) Annotations(annotations ...schema.Annotation) *enumBuilder {
+func (b *EnumBuilder) Annotations(annotations ...schema.Annotation) *EnumBuilder {
 	b.desc.Annotations = append(b.desc.Annotations, annotations...)
 	return b
 }
@@ -929,14 +929,14 @@ type EnumValues interface {
 //
 //	field.Enum("enum").
 //		GoType(role.Enum("role"))
-func (b *enumBuilder) GoType(ev EnumValues) *enumBuilder {
+func (b *EnumBuilder) GoType(ev EnumValues) *EnumBuilder {
 	b.Values(ev.Values()...)
 	b.desc.goType(ev)
 	return b
 }
 
 // Descriptor implements the ent.Field interface by returning its descriptor.
-func (b *enumBuilder) Descriptor() *Descriptor {
+func (b *EnumBuilder) Descriptor() *Descriptor {
 	if b.desc.Info.RType != nil {
 		// If an error already exists, let that be returned instead.
 		// Otherwise, check that the underlying type is either a string or implements Stringer.
@@ -948,52 +948,52 @@ func (b *enumBuilder) Descriptor() *Descriptor {
 	return b.desc
 }
 
-// uuidBuilder is the builder for uuid fields.
-type uuidBuilder struct {
+// UuidBuilder is the builder for uuid fields.
+type UuidBuilder struct {
 	desc *Descriptor
 }
 
 // StorageKey sets the storage key of the field.
 // In SQL dialects is the column name and Gremlin is the property.
-func (b *uuidBuilder) StorageKey(key string) *uuidBuilder {
+func (b *UuidBuilder) StorageKey(key string) *UuidBuilder {
 	b.desc.StorageKey = key
 	return b
 }
 
 // Nillable indicates that this field is a nillable.
 // Unlike "Optional" only fields, "Nillable" fields are pointers in the generated struct.
-func (b *uuidBuilder) Nillable() *uuidBuilder {
+func (b *UuidBuilder) Nillable() *UuidBuilder {
 	b.desc.Nillable = true
 	return b
 }
 
 // Optional indicates that this field is optional on create.
 // Unlike edges, fields are required by default.
-func (b *uuidBuilder) Optional() *uuidBuilder {
+func (b *UuidBuilder) Optional() *UuidBuilder {
 	b.desc.Optional = true
 	return b
 }
 
 // Unique makes the field unique within all vertices of this type.
-func (b *uuidBuilder) Unique() *uuidBuilder {
+func (b *UuidBuilder) Unique() *UuidBuilder {
 	b.desc.Unique = true
 	return b
 }
 
 // Immutable indicates that this field cannot be updated.
-func (b *uuidBuilder) Immutable() *uuidBuilder {
+func (b *UuidBuilder) Immutable() *UuidBuilder {
 	b.desc.Immutable = true
 	return b
 }
 
 // Comment sets the comment of the field.
-func (b *uuidBuilder) Comment(c string) *uuidBuilder {
+func (b *UuidBuilder) Comment(c string) *UuidBuilder {
 	b.desc.Comment = c
 	return b
 }
 
 // StructTag sets the struct tag of the field.
-func (b *uuidBuilder) StructTag(s string) *uuidBuilder {
+func (b *UuidBuilder) StructTag(s string) *UuidBuilder {
 	b.desc.Tag = s
 	return b
 }
@@ -1004,7 +1004,7 @@ func (b *uuidBuilder) StructTag(s string) *uuidBuilder {
 //
 //	field.UUID("id", uuid.UUID{}).
 //		Default(uuid.New)
-func (b *uuidBuilder) Default(fn any) *uuidBuilder {
+func (b *UuidBuilder) Default(fn any) *UuidBuilder {
 	typ := reflect.TypeOf(fn)
 	if typ.Kind() != reflect.Func || typ.NumIn() != 0 || typ.NumOut() != 1 || typ.Out(0).String() != b.desc.Info.String() {
 		b.desc.Err = fmt.Errorf("expect type (func() %s) for uuid default value", b.desc.Info)
@@ -1020,7 +1020,7 @@ func (b *uuidBuilder) Default(fn any) *uuidBuilder {
 //		SchemaType(map[string]string{
 //			dialect.Postgres: "CustomUUID",
 //		})
-func (b *uuidBuilder) SchemaType(types map[string]string) *uuidBuilder {
+func (b *UuidBuilder) SchemaType(types map[string]string) *UuidBuilder {
 	b.desc.SchemaType = types
 	return b
 }
@@ -1032,30 +1032,30 @@ func (b *uuidBuilder) SchemaType(types map[string]string) *uuidBuilder {
 //		Annotations(
 //			entgql.OrderField("ID"),
 //		)
-func (b *uuidBuilder) Annotations(annotations ...schema.Annotation) *uuidBuilder {
+func (b *UuidBuilder) Annotations(annotations ...schema.Annotation) *UuidBuilder {
 	b.desc.Annotations = append(b.desc.Annotations, annotations...)
 	return b
 }
 
 // Descriptor implements the ent.Field interface by returning its descriptor.
-func (b *uuidBuilder) Descriptor() *Descriptor {
+func (b *UuidBuilder) Descriptor() *Descriptor {
 	b.desc.checkGoType(valueScannerType)
 	return b.desc
 }
 
-// otherBuilder is the builder for other fields.
-type otherBuilder struct {
+// OtherBuilder is the builder for other fields.
+type OtherBuilder struct {
 	desc *Descriptor
 }
 
 // Unique makes the field unique within all vertices of this type.
-func (b *otherBuilder) Unique() *otherBuilder {
+func (b *OtherBuilder) Unique() *OtherBuilder {
 	b.desc.Unique = true
 	return b
 }
 
 // Sensitive fields not printable and not serializable.
-func (b *otherBuilder) Sensitive() *otherBuilder {
+func (b *OtherBuilder) Sensitive() *OtherBuilder {
 	b.desc.Sensitive = true
 	return b
 }
@@ -1077,7 +1077,7 @@ func (b *otherBuilder) Sensitive() *otherBuilder {
 //		}).
 //		// A function for generating the default value.
 //		Default(NewLink)
-func (b *otherBuilder) Default(v any) *otherBuilder {
+func (b *OtherBuilder) Default(v any) *OtherBuilder {
 	b.desc.Default = v
 	switch fieldT, defaultT := b.desc.Info.RType.rtype, reflect.TypeOf(v); {
 	case fieldT == defaultT:
@@ -1091,39 +1091,39 @@ func (b *otherBuilder) Default(v any) *otherBuilder {
 
 // Nillable indicates that this field is a nillable.
 // Unlike "Optional" only fields, "Nillable" fields are pointers in the generated field.
-func (b *otherBuilder) Nillable() *otherBuilder {
+func (b *OtherBuilder) Nillable() *OtherBuilder {
 	b.desc.Nillable = true
 	return b
 }
 
 // Optional indicates that this field is optional on create.
 // Unlike edges, fields are required by default.
-func (b *otherBuilder) Optional() *otherBuilder {
+func (b *OtherBuilder) Optional() *OtherBuilder {
 	b.desc.Optional = true
 	return b
 }
 
 // Immutable indicates that this field cannot be updated.
-func (b *otherBuilder) Immutable() *otherBuilder {
+func (b *OtherBuilder) Immutable() *OtherBuilder {
 	b.desc.Immutable = true
 	return b
 }
 
 // Comment sets the comment of the field.
-func (b *otherBuilder) Comment(c string) *otherBuilder {
+func (b *OtherBuilder) Comment(c string) *OtherBuilder {
 	b.desc.Comment = c
 	return b
 }
 
 // StructTag sets the struct tag of the field.
-func (b *otherBuilder) StructTag(s string) *otherBuilder {
+func (b *OtherBuilder) StructTag(s string) *OtherBuilder {
 	b.desc.Tag = s
 	return b
 }
 
 // StorageKey sets the storage key of the field.
 // In SQL dialects is the column name and Gremlin is the property.
-func (b *otherBuilder) StorageKey(key string) *otherBuilder {
+func (b *OtherBuilder) StorageKey(key string) *OtherBuilder {
 	b.desc.StorageKey = key
 	return b
 }
@@ -1136,7 +1136,7 @@ func (b *otherBuilder) StorageKey(key string) *otherBuilder {
 //			dialect.MySQL:    "text",
 //			dialect.Postgres: "varchar",
 //		})
-func (b *otherBuilder) SchemaType(types map[string]string) *otherBuilder {
+func (b *OtherBuilder) SchemaType(types map[string]string) *OtherBuilder {
 	b.desc.SchemaType = types
 	return b
 }
@@ -1152,13 +1152,13 @@ func (b *otherBuilder) SchemaType(types map[string]string) *otherBuilder {
 //		Annotations(
 //			entgql.OrderField("LINK"),
 //		)
-func (b *otherBuilder) Annotations(annotations ...schema.Annotation) *otherBuilder {
+func (b *OtherBuilder) Annotations(annotations ...schema.Annotation) *OtherBuilder {
 	b.desc.Annotations = append(b.desc.Annotations, annotations...)
 	return b
 }
 
 // Descriptor implements the ent.Field interface by returning its descriptor.
-func (b *otherBuilder) Descriptor() *Descriptor {
+func (b *OtherBuilder) Descriptor() *Descriptor {
 	b.desc.checkGoType(valueScannerType)
 	if len(b.desc.SchemaType) == 0 {
 		b.desc.Err = fmt.Errorf("expect SchemaType to be set for other field")

--- a/schema/field/internal/numeric.tmpl
+++ b/schema/field/internal/numeric.tmpl
@@ -19,7 +19,7 @@ import (
 {{ range $t := $.Ints }}
 	{{ $title := title $t.String }}
 	// {{ $title }} returns a new Field with type {{ $t }}.
-	func {{ $title }}(name string) *{{ $t }}Builder { return &{{ $t }}Builder{&Descriptor{
+	func {{ $title }}(name string) *{{ $title }}Builder { return &{{ $title }}Builder{&Descriptor{
 			Name: name,
 			Info: &TypeInfo{Type: Type{{ $title }} },
 		}}
@@ -27,21 +27,22 @@ import (
 {{ end }}
 
 // Float returns a new Field with type float64.
-func Float(name string) *float64Builder { return &float64Builder{&Descriptor{
+func Float(name string) *Float64Builder { return &Float64Builder{&Descriptor{
 		Name: name,
 		Info: &TypeInfo{Type: TypeFloat64},
 	}}
 }
 
 // Float32 returns a new Field with type float32.
-func Float32(name string) *float32Builder { return &float32Builder{&Descriptor{
+func Float32(name string) *Float32Builder { return &Float32Builder{&Descriptor{
 		Name: name,
 		Info: &TypeInfo{Type: TypeFloat32},
 	}}
 }
 
 {{ range $t := $.Ints }}
-{{ $builder := printf "%sBuilder" $t }}
+{{ $title := title $t.String }}
+{{ $builder := printf "%sBuilder" $title }}
 
 // {{ $builder }} is the builder for {{ $t }} field.
 type {{ $builder }} struct {
@@ -246,7 +247,8 @@ var (
 )
 
 {{ range $t := $.Floats }}
-{{ $builder := printf "%sBuilder" $t }}
+{{ $title := title $t.String }}
+{{ $builder := printf "%sBuilder" $title }}
 
 // {{ $builder }} is the builder for float fields.
 type {{ $builder }} struct {

--- a/schema/field/numeric.go
+++ b/schema/field/numeric.go
@@ -16,114 +16,114 @@ import (
 //go:generate go run internal/gen.go
 
 // Int returns a new Field with type int.
-func Int(name string) *intBuilder {
-	return &intBuilder{&Descriptor{
+func Int(name string) *IntBuilder {
+	return &IntBuilder{&Descriptor{
 		Name: name,
 		Info: &TypeInfo{Type: TypeInt},
 	}}
 }
 
 // Uint returns a new Field with type uint.
-func Uint(name string) *uintBuilder {
-	return &uintBuilder{&Descriptor{
+func Uint(name string) *UintBuilder {
+	return &UintBuilder{&Descriptor{
 		Name: name,
 		Info: &TypeInfo{Type: TypeUint},
 	}}
 }
 
 // Int8 returns a new Field with type int8.
-func Int8(name string) *int8Builder {
-	return &int8Builder{&Descriptor{
+func Int8(name string) *Int8Builder {
+	return &Int8Builder{&Descriptor{
 		Name: name,
 		Info: &TypeInfo{Type: TypeInt8},
 	}}
 }
 
 // Int16 returns a new Field with type int16.
-func Int16(name string) *int16Builder {
-	return &int16Builder{&Descriptor{
+func Int16(name string) *Int16Builder {
+	return &Int16Builder{&Descriptor{
 		Name: name,
 		Info: &TypeInfo{Type: TypeInt16},
 	}}
 }
 
 // Int32 returns a new Field with type int32.
-func Int32(name string) *int32Builder {
-	return &int32Builder{&Descriptor{
+func Int32(name string) *Int32Builder {
+	return &Int32Builder{&Descriptor{
 		Name: name,
 		Info: &TypeInfo{Type: TypeInt32},
 	}}
 }
 
 // Int64 returns a new Field with type int64.
-func Int64(name string) *int64Builder {
-	return &int64Builder{&Descriptor{
+func Int64(name string) *Int64Builder {
+	return &Int64Builder{&Descriptor{
 		Name: name,
 		Info: &TypeInfo{Type: TypeInt64},
 	}}
 }
 
 // Uint8 returns a new Field with type uint8.
-func Uint8(name string) *uint8Builder {
-	return &uint8Builder{&Descriptor{
+func Uint8(name string) *Uint8Builder {
+	return &Uint8Builder{&Descriptor{
 		Name: name,
 		Info: &TypeInfo{Type: TypeUint8},
 	}}
 }
 
 // Uint16 returns a new Field with type uint16.
-func Uint16(name string) *uint16Builder {
-	return &uint16Builder{&Descriptor{
+func Uint16(name string) *Uint16Builder {
+	return &Uint16Builder{&Descriptor{
 		Name: name,
 		Info: &TypeInfo{Type: TypeUint16},
 	}}
 }
 
 // Uint32 returns a new Field with type uint32.
-func Uint32(name string) *uint32Builder {
-	return &uint32Builder{&Descriptor{
+func Uint32(name string) *Uint32Builder {
+	return &Uint32Builder{&Descriptor{
 		Name: name,
 		Info: &TypeInfo{Type: TypeUint32},
 	}}
 }
 
 // Uint64 returns a new Field with type uint64.
-func Uint64(name string) *uint64Builder {
-	return &uint64Builder{&Descriptor{
+func Uint64(name string) *Uint64Builder {
+	return &Uint64Builder{&Descriptor{
 		Name: name,
 		Info: &TypeInfo{Type: TypeUint64},
 	}}
 }
 
 // Float returns a new Field with type float64.
-func Float(name string) *float64Builder {
-	return &float64Builder{&Descriptor{
+func Float(name string) *Float64Builder {
+	return &Float64Builder{&Descriptor{
 		Name: name,
 		Info: &TypeInfo{Type: TypeFloat64},
 	}}
 }
 
 // Float32 returns a new Field with type float32.
-func Float32(name string) *float32Builder {
-	return &float32Builder{&Descriptor{
+func Float32(name string) *Float32Builder {
+	return &Float32Builder{&Descriptor{
 		Name: name,
 		Info: &TypeInfo{Type: TypeFloat32},
 	}}
 }
 
-// intBuilder is the builder for int field.
-type intBuilder struct {
+// IntBuilder is the builder for int field.
+type IntBuilder struct {
 	desc *Descriptor
 }
 
 // Unique makes the field unique within all vertices of this type.
-func (b *intBuilder) Unique() *intBuilder {
+func (b *IntBuilder) Unique() *IntBuilder {
 	b.desc.Unique = true
 	return b
 }
 
 // Range adds a range validator for this field where the given value needs to be in the range of [i, j].
-func (b *intBuilder) Range(i, j int) *intBuilder {
+func (b *IntBuilder) Range(i, j int) *IntBuilder {
 	b.desc.Validators = append(b.desc.Validators, func(v int) error {
 		if v < i || v > j {
 			return errors.New("value out of range")
@@ -134,7 +134,7 @@ func (b *intBuilder) Range(i, j int) *intBuilder {
 }
 
 // Min adds a minimum value validator for this field. Operation fails if the validator fails.
-func (b *intBuilder) Min(i int) *intBuilder {
+func (b *IntBuilder) Min(i int) *IntBuilder {
 	b.desc.Validators = append(b.desc.Validators, func(v int) error {
 		if v < i {
 			return errors.New("value out of range")
@@ -145,7 +145,7 @@ func (b *intBuilder) Min(i int) *intBuilder {
 }
 
 // Max adds a maximum value validator for this field. Operation fails if the validator fails.
-func (b *intBuilder) Max(i int) *intBuilder {
+func (b *IntBuilder) Max(i int) *IntBuilder {
 	b.desc.Validators = append(b.desc.Validators, func(v int) error {
 		if v > i {
 			return errors.New("value out of range")
@@ -156,29 +156,29 @@ func (b *intBuilder) Max(i int) *intBuilder {
 }
 
 // Positive adds a minimum value validator with the value of 1. Operation fails if the validator fails.
-func (b *intBuilder) Positive() *intBuilder {
+func (b *IntBuilder) Positive() *IntBuilder {
 	return b.Min(1)
 }
 
 // Negative adds a maximum value validator with the value of -1. Operation fails if the validator fails.
-func (b *intBuilder) Negative() *intBuilder {
+func (b *IntBuilder) Negative() *IntBuilder {
 	return b.Max(-1)
 }
 
 // NonNegative adds a minimum value validator with the value of 0. Operation fails if the validator fails.
-func (b *intBuilder) NonNegative() *intBuilder {
+func (b *IntBuilder) NonNegative() *IntBuilder {
 	return b.Min(0)
 }
 
 // Default sets the default value of the field.
-func (b *intBuilder) Default(i int) *intBuilder {
+func (b *IntBuilder) Default(i int) *IntBuilder {
 	b.desc.Default = i
 	return b
 }
 
 // DefaultFunc sets the function that is applied to set the default value
 // of the field on creation.
-func (b *intBuilder) DefaultFunc(fn any) *intBuilder {
+func (b *IntBuilder) DefaultFunc(fn any) *IntBuilder {
 	b.desc.Default = fn
 	return b
 }
@@ -189,52 +189,52 @@ func (b *intBuilder) DefaultFunc(fn any) *intBuilder {
 //	field.Int("int").
 //		Default(0).
 //		UpdateDefault(GenNumber),
-func (b *intBuilder) UpdateDefault(fn any) *intBuilder {
+func (b *IntBuilder) UpdateDefault(fn any) *IntBuilder {
 	b.desc.UpdateDefault = fn
 	return b
 }
 
 // Nillable indicates that this field is a nillable.
 // Unlike "Optional" only fields, "Nillable" fields are pointers in the generated struct.
-func (b *intBuilder) Nillable() *intBuilder {
+func (b *IntBuilder) Nillable() *IntBuilder {
 	b.desc.Nillable = true
 	return b
 }
 
 // Comment sets the comment of the field.
-func (b *intBuilder) Comment(c string) *intBuilder {
+func (b *IntBuilder) Comment(c string) *IntBuilder {
 	b.desc.Comment = c
 	return b
 }
 
 // Optional indicates that this field is optional on create.
 // Unlike edges, fields are required by default.
-func (b *intBuilder) Optional() *intBuilder {
+func (b *IntBuilder) Optional() *IntBuilder {
 	b.desc.Optional = true
 	return b
 }
 
 // Immutable indicates that this field cannot be updated.
-func (b *intBuilder) Immutable() *intBuilder {
+func (b *IntBuilder) Immutable() *IntBuilder {
 	b.desc.Immutable = true
 	return b
 }
 
 // StructTag sets the struct tag of the field.
-func (b *intBuilder) StructTag(s string) *intBuilder {
+func (b *IntBuilder) StructTag(s string) *IntBuilder {
 	b.desc.Tag = s
 	return b
 }
 
 // Validate adds a validator for this field. Operation fails if the validation fails.
-func (b *intBuilder) Validate(fn func(int) error) *intBuilder {
+func (b *IntBuilder) Validate(fn func(int) error) *IntBuilder {
 	b.desc.Validators = append(b.desc.Validators, fn)
 	return b
 }
 
 // StorageKey sets the storage key of the field.
 // In SQL dialects is the column name and Gremlin is the property.
-func (b *intBuilder) StorageKey(key string) *intBuilder {
+func (b *IntBuilder) StorageKey(key string) *IntBuilder {
 	b.desc.StorageKey = key
 	return b
 }
@@ -246,7 +246,7 @@ func (b *intBuilder) StorageKey(key string) *intBuilder {
 //		SchemaType(map[string]string{
 //			dialect.Postgres: "CustomType",
 //		})
-func (b *intBuilder) SchemaType(types map[string]string) *intBuilder {
+func (b *IntBuilder) SchemaType(types map[string]string) *IntBuilder {
 	b.desc.SchemaType = types
 	return b
 }
@@ -266,7 +266,7 @@ func (b *intBuilder) SchemaType(types map[string]string) *intBuilder {
 //	func(t1 T) Add(t2 T) T {
 //		return add(t1, t2)
 //	}
-func (b *intBuilder) GoType(typ any) *intBuilder {
+func (b *IntBuilder) GoType(typ any) *IntBuilder {
 	b.desc.goType(typ)
 	return b
 }
@@ -274,7 +274,7 @@ func (b *intBuilder) GoType(typ any) *intBuilder {
 // ValueScanner provides an external value scanner for the given GoType.
 // Using this option allow users to use field types that do not implement
 // the sql.Scanner and driver.Valuer interfaces.
-func (b *intBuilder) ValueScanner(vs any) *intBuilder {
+func (b *IntBuilder) ValueScanner(vs any) *IntBuilder {
 	b.desc.ValueScanner = vs
 	return b
 }
@@ -284,13 +284,13 @@ func (b *intBuilder) ValueScanner(vs any) *intBuilder {
 //
 //	field.Int("int").
 //		Annotations(entgql.OrderField("INT"))
-func (b *intBuilder) Annotations(annotations ...schema.Annotation) *intBuilder {
+func (b *IntBuilder) Annotations(annotations ...schema.Annotation) *IntBuilder {
 	b.desc.Annotations = append(b.desc.Annotations, annotations...)
 	return b
 }
 
 // Descriptor implements the ent.Field interface by returning its descriptor.
-func (b *intBuilder) Descriptor() *Descriptor {
+func (b *IntBuilder) Descriptor() *Descriptor {
 	if b.desc.Default != nil || b.desc.UpdateDefault != nil {
 		b.desc.checkDefaultFunc(intType)
 	}
@@ -298,19 +298,19 @@ func (b *intBuilder) Descriptor() *Descriptor {
 	return b.desc
 }
 
-// uintBuilder is the builder for uint field.
-type uintBuilder struct {
+// UintBuilder is the builder for uint field.
+type UintBuilder struct {
 	desc *Descriptor
 }
 
 // Unique makes the field unique within all vertices of this type.
-func (b *uintBuilder) Unique() *uintBuilder {
+func (b *UintBuilder) Unique() *UintBuilder {
 	b.desc.Unique = true
 	return b
 }
 
 // Range adds a range validator for this field where the given value needs to be in the range of [i, j].
-func (b *uintBuilder) Range(i, j uint) *uintBuilder {
+func (b *UintBuilder) Range(i, j uint) *UintBuilder {
 	b.desc.Validators = append(b.desc.Validators, func(v uint) error {
 		if v < i || v > j {
 			return errors.New("value out of range")
@@ -321,7 +321,7 @@ func (b *uintBuilder) Range(i, j uint) *uintBuilder {
 }
 
 // Min adds a minimum value validator for this field. Operation fails if the validator fails.
-func (b *uintBuilder) Min(i uint) *uintBuilder {
+func (b *UintBuilder) Min(i uint) *UintBuilder {
 	b.desc.Validators = append(b.desc.Validators, func(v uint) error {
 		if v < i {
 			return errors.New("value out of range")
@@ -332,7 +332,7 @@ func (b *uintBuilder) Min(i uint) *uintBuilder {
 }
 
 // Max adds a maximum value validator for this field. Operation fails if the validator fails.
-func (b *uintBuilder) Max(i uint) *uintBuilder {
+func (b *UintBuilder) Max(i uint) *UintBuilder {
 	b.desc.Validators = append(b.desc.Validators, func(v uint) error {
 		if v > i {
 			return errors.New("value out of range")
@@ -343,19 +343,19 @@ func (b *uintBuilder) Max(i uint) *uintBuilder {
 }
 
 // Positive adds a minimum value validator with the value of 1. Operation fails if the validator fails.
-func (b *uintBuilder) Positive() *uintBuilder {
+func (b *UintBuilder) Positive() *UintBuilder {
 	return b.Min(1)
 }
 
 // Default sets the default value of the field.
-func (b *uintBuilder) Default(i uint) *uintBuilder {
+func (b *UintBuilder) Default(i uint) *UintBuilder {
 	b.desc.Default = i
 	return b
 }
 
 // DefaultFunc sets the function that is applied to set the default value
 // of the field on creation.
-func (b *uintBuilder) DefaultFunc(fn any) *uintBuilder {
+func (b *UintBuilder) DefaultFunc(fn any) *UintBuilder {
 	b.desc.Default = fn
 	return b
 }
@@ -366,52 +366,52 @@ func (b *uintBuilder) DefaultFunc(fn any) *uintBuilder {
 //	field.Uint("uint").
 //		Default(0).
 //		UpdateDefault(GenNumber),
-func (b *uintBuilder) UpdateDefault(fn any) *uintBuilder {
+func (b *UintBuilder) UpdateDefault(fn any) *UintBuilder {
 	b.desc.UpdateDefault = fn
 	return b
 }
 
 // Nillable indicates that this field is a nillable.
 // Unlike "Optional" only fields, "Nillable" fields are pointers in the generated struct.
-func (b *uintBuilder) Nillable() *uintBuilder {
+func (b *UintBuilder) Nillable() *UintBuilder {
 	b.desc.Nillable = true
 	return b
 }
 
 // Comment sets the comment of the field.
-func (b *uintBuilder) Comment(c string) *uintBuilder {
+func (b *UintBuilder) Comment(c string) *UintBuilder {
 	b.desc.Comment = c
 	return b
 }
 
 // Optional indicates that this field is optional on create.
 // Unlike edges, fields are required by default.
-func (b *uintBuilder) Optional() *uintBuilder {
+func (b *UintBuilder) Optional() *UintBuilder {
 	b.desc.Optional = true
 	return b
 }
 
 // Immutable indicates that this field cannot be updated.
-func (b *uintBuilder) Immutable() *uintBuilder {
+func (b *UintBuilder) Immutable() *UintBuilder {
 	b.desc.Immutable = true
 	return b
 }
 
 // StructTag sets the struct tag of the field.
-func (b *uintBuilder) StructTag(s string) *uintBuilder {
+func (b *UintBuilder) StructTag(s string) *UintBuilder {
 	b.desc.Tag = s
 	return b
 }
 
 // Validate adds a validator for this field. Operation fails if the validation fails.
-func (b *uintBuilder) Validate(fn func(uint) error) *uintBuilder {
+func (b *UintBuilder) Validate(fn func(uint) error) *UintBuilder {
 	b.desc.Validators = append(b.desc.Validators, fn)
 	return b
 }
 
 // StorageKey sets the storage key of the field.
 // In SQL dialects is the column name and Gremlin is the property.
-func (b *uintBuilder) StorageKey(key string) *uintBuilder {
+func (b *UintBuilder) StorageKey(key string) *UintBuilder {
 	b.desc.StorageKey = key
 	return b
 }
@@ -423,7 +423,7 @@ func (b *uintBuilder) StorageKey(key string) *uintBuilder {
 //		SchemaType(map[string]string{
 //			dialect.Postgres: "CustomType",
 //		})
-func (b *uintBuilder) SchemaType(types map[string]string) *uintBuilder {
+func (b *UintBuilder) SchemaType(types map[string]string) *UintBuilder {
 	b.desc.SchemaType = types
 	return b
 }
@@ -443,7 +443,7 @@ func (b *uintBuilder) SchemaType(types map[string]string) *uintBuilder {
 //	func(t1 T) Add(t2 T) T {
 //		return add(t1, t2)
 //	}
-func (b *uintBuilder) GoType(typ any) *uintBuilder {
+func (b *UintBuilder) GoType(typ any) *UintBuilder {
 	b.desc.goType(typ)
 	return b
 }
@@ -451,7 +451,7 @@ func (b *uintBuilder) GoType(typ any) *uintBuilder {
 // ValueScanner provides an external value scanner for the given GoType.
 // Using this option allow users to use field types that do not implement
 // the sql.Scanner and driver.Valuer interfaces.
-func (b *uintBuilder) ValueScanner(vs any) *uintBuilder {
+func (b *UintBuilder) ValueScanner(vs any) *UintBuilder {
 	b.desc.ValueScanner = vs
 	return b
 }
@@ -461,13 +461,13 @@ func (b *uintBuilder) ValueScanner(vs any) *uintBuilder {
 //
 //	field.Uint("uint").
 //		Annotations(entgql.OrderField("UINT"))
-func (b *uintBuilder) Annotations(annotations ...schema.Annotation) *uintBuilder {
+func (b *UintBuilder) Annotations(annotations ...schema.Annotation) *UintBuilder {
 	b.desc.Annotations = append(b.desc.Annotations, annotations...)
 	return b
 }
 
 // Descriptor implements the ent.Field interface by returning its descriptor.
-func (b *uintBuilder) Descriptor() *Descriptor {
+func (b *UintBuilder) Descriptor() *Descriptor {
 	if b.desc.Default != nil || b.desc.UpdateDefault != nil {
 		b.desc.checkDefaultFunc(uintType)
 	}
@@ -475,19 +475,19 @@ func (b *uintBuilder) Descriptor() *Descriptor {
 	return b.desc
 }
 
-// int8Builder is the builder for int8 field.
-type int8Builder struct {
+// Int8Builder is the builder for int8 field.
+type Int8Builder struct {
 	desc *Descriptor
 }
 
 // Unique makes the field unique within all vertices of this type.
-func (b *int8Builder) Unique() *int8Builder {
+func (b *Int8Builder) Unique() *Int8Builder {
 	b.desc.Unique = true
 	return b
 }
 
 // Range adds a range validator for this field where the given value needs to be in the range of [i, j].
-func (b *int8Builder) Range(i, j int8) *int8Builder {
+func (b *Int8Builder) Range(i, j int8) *Int8Builder {
 	b.desc.Validators = append(b.desc.Validators, func(v int8) error {
 		if v < i || v > j {
 			return errors.New("value out of range")
@@ -498,7 +498,7 @@ func (b *int8Builder) Range(i, j int8) *int8Builder {
 }
 
 // Min adds a minimum value validator for this field. Operation fails if the validator fails.
-func (b *int8Builder) Min(i int8) *int8Builder {
+func (b *Int8Builder) Min(i int8) *Int8Builder {
 	b.desc.Validators = append(b.desc.Validators, func(v int8) error {
 		if v < i {
 			return errors.New("value out of range")
@@ -509,7 +509,7 @@ func (b *int8Builder) Min(i int8) *int8Builder {
 }
 
 // Max adds a maximum value validator for this field. Operation fails if the validator fails.
-func (b *int8Builder) Max(i int8) *int8Builder {
+func (b *Int8Builder) Max(i int8) *Int8Builder {
 	b.desc.Validators = append(b.desc.Validators, func(v int8) error {
 		if v > i {
 			return errors.New("value out of range")
@@ -520,29 +520,29 @@ func (b *int8Builder) Max(i int8) *int8Builder {
 }
 
 // Positive adds a minimum value validator with the value of 1. Operation fails if the validator fails.
-func (b *int8Builder) Positive() *int8Builder {
+func (b *Int8Builder) Positive() *Int8Builder {
 	return b.Min(1)
 }
 
 // Negative adds a maximum value validator with the value of -1. Operation fails if the validator fails.
-func (b *int8Builder) Negative() *int8Builder {
+func (b *Int8Builder) Negative() *Int8Builder {
 	return b.Max(-1)
 }
 
 // NonNegative adds a minimum value validator with the value of 0. Operation fails if the validator fails.
-func (b *int8Builder) NonNegative() *int8Builder {
+func (b *Int8Builder) NonNegative() *Int8Builder {
 	return b.Min(0)
 }
 
 // Default sets the default value of the field.
-func (b *int8Builder) Default(i int8) *int8Builder {
+func (b *Int8Builder) Default(i int8) *Int8Builder {
 	b.desc.Default = i
 	return b
 }
 
 // DefaultFunc sets the function that is applied to set the default value
 // of the field on creation.
-func (b *int8Builder) DefaultFunc(fn any) *int8Builder {
+func (b *Int8Builder) DefaultFunc(fn any) *Int8Builder {
 	b.desc.Default = fn
 	return b
 }
@@ -553,52 +553,52 @@ func (b *int8Builder) DefaultFunc(fn any) *int8Builder {
 //	field.Int8("int8").
 //		Default(0).
 //		UpdateDefault(GenNumber),
-func (b *int8Builder) UpdateDefault(fn any) *int8Builder {
+func (b *Int8Builder) UpdateDefault(fn any) *Int8Builder {
 	b.desc.UpdateDefault = fn
 	return b
 }
 
 // Nillable indicates that this field is a nillable.
 // Unlike "Optional" only fields, "Nillable" fields are pointers in the generated struct.
-func (b *int8Builder) Nillable() *int8Builder {
+func (b *Int8Builder) Nillable() *Int8Builder {
 	b.desc.Nillable = true
 	return b
 }
 
 // Comment sets the comment of the field.
-func (b *int8Builder) Comment(c string) *int8Builder {
+func (b *Int8Builder) Comment(c string) *Int8Builder {
 	b.desc.Comment = c
 	return b
 }
 
 // Optional indicates that this field is optional on create.
 // Unlike edges, fields are required by default.
-func (b *int8Builder) Optional() *int8Builder {
+func (b *Int8Builder) Optional() *Int8Builder {
 	b.desc.Optional = true
 	return b
 }
 
 // Immutable indicates that this field cannot be updated.
-func (b *int8Builder) Immutable() *int8Builder {
+func (b *Int8Builder) Immutable() *Int8Builder {
 	b.desc.Immutable = true
 	return b
 }
 
 // StructTag sets the struct tag of the field.
-func (b *int8Builder) StructTag(s string) *int8Builder {
+func (b *Int8Builder) StructTag(s string) *Int8Builder {
 	b.desc.Tag = s
 	return b
 }
 
 // Validate adds a validator for this field. Operation fails if the validation fails.
-func (b *int8Builder) Validate(fn func(int8) error) *int8Builder {
+func (b *Int8Builder) Validate(fn func(int8) error) *Int8Builder {
 	b.desc.Validators = append(b.desc.Validators, fn)
 	return b
 }
 
 // StorageKey sets the storage key of the field.
 // In SQL dialects is the column name and Gremlin is the property.
-func (b *int8Builder) StorageKey(key string) *int8Builder {
+func (b *Int8Builder) StorageKey(key string) *Int8Builder {
 	b.desc.StorageKey = key
 	return b
 }
@@ -610,7 +610,7 @@ func (b *int8Builder) StorageKey(key string) *int8Builder {
 //		SchemaType(map[string]string{
 //			dialect.Postgres: "CustomType",
 //		})
-func (b *int8Builder) SchemaType(types map[string]string) *int8Builder {
+func (b *Int8Builder) SchemaType(types map[string]string) *Int8Builder {
 	b.desc.SchemaType = types
 	return b
 }
@@ -630,7 +630,7 @@ func (b *int8Builder) SchemaType(types map[string]string) *int8Builder {
 //	func(t1 T) Add(t2 T) T {
 //		return add(t1, t2)
 //	}
-func (b *int8Builder) GoType(typ any) *int8Builder {
+func (b *Int8Builder) GoType(typ any) *Int8Builder {
 	b.desc.goType(typ)
 	return b
 }
@@ -638,7 +638,7 @@ func (b *int8Builder) GoType(typ any) *int8Builder {
 // ValueScanner provides an external value scanner for the given GoType.
 // Using this option allow users to use field types that do not implement
 // the sql.Scanner and driver.Valuer interfaces.
-func (b *int8Builder) ValueScanner(vs any) *int8Builder {
+func (b *Int8Builder) ValueScanner(vs any) *Int8Builder {
 	b.desc.ValueScanner = vs
 	return b
 }
@@ -648,13 +648,13 @@ func (b *int8Builder) ValueScanner(vs any) *int8Builder {
 //
 //	field.Int8("int8").
 //		Annotations(entgql.OrderField("INT8"))
-func (b *int8Builder) Annotations(annotations ...schema.Annotation) *int8Builder {
+func (b *Int8Builder) Annotations(annotations ...schema.Annotation) *Int8Builder {
 	b.desc.Annotations = append(b.desc.Annotations, annotations...)
 	return b
 }
 
 // Descriptor implements the ent.Field interface by returning its descriptor.
-func (b *int8Builder) Descriptor() *Descriptor {
+func (b *Int8Builder) Descriptor() *Descriptor {
 	if b.desc.Default != nil || b.desc.UpdateDefault != nil {
 		b.desc.checkDefaultFunc(int8Type)
 	}
@@ -662,19 +662,19 @@ func (b *int8Builder) Descriptor() *Descriptor {
 	return b.desc
 }
 
-// int16Builder is the builder for int16 field.
-type int16Builder struct {
+// Int16Builder is the builder for int16 field.
+type Int16Builder struct {
 	desc *Descriptor
 }
 
 // Unique makes the field unique within all vertices of this type.
-func (b *int16Builder) Unique() *int16Builder {
+func (b *Int16Builder) Unique() *Int16Builder {
 	b.desc.Unique = true
 	return b
 }
 
 // Range adds a range validator for this field where the given value needs to be in the range of [i, j].
-func (b *int16Builder) Range(i, j int16) *int16Builder {
+func (b *Int16Builder) Range(i, j int16) *Int16Builder {
 	b.desc.Validators = append(b.desc.Validators, func(v int16) error {
 		if v < i || v > j {
 			return errors.New("value out of range")
@@ -685,7 +685,7 @@ func (b *int16Builder) Range(i, j int16) *int16Builder {
 }
 
 // Min adds a minimum value validator for this field. Operation fails if the validator fails.
-func (b *int16Builder) Min(i int16) *int16Builder {
+func (b *Int16Builder) Min(i int16) *Int16Builder {
 	b.desc.Validators = append(b.desc.Validators, func(v int16) error {
 		if v < i {
 			return errors.New("value out of range")
@@ -696,7 +696,7 @@ func (b *int16Builder) Min(i int16) *int16Builder {
 }
 
 // Max adds a maximum value validator for this field. Operation fails if the validator fails.
-func (b *int16Builder) Max(i int16) *int16Builder {
+func (b *Int16Builder) Max(i int16) *Int16Builder {
 	b.desc.Validators = append(b.desc.Validators, func(v int16) error {
 		if v > i {
 			return errors.New("value out of range")
@@ -707,29 +707,29 @@ func (b *int16Builder) Max(i int16) *int16Builder {
 }
 
 // Positive adds a minimum value validator with the value of 1. Operation fails if the validator fails.
-func (b *int16Builder) Positive() *int16Builder {
+func (b *Int16Builder) Positive() *Int16Builder {
 	return b.Min(1)
 }
 
 // Negative adds a maximum value validator with the value of -1. Operation fails if the validator fails.
-func (b *int16Builder) Negative() *int16Builder {
+func (b *Int16Builder) Negative() *Int16Builder {
 	return b.Max(-1)
 }
 
 // NonNegative adds a minimum value validator with the value of 0. Operation fails if the validator fails.
-func (b *int16Builder) NonNegative() *int16Builder {
+func (b *Int16Builder) NonNegative() *Int16Builder {
 	return b.Min(0)
 }
 
 // Default sets the default value of the field.
-func (b *int16Builder) Default(i int16) *int16Builder {
+func (b *Int16Builder) Default(i int16) *Int16Builder {
 	b.desc.Default = i
 	return b
 }
 
 // DefaultFunc sets the function that is applied to set the default value
 // of the field on creation.
-func (b *int16Builder) DefaultFunc(fn any) *int16Builder {
+func (b *Int16Builder) DefaultFunc(fn any) *Int16Builder {
 	b.desc.Default = fn
 	return b
 }
@@ -740,52 +740,52 @@ func (b *int16Builder) DefaultFunc(fn any) *int16Builder {
 //	field.Int16("int16").
 //		Default(0).
 //		UpdateDefault(GenNumber),
-func (b *int16Builder) UpdateDefault(fn any) *int16Builder {
+func (b *Int16Builder) UpdateDefault(fn any) *Int16Builder {
 	b.desc.UpdateDefault = fn
 	return b
 }
 
 // Nillable indicates that this field is a nillable.
 // Unlike "Optional" only fields, "Nillable" fields are pointers in the generated struct.
-func (b *int16Builder) Nillable() *int16Builder {
+func (b *Int16Builder) Nillable() *Int16Builder {
 	b.desc.Nillable = true
 	return b
 }
 
 // Comment sets the comment of the field.
-func (b *int16Builder) Comment(c string) *int16Builder {
+func (b *Int16Builder) Comment(c string) *Int16Builder {
 	b.desc.Comment = c
 	return b
 }
 
 // Optional indicates that this field is optional on create.
 // Unlike edges, fields are required by default.
-func (b *int16Builder) Optional() *int16Builder {
+func (b *Int16Builder) Optional() *Int16Builder {
 	b.desc.Optional = true
 	return b
 }
 
 // Immutable indicates that this field cannot be updated.
-func (b *int16Builder) Immutable() *int16Builder {
+func (b *Int16Builder) Immutable() *Int16Builder {
 	b.desc.Immutable = true
 	return b
 }
 
 // StructTag sets the struct tag of the field.
-func (b *int16Builder) StructTag(s string) *int16Builder {
+func (b *Int16Builder) StructTag(s string) *Int16Builder {
 	b.desc.Tag = s
 	return b
 }
 
 // Validate adds a validator for this field. Operation fails if the validation fails.
-func (b *int16Builder) Validate(fn func(int16) error) *int16Builder {
+func (b *Int16Builder) Validate(fn func(int16) error) *Int16Builder {
 	b.desc.Validators = append(b.desc.Validators, fn)
 	return b
 }
 
 // StorageKey sets the storage key of the field.
 // In SQL dialects is the column name and Gremlin is the property.
-func (b *int16Builder) StorageKey(key string) *int16Builder {
+func (b *Int16Builder) StorageKey(key string) *Int16Builder {
 	b.desc.StorageKey = key
 	return b
 }
@@ -797,7 +797,7 @@ func (b *int16Builder) StorageKey(key string) *int16Builder {
 //		SchemaType(map[string]string{
 //			dialect.Postgres: "CustomType",
 //		})
-func (b *int16Builder) SchemaType(types map[string]string) *int16Builder {
+func (b *Int16Builder) SchemaType(types map[string]string) *Int16Builder {
 	b.desc.SchemaType = types
 	return b
 }
@@ -817,7 +817,7 @@ func (b *int16Builder) SchemaType(types map[string]string) *int16Builder {
 //	func(t1 T) Add(t2 T) T {
 //		return add(t1, t2)
 //	}
-func (b *int16Builder) GoType(typ any) *int16Builder {
+func (b *Int16Builder) GoType(typ any) *Int16Builder {
 	b.desc.goType(typ)
 	return b
 }
@@ -825,7 +825,7 @@ func (b *int16Builder) GoType(typ any) *int16Builder {
 // ValueScanner provides an external value scanner for the given GoType.
 // Using this option allow users to use field types that do not implement
 // the sql.Scanner and driver.Valuer interfaces.
-func (b *int16Builder) ValueScanner(vs any) *int16Builder {
+func (b *Int16Builder) ValueScanner(vs any) *Int16Builder {
 	b.desc.ValueScanner = vs
 	return b
 }
@@ -835,13 +835,13 @@ func (b *int16Builder) ValueScanner(vs any) *int16Builder {
 //
 //	field.Int16("int16").
 //		Annotations(entgql.OrderField("INT16"))
-func (b *int16Builder) Annotations(annotations ...schema.Annotation) *int16Builder {
+func (b *Int16Builder) Annotations(annotations ...schema.Annotation) *Int16Builder {
 	b.desc.Annotations = append(b.desc.Annotations, annotations...)
 	return b
 }
 
 // Descriptor implements the ent.Field interface by returning its descriptor.
-func (b *int16Builder) Descriptor() *Descriptor {
+func (b *Int16Builder) Descriptor() *Descriptor {
 	if b.desc.Default != nil || b.desc.UpdateDefault != nil {
 		b.desc.checkDefaultFunc(int16Type)
 	}
@@ -849,19 +849,19 @@ func (b *int16Builder) Descriptor() *Descriptor {
 	return b.desc
 }
 
-// int32Builder is the builder for int32 field.
-type int32Builder struct {
+// Int32Builder is the builder for int32 field.
+type Int32Builder struct {
 	desc *Descriptor
 }
 
 // Unique makes the field unique within all vertices of this type.
-func (b *int32Builder) Unique() *int32Builder {
+func (b *Int32Builder) Unique() *Int32Builder {
 	b.desc.Unique = true
 	return b
 }
 
 // Range adds a range validator for this field where the given value needs to be in the range of [i, j].
-func (b *int32Builder) Range(i, j int32) *int32Builder {
+func (b *Int32Builder) Range(i, j int32) *Int32Builder {
 	b.desc.Validators = append(b.desc.Validators, func(v int32) error {
 		if v < i || v > j {
 			return errors.New("value out of range")
@@ -872,7 +872,7 @@ func (b *int32Builder) Range(i, j int32) *int32Builder {
 }
 
 // Min adds a minimum value validator for this field. Operation fails if the validator fails.
-func (b *int32Builder) Min(i int32) *int32Builder {
+func (b *Int32Builder) Min(i int32) *Int32Builder {
 	b.desc.Validators = append(b.desc.Validators, func(v int32) error {
 		if v < i {
 			return errors.New("value out of range")
@@ -883,7 +883,7 @@ func (b *int32Builder) Min(i int32) *int32Builder {
 }
 
 // Max adds a maximum value validator for this field. Operation fails if the validator fails.
-func (b *int32Builder) Max(i int32) *int32Builder {
+func (b *Int32Builder) Max(i int32) *Int32Builder {
 	b.desc.Validators = append(b.desc.Validators, func(v int32) error {
 		if v > i {
 			return errors.New("value out of range")
@@ -894,29 +894,29 @@ func (b *int32Builder) Max(i int32) *int32Builder {
 }
 
 // Positive adds a minimum value validator with the value of 1. Operation fails if the validator fails.
-func (b *int32Builder) Positive() *int32Builder {
+func (b *Int32Builder) Positive() *Int32Builder {
 	return b.Min(1)
 }
 
 // Negative adds a maximum value validator with the value of -1. Operation fails if the validator fails.
-func (b *int32Builder) Negative() *int32Builder {
+func (b *Int32Builder) Negative() *Int32Builder {
 	return b.Max(-1)
 }
 
 // NonNegative adds a minimum value validator with the value of 0. Operation fails if the validator fails.
-func (b *int32Builder) NonNegative() *int32Builder {
+func (b *Int32Builder) NonNegative() *Int32Builder {
 	return b.Min(0)
 }
 
 // Default sets the default value of the field.
-func (b *int32Builder) Default(i int32) *int32Builder {
+func (b *Int32Builder) Default(i int32) *Int32Builder {
 	b.desc.Default = i
 	return b
 }
 
 // DefaultFunc sets the function that is applied to set the default value
 // of the field on creation.
-func (b *int32Builder) DefaultFunc(fn any) *int32Builder {
+func (b *Int32Builder) DefaultFunc(fn any) *Int32Builder {
 	b.desc.Default = fn
 	return b
 }
@@ -927,52 +927,52 @@ func (b *int32Builder) DefaultFunc(fn any) *int32Builder {
 //	field.Int32("int32").
 //		Default(0).
 //		UpdateDefault(GenNumber),
-func (b *int32Builder) UpdateDefault(fn any) *int32Builder {
+func (b *Int32Builder) UpdateDefault(fn any) *Int32Builder {
 	b.desc.UpdateDefault = fn
 	return b
 }
 
 // Nillable indicates that this field is a nillable.
 // Unlike "Optional" only fields, "Nillable" fields are pointers in the generated struct.
-func (b *int32Builder) Nillable() *int32Builder {
+func (b *Int32Builder) Nillable() *Int32Builder {
 	b.desc.Nillable = true
 	return b
 }
 
 // Comment sets the comment of the field.
-func (b *int32Builder) Comment(c string) *int32Builder {
+func (b *Int32Builder) Comment(c string) *Int32Builder {
 	b.desc.Comment = c
 	return b
 }
 
 // Optional indicates that this field is optional on create.
 // Unlike edges, fields are required by default.
-func (b *int32Builder) Optional() *int32Builder {
+func (b *Int32Builder) Optional() *Int32Builder {
 	b.desc.Optional = true
 	return b
 }
 
 // Immutable indicates that this field cannot be updated.
-func (b *int32Builder) Immutable() *int32Builder {
+func (b *Int32Builder) Immutable() *Int32Builder {
 	b.desc.Immutable = true
 	return b
 }
 
 // StructTag sets the struct tag of the field.
-func (b *int32Builder) StructTag(s string) *int32Builder {
+func (b *Int32Builder) StructTag(s string) *Int32Builder {
 	b.desc.Tag = s
 	return b
 }
 
 // Validate adds a validator for this field. Operation fails if the validation fails.
-func (b *int32Builder) Validate(fn func(int32) error) *int32Builder {
+func (b *Int32Builder) Validate(fn func(int32) error) *Int32Builder {
 	b.desc.Validators = append(b.desc.Validators, fn)
 	return b
 }
 
 // StorageKey sets the storage key of the field.
 // In SQL dialects is the column name and Gremlin is the property.
-func (b *int32Builder) StorageKey(key string) *int32Builder {
+func (b *Int32Builder) StorageKey(key string) *Int32Builder {
 	b.desc.StorageKey = key
 	return b
 }
@@ -984,7 +984,7 @@ func (b *int32Builder) StorageKey(key string) *int32Builder {
 //		SchemaType(map[string]string{
 //			dialect.Postgres: "CustomType",
 //		})
-func (b *int32Builder) SchemaType(types map[string]string) *int32Builder {
+func (b *Int32Builder) SchemaType(types map[string]string) *Int32Builder {
 	b.desc.SchemaType = types
 	return b
 }
@@ -1004,7 +1004,7 @@ func (b *int32Builder) SchemaType(types map[string]string) *int32Builder {
 //	func(t1 T) Add(t2 T) T {
 //		return add(t1, t2)
 //	}
-func (b *int32Builder) GoType(typ any) *int32Builder {
+func (b *Int32Builder) GoType(typ any) *Int32Builder {
 	b.desc.goType(typ)
 	return b
 }
@@ -1012,7 +1012,7 @@ func (b *int32Builder) GoType(typ any) *int32Builder {
 // ValueScanner provides an external value scanner for the given GoType.
 // Using this option allow users to use field types that do not implement
 // the sql.Scanner and driver.Valuer interfaces.
-func (b *int32Builder) ValueScanner(vs any) *int32Builder {
+func (b *Int32Builder) ValueScanner(vs any) *Int32Builder {
 	b.desc.ValueScanner = vs
 	return b
 }
@@ -1022,13 +1022,13 @@ func (b *int32Builder) ValueScanner(vs any) *int32Builder {
 //
 //	field.Int32("int32").
 //		Annotations(entgql.OrderField("INT32"))
-func (b *int32Builder) Annotations(annotations ...schema.Annotation) *int32Builder {
+func (b *Int32Builder) Annotations(annotations ...schema.Annotation) *Int32Builder {
 	b.desc.Annotations = append(b.desc.Annotations, annotations...)
 	return b
 }
 
 // Descriptor implements the ent.Field interface by returning its descriptor.
-func (b *int32Builder) Descriptor() *Descriptor {
+func (b *Int32Builder) Descriptor() *Descriptor {
 	if b.desc.Default != nil || b.desc.UpdateDefault != nil {
 		b.desc.checkDefaultFunc(int32Type)
 	}
@@ -1036,19 +1036,19 @@ func (b *int32Builder) Descriptor() *Descriptor {
 	return b.desc
 }
 
-// int64Builder is the builder for int64 field.
-type int64Builder struct {
+// Int64Builder is the builder for int64 field.
+type Int64Builder struct {
 	desc *Descriptor
 }
 
 // Unique makes the field unique within all vertices of this type.
-func (b *int64Builder) Unique() *int64Builder {
+func (b *Int64Builder) Unique() *Int64Builder {
 	b.desc.Unique = true
 	return b
 }
 
 // Range adds a range validator for this field where the given value needs to be in the range of [i, j].
-func (b *int64Builder) Range(i, j int64) *int64Builder {
+func (b *Int64Builder) Range(i, j int64) *Int64Builder {
 	b.desc.Validators = append(b.desc.Validators, func(v int64) error {
 		if v < i || v > j {
 			return errors.New("value out of range")
@@ -1059,7 +1059,7 @@ func (b *int64Builder) Range(i, j int64) *int64Builder {
 }
 
 // Min adds a minimum value validator for this field. Operation fails if the validator fails.
-func (b *int64Builder) Min(i int64) *int64Builder {
+func (b *Int64Builder) Min(i int64) *Int64Builder {
 	b.desc.Validators = append(b.desc.Validators, func(v int64) error {
 		if v < i {
 			return errors.New("value out of range")
@@ -1070,7 +1070,7 @@ func (b *int64Builder) Min(i int64) *int64Builder {
 }
 
 // Max adds a maximum value validator for this field. Operation fails if the validator fails.
-func (b *int64Builder) Max(i int64) *int64Builder {
+func (b *Int64Builder) Max(i int64) *Int64Builder {
 	b.desc.Validators = append(b.desc.Validators, func(v int64) error {
 		if v > i {
 			return errors.New("value out of range")
@@ -1081,29 +1081,29 @@ func (b *int64Builder) Max(i int64) *int64Builder {
 }
 
 // Positive adds a minimum value validator with the value of 1. Operation fails if the validator fails.
-func (b *int64Builder) Positive() *int64Builder {
+func (b *Int64Builder) Positive() *Int64Builder {
 	return b.Min(1)
 }
 
 // Negative adds a maximum value validator with the value of -1. Operation fails if the validator fails.
-func (b *int64Builder) Negative() *int64Builder {
+func (b *Int64Builder) Negative() *Int64Builder {
 	return b.Max(-1)
 }
 
 // NonNegative adds a minimum value validator with the value of 0. Operation fails if the validator fails.
-func (b *int64Builder) NonNegative() *int64Builder {
+func (b *Int64Builder) NonNegative() *Int64Builder {
 	return b.Min(0)
 }
 
 // Default sets the default value of the field.
-func (b *int64Builder) Default(i int64) *int64Builder {
+func (b *Int64Builder) Default(i int64) *Int64Builder {
 	b.desc.Default = i
 	return b
 }
 
 // DefaultFunc sets the function that is applied to set the default value
 // of the field on creation.
-func (b *int64Builder) DefaultFunc(fn any) *int64Builder {
+func (b *Int64Builder) DefaultFunc(fn any) *Int64Builder {
 	b.desc.Default = fn
 	return b
 }
@@ -1114,52 +1114,52 @@ func (b *int64Builder) DefaultFunc(fn any) *int64Builder {
 //	field.Int64("int64").
 //		Default(0).
 //		UpdateDefault(GenNumber),
-func (b *int64Builder) UpdateDefault(fn any) *int64Builder {
+func (b *Int64Builder) UpdateDefault(fn any) *Int64Builder {
 	b.desc.UpdateDefault = fn
 	return b
 }
 
 // Nillable indicates that this field is a nillable.
 // Unlike "Optional" only fields, "Nillable" fields are pointers in the generated struct.
-func (b *int64Builder) Nillable() *int64Builder {
+func (b *Int64Builder) Nillable() *Int64Builder {
 	b.desc.Nillable = true
 	return b
 }
 
 // Comment sets the comment of the field.
-func (b *int64Builder) Comment(c string) *int64Builder {
+func (b *Int64Builder) Comment(c string) *Int64Builder {
 	b.desc.Comment = c
 	return b
 }
 
 // Optional indicates that this field is optional on create.
 // Unlike edges, fields are required by default.
-func (b *int64Builder) Optional() *int64Builder {
+func (b *Int64Builder) Optional() *Int64Builder {
 	b.desc.Optional = true
 	return b
 }
 
 // Immutable indicates that this field cannot be updated.
-func (b *int64Builder) Immutable() *int64Builder {
+func (b *Int64Builder) Immutable() *Int64Builder {
 	b.desc.Immutable = true
 	return b
 }
 
 // StructTag sets the struct tag of the field.
-func (b *int64Builder) StructTag(s string) *int64Builder {
+func (b *Int64Builder) StructTag(s string) *Int64Builder {
 	b.desc.Tag = s
 	return b
 }
 
 // Validate adds a validator for this field. Operation fails if the validation fails.
-func (b *int64Builder) Validate(fn func(int64) error) *int64Builder {
+func (b *Int64Builder) Validate(fn func(int64) error) *Int64Builder {
 	b.desc.Validators = append(b.desc.Validators, fn)
 	return b
 }
 
 // StorageKey sets the storage key of the field.
 // In SQL dialects is the column name and Gremlin is the property.
-func (b *int64Builder) StorageKey(key string) *int64Builder {
+func (b *Int64Builder) StorageKey(key string) *Int64Builder {
 	b.desc.StorageKey = key
 	return b
 }
@@ -1171,7 +1171,7 @@ func (b *int64Builder) StorageKey(key string) *int64Builder {
 //		SchemaType(map[string]string{
 //			dialect.Postgres: "CustomType",
 //		})
-func (b *int64Builder) SchemaType(types map[string]string) *int64Builder {
+func (b *Int64Builder) SchemaType(types map[string]string) *Int64Builder {
 	b.desc.SchemaType = types
 	return b
 }
@@ -1191,7 +1191,7 @@ func (b *int64Builder) SchemaType(types map[string]string) *int64Builder {
 //	func(t1 T) Add(t2 T) T {
 //		return add(t1, t2)
 //	}
-func (b *int64Builder) GoType(typ any) *int64Builder {
+func (b *Int64Builder) GoType(typ any) *Int64Builder {
 	b.desc.goType(typ)
 	return b
 }
@@ -1199,7 +1199,7 @@ func (b *int64Builder) GoType(typ any) *int64Builder {
 // ValueScanner provides an external value scanner for the given GoType.
 // Using this option allow users to use field types that do not implement
 // the sql.Scanner and driver.Valuer interfaces.
-func (b *int64Builder) ValueScanner(vs any) *int64Builder {
+func (b *Int64Builder) ValueScanner(vs any) *Int64Builder {
 	b.desc.ValueScanner = vs
 	return b
 }
@@ -1209,13 +1209,13 @@ func (b *int64Builder) ValueScanner(vs any) *int64Builder {
 //
 //	field.Int64("int64").
 //		Annotations(entgql.OrderField("INT64"))
-func (b *int64Builder) Annotations(annotations ...schema.Annotation) *int64Builder {
+func (b *Int64Builder) Annotations(annotations ...schema.Annotation) *Int64Builder {
 	b.desc.Annotations = append(b.desc.Annotations, annotations...)
 	return b
 }
 
 // Descriptor implements the ent.Field interface by returning its descriptor.
-func (b *int64Builder) Descriptor() *Descriptor {
+func (b *Int64Builder) Descriptor() *Descriptor {
 	if b.desc.Default != nil || b.desc.UpdateDefault != nil {
 		b.desc.checkDefaultFunc(int64Type)
 	}
@@ -1223,19 +1223,19 @@ func (b *int64Builder) Descriptor() *Descriptor {
 	return b.desc
 }
 
-// uint8Builder is the builder for uint8 field.
-type uint8Builder struct {
+// Uint8Builder is the builder for uint8 field.
+type Uint8Builder struct {
 	desc *Descriptor
 }
 
 // Unique makes the field unique within all vertices of this type.
-func (b *uint8Builder) Unique() *uint8Builder {
+func (b *Uint8Builder) Unique() *Uint8Builder {
 	b.desc.Unique = true
 	return b
 }
 
 // Range adds a range validator for this field where the given value needs to be in the range of [i, j].
-func (b *uint8Builder) Range(i, j uint8) *uint8Builder {
+func (b *Uint8Builder) Range(i, j uint8) *Uint8Builder {
 	b.desc.Validators = append(b.desc.Validators, func(v uint8) error {
 		if v < i || v > j {
 			return errors.New("value out of range")
@@ -1246,7 +1246,7 @@ func (b *uint8Builder) Range(i, j uint8) *uint8Builder {
 }
 
 // Min adds a minimum value validator for this field. Operation fails if the validator fails.
-func (b *uint8Builder) Min(i uint8) *uint8Builder {
+func (b *Uint8Builder) Min(i uint8) *Uint8Builder {
 	b.desc.Validators = append(b.desc.Validators, func(v uint8) error {
 		if v < i {
 			return errors.New("value out of range")
@@ -1257,7 +1257,7 @@ func (b *uint8Builder) Min(i uint8) *uint8Builder {
 }
 
 // Max adds a maximum value validator for this field. Operation fails if the validator fails.
-func (b *uint8Builder) Max(i uint8) *uint8Builder {
+func (b *Uint8Builder) Max(i uint8) *Uint8Builder {
 	b.desc.Validators = append(b.desc.Validators, func(v uint8) error {
 		if v > i {
 			return errors.New("value out of range")
@@ -1268,19 +1268,19 @@ func (b *uint8Builder) Max(i uint8) *uint8Builder {
 }
 
 // Positive adds a minimum value validator with the value of 1. Operation fails if the validator fails.
-func (b *uint8Builder) Positive() *uint8Builder {
+func (b *Uint8Builder) Positive() *Uint8Builder {
 	return b.Min(1)
 }
 
 // Default sets the default value of the field.
-func (b *uint8Builder) Default(i uint8) *uint8Builder {
+func (b *Uint8Builder) Default(i uint8) *Uint8Builder {
 	b.desc.Default = i
 	return b
 }
 
 // DefaultFunc sets the function that is applied to set the default value
 // of the field on creation.
-func (b *uint8Builder) DefaultFunc(fn any) *uint8Builder {
+func (b *Uint8Builder) DefaultFunc(fn any) *Uint8Builder {
 	b.desc.Default = fn
 	return b
 }
@@ -1291,52 +1291,52 @@ func (b *uint8Builder) DefaultFunc(fn any) *uint8Builder {
 //	field.Uint8("uint8").
 //		Default(0).
 //		UpdateDefault(GenNumber),
-func (b *uint8Builder) UpdateDefault(fn any) *uint8Builder {
+func (b *Uint8Builder) UpdateDefault(fn any) *Uint8Builder {
 	b.desc.UpdateDefault = fn
 	return b
 }
 
 // Nillable indicates that this field is a nillable.
 // Unlike "Optional" only fields, "Nillable" fields are pointers in the generated struct.
-func (b *uint8Builder) Nillable() *uint8Builder {
+func (b *Uint8Builder) Nillable() *Uint8Builder {
 	b.desc.Nillable = true
 	return b
 }
 
 // Comment sets the comment of the field.
-func (b *uint8Builder) Comment(c string) *uint8Builder {
+func (b *Uint8Builder) Comment(c string) *Uint8Builder {
 	b.desc.Comment = c
 	return b
 }
 
 // Optional indicates that this field is optional on create.
 // Unlike edges, fields are required by default.
-func (b *uint8Builder) Optional() *uint8Builder {
+func (b *Uint8Builder) Optional() *Uint8Builder {
 	b.desc.Optional = true
 	return b
 }
 
 // Immutable indicates that this field cannot be updated.
-func (b *uint8Builder) Immutable() *uint8Builder {
+func (b *Uint8Builder) Immutable() *Uint8Builder {
 	b.desc.Immutable = true
 	return b
 }
 
 // StructTag sets the struct tag of the field.
-func (b *uint8Builder) StructTag(s string) *uint8Builder {
+func (b *Uint8Builder) StructTag(s string) *Uint8Builder {
 	b.desc.Tag = s
 	return b
 }
 
 // Validate adds a validator for this field. Operation fails if the validation fails.
-func (b *uint8Builder) Validate(fn func(uint8) error) *uint8Builder {
+func (b *Uint8Builder) Validate(fn func(uint8) error) *Uint8Builder {
 	b.desc.Validators = append(b.desc.Validators, fn)
 	return b
 }
 
 // StorageKey sets the storage key of the field.
 // In SQL dialects is the column name and Gremlin is the property.
-func (b *uint8Builder) StorageKey(key string) *uint8Builder {
+func (b *Uint8Builder) StorageKey(key string) *Uint8Builder {
 	b.desc.StorageKey = key
 	return b
 }
@@ -1348,7 +1348,7 @@ func (b *uint8Builder) StorageKey(key string) *uint8Builder {
 //		SchemaType(map[string]string{
 //			dialect.Postgres: "CustomType",
 //		})
-func (b *uint8Builder) SchemaType(types map[string]string) *uint8Builder {
+func (b *Uint8Builder) SchemaType(types map[string]string) *Uint8Builder {
 	b.desc.SchemaType = types
 	return b
 }
@@ -1368,7 +1368,7 @@ func (b *uint8Builder) SchemaType(types map[string]string) *uint8Builder {
 //	func(t1 T) Add(t2 T) T {
 //		return add(t1, t2)
 //	}
-func (b *uint8Builder) GoType(typ any) *uint8Builder {
+func (b *Uint8Builder) GoType(typ any) *Uint8Builder {
 	b.desc.goType(typ)
 	return b
 }
@@ -1376,7 +1376,7 @@ func (b *uint8Builder) GoType(typ any) *uint8Builder {
 // ValueScanner provides an external value scanner for the given GoType.
 // Using this option allow users to use field types that do not implement
 // the sql.Scanner and driver.Valuer interfaces.
-func (b *uint8Builder) ValueScanner(vs any) *uint8Builder {
+func (b *Uint8Builder) ValueScanner(vs any) *Uint8Builder {
 	b.desc.ValueScanner = vs
 	return b
 }
@@ -1386,13 +1386,13 @@ func (b *uint8Builder) ValueScanner(vs any) *uint8Builder {
 //
 //	field.Uint8("uint8").
 //		Annotations(entgql.OrderField("UINT8"))
-func (b *uint8Builder) Annotations(annotations ...schema.Annotation) *uint8Builder {
+func (b *Uint8Builder) Annotations(annotations ...schema.Annotation) *Uint8Builder {
 	b.desc.Annotations = append(b.desc.Annotations, annotations...)
 	return b
 }
 
 // Descriptor implements the ent.Field interface by returning its descriptor.
-func (b *uint8Builder) Descriptor() *Descriptor {
+func (b *Uint8Builder) Descriptor() *Descriptor {
 	if b.desc.Default != nil || b.desc.UpdateDefault != nil {
 		b.desc.checkDefaultFunc(uint8Type)
 	}
@@ -1400,19 +1400,19 @@ func (b *uint8Builder) Descriptor() *Descriptor {
 	return b.desc
 }
 
-// uint16Builder is the builder for uint16 field.
-type uint16Builder struct {
+// Uint16Builder is the builder for uint16 field.
+type Uint16Builder struct {
 	desc *Descriptor
 }
 
 // Unique makes the field unique within all vertices of this type.
-func (b *uint16Builder) Unique() *uint16Builder {
+func (b *Uint16Builder) Unique() *Uint16Builder {
 	b.desc.Unique = true
 	return b
 }
 
 // Range adds a range validator for this field where the given value needs to be in the range of [i, j].
-func (b *uint16Builder) Range(i, j uint16) *uint16Builder {
+func (b *Uint16Builder) Range(i, j uint16) *Uint16Builder {
 	b.desc.Validators = append(b.desc.Validators, func(v uint16) error {
 		if v < i || v > j {
 			return errors.New("value out of range")
@@ -1423,7 +1423,7 @@ func (b *uint16Builder) Range(i, j uint16) *uint16Builder {
 }
 
 // Min adds a minimum value validator for this field. Operation fails if the validator fails.
-func (b *uint16Builder) Min(i uint16) *uint16Builder {
+func (b *Uint16Builder) Min(i uint16) *Uint16Builder {
 	b.desc.Validators = append(b.desc.Validators, func(v uint16) error {
 		if v < i {
 			return errors.New("value out of range")
@@ -1434,7 +1434,7 @@ func (b *uint16Builder) Min(i uint16) *uint16Builder {
 }
 
 // Max adds a maximum value validator for this field. Operation fails if the validator fails.
-func (b *uint16Builder) Max(i uint16) *uint16Builder {
+func (b *Uint16Builder) Max(i uint16) *Uint16Builder {
 	b.desc.Validators = append(b.desc.Validators, func(v uint16) error {
 		if v > i {
 			return errors.New("value out of range")
@@ -1445,19 +1445,19 @@ func (b *uint16Builder) Max(i uint16) *uint16Builder {
 }
 
 // Positive adds a minimum value validator with the value of 1. Operation fails if the validator fails.
-func (b *uint16Builder) Positive() *uint16Builder {
+func (b *Uint16Builder) Positive() *Uint16Builder {
 	return b.Min(1)
 }
 
 // Default sets the default value of the field.
-func (b *uint16Builder) Default(i uint16) *uint16Builder {
+func (b *Uint16Builder) Default(i uint16) *Uint16Builder {
 	b.desc.Default = i
 	return b
 }
 
 // DefaultFunc sets the function that is applied to set the default value
 // of the field on creation.
-func (b *uint16Builder) DefaultFunc(fn any) *uint16Builder {
+func (b *Uint16Builder) DefaultFunc(fn any) *Uint16Builder {
 	b.desc.Default = fn
 	return b
 }
@@ -1468,52 +1468,52 @@ func (b *uint16Builder) DefaultFunc(fn any) *uint16Builder {
 //	field.Uint16("uint16").
 //		Default(0).
 //		UpdateDefault(GenNumber),
-func (b *uint16Builder) UpdateDefault(fn any) *uint16Builder {
+func (b *Uint16Builder) UpdateDefault(fn any) *Uint16Builder {
 	b.desc.UpdateDefault = fn
 	return b
 }
 
 // Nillable indicates that this field is a nillable.
 // Unlike "Optional" only fields, "Nillable" fields are pointers in the generated struct.
-func (b *uint16Builder) Nillable() *uint16Builder {
+func (b *Uint16Builder) Nillable() *Uint16Builder {
 	b.desc.Nillable = true
 	return b
 }
 
 // Comment sets the comment of the field.
-func (b *uint16Builder) Comment(c string) *uint16Builder {
+func (b *Uint16Builder) Comment(c string) *Uint16Builder {
 	b.desc.Comment = c
 	return b
 }
 
 // Optional indicates that this field is optional on create.
 // Unlike edges, fields are required by default.
-func (b *uint16Builder) Optional() *uint16Builder {
+func (b *Uint16Builder) Optional() *Uint16Builder {
 	b.desc.Optional = true
 	return b
 }
 
 // Immutable indicates that this field cannot be updated.
-func (b *uint16Builder) Immutable() *uint16Builder {
+func (b *Uint16Builder) Immutable() *Uint16Builder {
 	b.desc.Immutable = true
 	return b
 }
 
 // StructTag sets the struct tag of the field.
-func (b *uint16Builder) StructTag(s string) *uint16Builder {
+func (b *Uint16Builder) StructTag(s string) *Uint16Builder {
 	b.desc.Tag = s
 	return b
 }
 
 // Validate adds a validator for this field. Operation fails if the validation fails.
-func (b *uint16Builder) Validate(fn func(uint16) error) *uint16Builder {
+func (b *Uint16Builder) Validate(fn func(uint16) error) *Uint16Builder {
 	b.desc.Validators = append(b.desc.Validators, fn)
 	return b
 }
 
 // StorageKey sets the storage key of the field.
 // In SQL dialects is the column name and Gremlin is the property.
-func (b *uint16Builder) StorageKey(key string) *uint16Builder {
+func (b *Uint16Builder) StorageKey(key string) *Uint16Builder {
 	b.desc.StorageKey = key
 	return b
 }
@@ -1525,7 +1525,7 @@ func (b *uint16Builder) StorageKey(key string) *uint16Builder {
 //		SchemaType(map[string]string{
 //			dialect.Postgres: "CustomType",
 //		})
-func (b *uint16Builder) SchemaType(types map[string]string) *uint16Builder {
+func (b *Uint16Builder) SchemaType(types map[string]string) *Uint16Builder {
 	b.desc.SchemaType = types
 	return b
 }
@@ -1545,7 +1545,7 @@ func (b *uint16Builder) SchemaType(types map[string]string) *uint16Builder {
 //	func(t1 T) Add(t2 T) T {
 //		return add(t1, t2)
 //	}
-func (b *uint16Builder) GoType(typ any) *uint16Builder {
+func (b *Uint16Builder) GoType(typ any) *Uint16Builder {
 	b.desc.goType(typ)
 	return b
 }
@@ -1553,7 +1553,7 @@ func (b *uint16Builder) GoType(typ any) *uint16Builder {
 // ValueScanner provides an external value scanner for the given GoType.
 // Using this option allow users to use field types that do not implement
 // the sql.Scanner and driver.Valuer interfaces.
-func (b *uint16Builder) ValueScanner(vs any) *uint16Builder {
+func (b *Uint16Builder) ValueScanner(vs any) *Uint16Builder {
 	b.desc.ValueScanner = vs
 	return b
 }
@@ -1563,13 +1563,13 @@ func (b *uint16Builder) ValueScanner(vs any) *uint16Builder {
 //
 //	field.Uint16("uint16").
 //		Annotations(entgql.OrderField("UINT16"))
-func (b *uint16Builder) Annotations(annotations ...schema.Annotation) *uint16Builder {
+func (b *Uint16Builder) Annotations(annotations ...schema.Annotation) *Uint16Builder {
 	b.desc.Annotations = append(b.desc.Annotations, annotations...)
 	return b
 }
 
 // Descriptor implements the ent.Field interface by returning its descriptor.
-func (b *uint16Builder) Descriptor() *Descriptor {
+func (b *Uint16Builder) Descriptor() *Descriptor {
 	if b.desc.Default != nil || b.desc.UpdateDefault != nil {
 		b.desc.checkDefaultFunc(uint16Type)
 	}
@@ -1577,19 +1577,19 @@ func (b *uint16Builder) Descriptor() *Descriptor {
 	return b.desc
 }
 
-// uint32Builder is the builder for uint32 field.
-type uint32Builder struct {
+// Uint32Builder is the builder for uint32 field.
+type Uint32Builder struct {
 	desc *Descriptor
 }
 
 // Unique makes the field unique within all vertices of this type.
-func (b *uint32Builder) Unique() *uint32Builder {
+func (b *Uint32Builder) Unique() *Uint32Builder {
 	b.desc.Unique = true
 	return b
 }
 
 // Range adds a range validator for this field where the given value needs to be in the range of [i, j].
-func (b *uint32Builder) Range(i, j uint32) *uint32Builder {
+func (b *Uint32Builder) Range(i, j uint32) *Uint32Builder {
 	b.desc.Validators = append(b.desc.Validators, func(v uint32) error {
 		if v < i || v > j {
 			return errors.New("value out of range")
@@ -1600,7 +1600,7 @@ func (b *uint32Builder) Range(i, j uint32) *uint32Builder {
 }
 
 // Min adds a minimum value validator for this field. Operation fails if the validator fails.
-func (b *uint32Builder) Min(i uint32) *uint32Builder {
+func (b *Uint32Builder) Min(i uint32) *Uint32Builder {
 	b.desc.Validators = append(b.desc.Validators, func(v uint32) error {
 		if v < i {
 			return errors.New("value out of range")
@@ -1611,7 +1611,7 @@ func (b *uint32Builder) Min(i uint32) *uint32Builder {
 }
 
 // Max adds a maximum value validator for this field. Operation fails if the validator fails.
-func (b *uint32Builder) Max(i uint32) *uint32Builder {
+func (b *Uint32Builder) Max(i uint32) *Uint32Builder {
 	b.desc.Validators = append(b.desc.Validators, func(v uint32) error {
 		if v > i {
 			return errors.New("value out of range")
@@ -1622,19 +1622,19 @@ func (b *uint32Builder) Max(i uint32) *uint32Builder {
 }
 
 // Positive adds a minimum value validator with the value of 1. Operation fails if the validator fails.
-func (b *uint32Builder) Positive() *uint32Builder {
+func (b *Uint32Builder) Positive() *Uint32Builder {
 	return b.Min(1)
 }
 
 // Default sets the default value of the field.
-func (b *uint32Builder) Default(i uint32) *uint32Builder {
+func (b *Uint32Builder) Default(i uint32) *Uint32Builder {
 	b.desc.Default = i
 	return b
 }
 
 // DefaultFunc sets the function that is applied to set the default value
 // of the field on creation.
-func (b *uint32Builder) DefaultFunc(fn any) *uint32Builder {
+func (b *Uint32Builder) DefaultFunc(fn any) *Uint32Builder {
 	b.desc.Default = fn
 	return b
 }
@@ -1645,52 +1645,52 @@ func (b *uint32Builder) DefaultFunc(fn any) *uint32Builder {
 //	field.Uint32("uint32").
 //		Default(0).
 //		UpdateDefault(GenNumber),
-func (b *uint32Builder) UpdateDefault(fn any) *uint32Builder {
+func (b *Uint32Builder) UpdateDefault(fn any) *Uint32Builder {
 	b.desc.UpdateDefault = fn
 	return b
 }
 
 // Nillable indicates that this field is a nillable.
 // Unlike "Optional" only fields, "Nillable" fields are pointers in the generated struct.
-func (b *uint32Builder) Nillable() *uint32Builder {
+func (b *Uint32Builder) Nillable() *Uint32Builder {
 	b.desc.Nillable = true
 	return b
 }
 
 // Comment sets the comment of the field.
-func (b *uint32Builder) Comment(c string) *uint32Builder {
+func (b *Uint32Builder) Comment(c string) *Uint32Builder {
 	b.desc.Comment = c
 	return b
 }
 
 // Optional indicates that this field is optional on create.
 // Unlike edges, fields are required by default.
-func (b *uint32Builder) Optional() *uint32Builder {
+func (b *Uint32Builder) Optional() *Uint32Builder {
 	b.desc.Optional = true
 	return b
 }
 
 // Immutable indicates that this field cannot be updated.
-func (b *uint32Builder) Immutable() *uint32Builder {
+func (b *Uint32Builder) Immutable() *Uint32Builder {
 	b.desc.Immutable = true
 	return b
 }
 
 // StructTag sets the struct tag of the field.
-func (b *uint32Builder) StructTag(s string) *uint32Builder {
+func (b *Uint32Builder) StructTag(s string) *Uint32Builder {
 	b.desc.Tag = s
 	return b
 }
 
 // Validate adds a validator for this field. Operation fails if the validation fails.
-func (b *uint32Builder) Validate(fn func(uint32) error) *uint32Builder {
+func (b *Uint32Builder) Validate(fn func(uint32) error) *Uint32Builder {
 	b.desc.Validators = append(b.desc.Validators, fn)
 	return b
 }
 
 // StorageKey sets the storage key of the field.
 // In SQL dialects is the column name and Gremlin is the property.
-func (b *uint32Builder) StorageKey(key string) *uint32Builder {
+func (b *Uint32Builder) StorageKey(key string) *Uint32Builder {
 	b.desc.StorageKey = key
 	return b
 }
@@ -1702,7 +1702,7 @@ func (b *uint32Builder) StorageKey(key string) *uint32Builder {
 //		SchemaType(map[string]string{
 //			dialect.Postgres: "CustomType",
 //		})
-func (b *uint32Builder) SchemaType(types map[string]string) *uint32Builder {
+func (b *Uint32Builder) SchemaType(types map[string]string) *Uint32Builder {
 	b.desc.SchemaType = types
 	return b
 }
@@ -1722,7 +1722,7 @@ func (b *uint32Builder) SchemaType(types map[string]string) *uint32Builder {
 //	func(t1 T) Add(t2 T) T {
 //		return add(t1, t2)
 //	}
-func (b *uint32Builder) GoType(typ any) *uint32Builder {
+func (b *Uint32Builder) GoType(typ any) *Uint32Builder {
 	b.desc.goType(typ)
 	return b
 }
@@ -1730,7 +1730,7 @@ func (b *uint32Builder) GoType(typ any) *uint32Builder {
 // ValueScanner provides an external value scanner for the given GoType.
 // Using this option allow users to use field types that do not implement
 // the sql.Scanner and driver.Valuer interfaces.
-func (b *uint32Builder) ValueScanner(vs any) *uint32Builder {
+func (b *Uint32Builder) ValueScanner(vs any) *Uint32Builder {
 	b.desc.ValueScanner = vs
 	return b
 }
@@ -1740,13 +1740,13 @@ func (b *uint32Builder) ValueScanner(vs any) *uint32Builder {
 //
 //	field.Uint32("uint32").
 //		Annotations(entgql.OrderField("UINT32"))
-func (b *uint32Builder) Annotations(annotations ...schema.Annotation) *uint32Builder {
+func (b *Uint32Builder) Annotations(annotations ...schema.Annotation) *Uint32Builder {
 	b.desc.Annotations = append(b.desc.Annotations, annotations...)
 	return b
 }
 
 // Descriptor implements the ent.Field interface by returning its descriptor.
-func (b *uint32Builder) Descriptor() *Descriptor {
+func (b *Uint32Builder) Descriptor() *Descriptor {
 	if b.desc.Default != nil || b.desc.UpdateDefault != nil {
 		b.desc.checkDefaultFunc(uint32Type)
 	}
@@ -1754,19 +1754,19 @@ func (b *uint32Builder) Descriptor() *Descriptor {
 	return b.desc
 }
 
-// uint64Builder is the builder for uint64 field.
-type uint64Builder struct {
+// Uint64Builder is the builder for uint64 field.
+type Uint64Builder struct {
 	desc *Descriptor
 }
 
 // Unique makes the field unique within all vertices of this type.
-func (b *uint64Builder) Unique() *uint64Builder {
+func (b *Uint64Builder) Unique() *Uint64Builder {
 	b.desc.Unique = true
 	return b
 }
 
 // Range adds a range validator for this field where the given value needs to be in the range of [i, j].
-func (b *uint64Builder) Range(i, j uint64) *uint64Builder {
+func (b *Uint64Builder) Range(i, j uint64) *Uint64Builder {
 	b.desc.Validators = append(b.desc.Validators, func(v uint64) error {
 		if v < i || v > j {
 			return errors.New("value out of range")
@@ -1777,7 +1777,7 @@ func (b *uint64Builder) Range(i, j uint64) *uint64Builder {
 }
 
 // Min adds a minimum value validator for this field. Operation fails if the validator fails.
-func (b *uint64Builder) Min(i uint64) *uint64Builder {
+func (b *Uint64Builder) Min(i uint64) *Uint64Builder {
 	b.desc.Validators = append(b.desc.Validators, func(v uint64) error {
 		if v < i {
 			return errors.New("value out of range")
@@ -1788,7 +1788,7 @@ func (b *uint64Builder) Min(i uint64) *uint64Builder {
 }
 
 // Max adds a maximum value validator for this field. Operation fails if the validator fails.
-func (b *uint64Builder) Max(i uint64) *uint64Builder {
+func (b *Uint64Builder) Max(i uint64) *Uint64Builder {
 	b.desc.Validators = append(b.desc.Validators, func(v uint64) error {
 		if v > i {
 			return errors.New("value out of range")
@@ -1799,19 +1799,19 @@ func (b *uint64Builder) Max(i uint64) *uint64Builder {
 }
 
 // Positive adds a minimum value validator with the value of 1. Operation fails if the validator fails.
-func (b *uint64Builder) Positive() *uint64Builder {
+func (b *Uint64Builder) Positive() *Uint64Builder {
 	return b.Min(1)
 }
 
 // Default sets the default value of the field.
-func (b *uint64Builder) Default(i uint64) *uint64Builder {
+func (b *Uint64Builder) Default(i uint64) *Uint64Builder {
 	b.desc.Default = i
 	return b
 }
 
 // DefaultFunc sets the function that is applied to set the default value
 // of the field on creation.
-func (b *uint64Builder) DefaultFunc(fn any) *uint64Builder {
+func (b *Uint64Builder) DefaultFunc(fn any) *Uint64Builder {
 	b.desc.Default = fn
 	return b
 }
@@ -1822,52 +1822,52 @@ func (b *uint64Builder) DefaultFunc(fn any) *uint64Builder {
 //	field.Uint64("uint64").
 //		Default(0).
 //		UpdateDefault(GenNumber),
-func (b *uint64Builder) UpdateDefault(fn any) *uint64Builder {
+func (b *Uint64Builder) UpdateDefault(fn any) *Uint64Builder {
 	b.desc.UpdateDefault = fn
 	return b
 }
 
 // Nillable indicates that this field is a nillable.
 // Unlike "Optional" only fields, "Nillable" fields are pointers in the generated struct.
-func (b *uint64Builder) Nillable() *uint64Builder {
+func (b *Uint64Builder) Nillable() *Uint64Builder {
 	b.desc.Nillable = true
 	return b
 }
 
 // Comment sets the comment of the field.
-func (b *uint64Builder) Comment(c string) *uint64Builder {
+func (b *Uint64Builder) Comment(c string) *Uint64Builder {
 	b.desc.Comment = c
 	return b
 }
 
 // Optional indicates that this field is optional on create.
 // Unlike edges, fields are required by default.
-func (b *uint64Builder) Optional() *uint64Builder {
+func (b *Uint64Builder) Optional() *Uint64Builder {
 	b.desc.Optional = true
 	return b
 }
 
 // Immutable indicates that this field cannot be updated.
-func (b *uint64Builder) Immutable() *uint64Builder {
+func (b *Uint64Builder) Immutable() *Uint64Builder {
 	b.desc.Immutable = true
 	return b
 }
 
 // StructTag sets the struct tag of the field.
-func (b *uint64Builder) StructTag(s string) *uint64Builder {
+func (b *Uint64Builder) StructTag(s string) *Uint64Builder {
 	b.desc.Tag = s
 	return b
 }
 
 // Validate adds a validator for this field. Operation fails if the validation fails.
-func (b *uint64Builder) Validate(fn func(uint64) error) *uint64Builder {
+func (b *Uint64Builder) Validate(fn func(uint64) error) *Uint64Builder {
 	b.desc.Validators = append(b.desc.Validators, fn)
 	return b
 }
 
 // StorageKey sets the storage key of the field.
 // In SQL dialects is the column name and Gremlin is the property.
-func (b *uint64Builder) StorageKey(key string) *uint64Builder {
+func (b *Uint64Builder) StorageKey(key string) *Uint64Builder {
 	b.desc.StorageKey = key
 	return b
 }
@@ -1879,7 +1879,7 @@ func (b *uint64Builder) StorageKey(key string) *uint64Builder {
 //		SchemaType(map[string]string{
 //			dialect.Postgres: "CustomType",
 //		})
-func (b *uint64Builder) SchemaType(types map[string]string) *uint64Builder {
+func (b *Uint64Builder) SchemaType(types map[string]string) *Uint64Builder {
 	b.desc.SchemaType = types
 	return b
 }
@@ -1899,7 +1899,7 @@ func (b *uint64Builder) SchemaType(types map[string]string) *uint64Builder {
 //	func(t1 T) Add(t2 T) T {
 //		return add(t1, t2)
 //	}
-func (b *uint64Builder) GoType(typ any) *uint64Builder {
+func (b *Uint64Builder) GoType(typ any) *Uint64Builder {
 	b.desc.goType(typ)
 	return b
 }
@@ -1907,7 +1907,7 @@ func (b *uint64Builder) GoType(typ any) *uint64Builder {
 // ValueScanner provides an external value scanner for the given GoType.
 // Using this option allow users to use field types that do not implement
 // the sql.Scanner and driver.Valuer interfaces.
-func (b *uint64Builder) ValueScanner(vs any) *uint64Builder {
+func (b *Uint64Builder) ValueScanner(vs any) *Uint64Builder {
 	b.desc.ValueScanner = vs
 	return b
 }
@@ -1917,13 +1917,13 @@ func (b *uint64Builder) ValueScanner(vs any) *uint64Builder {
 //
 //	field.Uint64("uint64").
 //		Annotations(entgql.OrderField("UINT64"))
-func (b *uint64Builder) Annotations(annotations ...schema.Annotation) *uint64Builder {
+func (b *Uint64Builder) Annotations(annotations ...schema.Annotation) *Uint64Builder {
 	b.desc.Annotations = append(b.desc.Annotations, annotations...)
 	return b
 }
 
 // Descriptor implements the ent.Field interface by returning its descriptor.
-func (b *uint64Builder) Descriptor() *Descriptor {
+func (b *Uint64Builder) Descriptor() *Descriptor {
 	if b.desc.Default != nil || b.desc.UpdateDefault != nil {
 		b.desc.checkDefaultFunc(uint64Type)
 	}
@@ -1944,19 +1944,19 @@ var (
 	uint64Type = reflect.TypeOf(uint64(0))
 )
 
-// float64Builder is the builder for float fields.
-type float64Builder struct {
+// Float64Builder is the builder for float fields.
+type Float64Builder struct {
 	desc *Descriptor
 }
 
 // Unique makes the field unique within all vertices of this type.
-func (b *float64Builder) Unique() *float64Builder {
+func (b *Float64Builder) Unique() *Float64Builder {
 	b.desc.Unique = true
 	return b
 }
 
 // Range adds a range validator for this field where the given value needs to be in the range of [i, j].
-func (b *float64Builder) Range(i, j float64) *float64Builder {
+func (b *Float64Builder) Range(i, j float64) *Float64Builder {
 	b.desc.Validators = append(b.desc.Validators, func(v float64) error {
 		if v < i || v > j {
 			return errors.New("value out of range")
@@ -1967,7 +1967,7 @@ func (b *float64Builder) Range(i, j float64) *float64Builder {
 }
 
 // Min adds a minimum value validator for this field. Operation fails if the validator fails.
-func (b *float64Builder) Min(i float64) *float64Builder {
+func (b *Float64Builder) Min(i float64) *Float64Builder {
 	b.desc.Validators = append(b.desc.Validators, func(v float64) error {
 		if v < i {
 			return errors.New("value out of range")
@@ -1978,7 +1978,7 @@ func (b *float64Builder) Min(i float64) *float64Builder {
 }
 
 // Max adds a maximum value validator for this field. Operation fails if the validator fails.
-func (b *float64Builder) Max(i float64) *float64Builder {
+func (b *Float64Builder) Max(i float64) *Float64Builder {
 	b.desc.Validators = append(b.desc.Validators, func(v float64) error {
 		if v > i {
 			return errors.New("value out of range")
@@ -1989,62 +1989,62 @@ func (b *float64Builder) Max(i float64) *float64Builder {
 }
 
 // Positive adds a minimum value validator with the value of 0.000001. Operation fails if the validator fails.
-func (b *float64Builder) Positive() *float64Builder {
+func (b *Float64Builder) Positive() *Float64Builder {
 	return b.Min(1e-06)
 }
 
 // Negative adds a maximum value validator with the value of -0.000001. Operation fails if the validator fails.
-func (b *float64Builder) Negative() *float64Builder {
+func (b *Float64Builder) Negative() *Float64Builder {
 	return b.Max(-1e-06)
 }
 
 // Default sets the default value of the field.
-func (b *float64Builder) Default(i float64) *float64Builder {
+func (b *Float64Builder) Default(i float64) *Float64Builder {
 	b.desc.Default = i
 	return b
 }
 
 // Nillable indicates that this field is a nillable.
 // Unlike "Optional" only fields, "Nillable" fields are pointers in the generated struct.
-func (b *float64Builder) Nillable() *float64Builder {
+func (b *Float64Builder) Nillable() *Float64Builder {
 	b.desc.Nillable = true
 	return b
 }
 
 // Comment sets the comment of the field.
-func (b *float64Builder) Comment(c string) *float64Builder {
+func (b *Float64Builder) Comment(c string) *Float64Builder {
 	b.desc.Comment = c
 	return b
 }
 
 // Optional indicates that this field is optional on create.
 // Unlike edges, fields are required by default.
-func (b *float64Builder) Optional() *float64Builder {
+func (b *Float64Builder) Optional() *Float64Builder {
 	b.desc.Optional = true
 	return b
 }
 
 // Immutable indicates that this field cannot be updated.
-func (b *float64Builder) Immutable() *float64Builder {
+func (b *Float64Builder) Immutable() *Float64Builder {
 	b.desc.Immutable = true
 	return b
 }
 
 // StructTag sets the struct tag of the field.
-func (b *float64Builder) StructTag(s string) *float64Builder {
+func (b *Float64Builder) StructTag(s string) *Float64Builder {
 	b.desc.Tag = s
 	return b
 }
 
 // Validate adds a validator for this field. Operation fails if the validation fails.
-func (b *float64Builder) Validate(fn func(float64) error) *float64Builder {
+func (b *Float64Builder) Validate(fn func(float64) error) *Float64Builder {
 	b.desc.Validators = append(b.desc.Validators, fn)
 	return b
 }
 
 // StorageKey sets the storage key of the field.
 // In SQL dialects is the column name and Gremlin is the property.
-func (b *float64Builder) StorageKey(key string) *float64Builder {
+func (b *Float64Builder) StorageKey(key string) *Float64Builder {
 	b.desc.StorageKey = key
 	return b
 }
@@ -2057,7 +2057,7 @@ func (b *float64Builder) StorageKey(key string) *float64Builder {
 //			dialect.MySQL:		"decimal(5, 2)",
 //			dialect.Postgres: 	"numeric(5, 2)",
 //		})
-func (b *float64Builder) SchemaType(types map[string]string) *float64Builder {
+func (b *Float64Builder) SchemaType(types map[string]string) *Float64Builder {
 	b.desc.SchemaType = types
 	return b
 }
@@ -2077,7 +2077,7 @@ func (b *float64Builder) SchemaType(types map[string]string) *float64Builder {
 //	func(t1 T) Add(t2 T) T {
 //		return add(t1, t2)
 //	}
-func (b *float64Builder) GoType(typ any) *float64Builder {
+func (b *Float64Builder) GoType(typ any) *Float64Builder {
 	b.desc.goType(typ)
 	return b
 }
@@ -2085,7 +2085,7 @@ func (b *float64Builder) GoType(typ any) *float64Builder {
 // ValueScanner provides an external value scanner for the given GoType.
 // Using this option allow users to use field types that do not implement
 // the sql.Scanner and driver.Valuer interfaces.
-func (b *float64Builder) ValueScanner(vs any) *float64Builder {
+func (b *Float64Builder) ValueScanner(vs any) *Float64Builder {
 	b.desc.ValueScanner = vs
 	return b
 }
@@ -2095,30 +2095,30 @@ func (b *float64Builder) ValueScanner(vs any) *float64Builder {
 //
 //	field.Float64("float64").
 //		Annotations(entgql.OrderField("FLOAT64"))
-func (b *float64Builder) Annotations(annotations ...schema.Annotation) *float64Builder {
+func (b *Float64Builder) Annotations(annotations ...schema.Annotation) *Float64Builder {
 	b.desc.Annotations = append(b.desc.Annotations, annotations...)
 	return b
 }
 
 // Descriptor implements the ent.Field interface by returning its descriptor.
-func (b *float64Builder) Descriptor() *Descriptor {
+func (b *Float64Builder) Descriptor() *Descriptor {
 	b.desc.checkGoType(float64Type)
 	return b.desc
 }
 
-// float32Builder is the builder for float fields.
-type float32Builder struct {
+// Float32Builder is the builder for float fields.
+type Float32Builder struct {
 	desc *Descriptor
 }
 
 // Unique makes the field unique within all vertices of this type.
-func (b *float32Builder) Unique() *float32Builder {
+func (b *Float32Builder) Unique() *Float32Builder {
 	b.desc.Unique = true
 	return b
 }
 
 // Range adds a range validator for this field where the given value needs to be in the range of [i, j].
-func (b *float32Builder) Range(i, j float32) *float32Builder {
+func (b *Float32Builder) Range(i, j float32) *Float32Builder {
 	b.desc.Validators = append(b.desc.Validators, func(v float32) error {
 		if v < i || v > j {
 			return errors.New("value out of range")
@@ -2129,7 +2129,7 @@ func (b *float32Builder) Range(i, j float32) *float32Builder {
 }
 
 // Min adds a minimum value validator for this field. Operation fails if the validator fails.
-func (b *float32Builder) Min(i float32) *float32Builder {
+func (b *Float32Builder) Min(i float32) *Float32Builder {
 	b.desc.Validators = append(b.desc.Validators, func(v float32) error {
 		if v < i {
 			return errors.New("value out of range")
@@ -2140,7 +2140,7 @@ func (b *float32Builder) Min(i float32) *float32Builder {
 }
 
 // Max adds a maximum value validator for this field. Operation fails if the validator fails.
-func (b *float32Builder) Max(i float32) *float32Builder {
+func (b *Float32Builder) Max(i float32) *Float32Builder {
 	b.desc.Validators = append(b.desc.Validators, func(v float32) error {
 		if v > i {
 			return errors.New("value out of range")
@@ -2151,62 +2151,62 @@ func (b *float32Builder) Max(i float32) *float32Builder {
 }
 
 // Positive adds a minimum value validator with the value of 0.000001. Operation fails if the validator fails.
-func (b *float32Builder) Positive() *float32Builder {
+func (b *Float32Builder) Positive() *Float32Builder {
 	return b.Min(1e-06)
 }
 
 // Negative adds a maximum value validator with the value of -0.000001. Operation fails if the validator fails.
-func (b *float32Builder) Negative() *float32Builder {
+func (b *Float32Builder) Negative() *Float32Builder {
 	return b.Max(-1e-06)
 }
 
 // Default sets the default value of the field.
-func (b *float32Builder) Default(i float32) *float32Builder {
+func (b *Float32Builder) Default(i float32) *Float32Builder {
 	b.desc.Default = i
 	return b
 }
 
 // Nillable indicates that this field is a nillable.
 // Unlike "Optional" only fields, "Nillable" fields are pointers in the generated struct.
-func (b *float32Builder) Nillable() *float32Builder {
+func (b *Float32Builder) Nillable() *Float32Builder {
 	b.desc.Nillable = true
 	return b
 }
 
 // Comment sets the comment of the field.
-func (b *float32Builder) Comment(c string) *float32Builder {
+func (b *Float32Builder) Comment(c string) *Float32Builder {
 	b.desc.Comment = c
 	return b
 }
 
 // Optional indicates that this field is optional on create.
 // Unlike edges, fields are required by default.
-func (b *float32Builder) Optional() *float32Builder {
+func (b *Float32Builder) Optional() *Float32Builder {
 	b.desc.Optional = true
 	return b
 }
 
 // Immutable indicates that this field cannot be updated.
-func (b *float32Builder) Immutable() *float32Builder {
+func (b *Float32Builder) Immutable() *Float32Builder {
 	b.desc.Immutable = true
 	return b
 }
 
 // StructTag sets the struct tag of the field.
-func (b *float32Builder) StructTag(s string) *float32Builder {
+func (b *Float32Builder) StructTag(s string) *Float32Builder {
 	b.desc.Tag = s
 	return b
 }
 
 // Validate adds a validator for this field. Operation fails if the validation fails.
-func (b *float32Builder) Validate(fn func(float32) error) *float32Builder {
+func (b *Float32Builder) Validate(fn func(float32) error) *Float32Builder {
 	b.desc.Validators = append(b.desc.Validators, fn)
 	return b
 }
 
 // StorageKey sets the storage key of the field.
 // In SQL dialects is the column name and Gremlin is the property.
-func (b *float32Builder) StorageKey(key string) *float32Builder {
+func (b *Float32Builder) StorageKey(key string) *Float32Builder {
 	b.desc.StorageKey = key
 	return b
 }
@@ -2219,7 +2219,7 @@ func (b *float32Builder) StorageKey(key string) *float32Builder {
 //			dialect.MySQL:		"decimal(5, 2)",
 //			dialect.Postgres: 	"numeric(5, 2)",
 //		})
-func (b *float32Builder) SchemaType(types map[string]string) *float32Builder {
+func (b *Float32Builder) SchemaType(types map[string]string) *Float32Builder {
 	b.desc.SchemaType = types
 	return b
 }
@@ -2239,7 +2239,7 @@ func (b *float32Builder) SchemaType(types map[string]string) *float32Builder {
 //	func(t1 T) Add(t2 T) T {
 //		return add(t1, t2)
 //	}
-func (b *float32Builder) GoType(typ any) *float32Builder {
+func (b *Float32Builder) GoType(typ any) *Float32Builder {
 	b.desc.goType(typ)
 	return b
 }
@@ -2247,7 +2247,7 @@ func (b *float32Builder) GoType(typ any) *float32Builder {
 // ValueScanner provides an external value scanner for the given GoType.
 // Using this option allow users to use field types that do not implement
 // the sql.Scanner and driver.Valuer interfaces.
-func (b *float32Builder) ValueScanner(vs any) *float32Builder {
+func (b *Float32Builder) ValueScanner(vs any) *Float32Builder {
 	b.desc.ValueScanner = vs
 	return b
 }
@@ -2257,13 +2257,13 @@ func (b *float32Builder) ValueScanner(vs any) *float32Builder {
 //
 //	field.Float32("float32").
 //		Annotations(entgql.OrderField("FLOAT32"))
-func (b *float32Builder) Annotations(annotations ...schema.Annotation) *float32Builder {
+func (b *Float32Builder) Annotations(annotations ...schema.Annotation) *Float32Builder {
 	b.desc.Annotations = append(b.desc.Annotations, annotations...)
 	return b
 }
 
 // Descriptor implements the ent.Field interface by returning its descriptor.
-func (b *float32Builder) Descriptor() *Descriptor {
+func (b *Float32Builder) Descriptor() *Descriptor {
 	b.desc.checkGoType(float32Type)
 	return b.desc
 }


### PR DESCRIPTION
Allows to create **field templates** as mentioned here https://github.com/ent/ent/issues/1381:
- fields can be defined in a much cleaner, consistent and flexible way
- simplifies to comply with company wide schema policies
- allows to create tests against complex field definitions once


A function like
```go
func PrimaryNanoID(fieldname string, prefix prefixes.Prefix) *field.StringBuilder {
	fieldname = strings.ToLower(prefix)

	return field.String("id").
		StorageKey(fieldname).
		GoType(nanoid.NanoID("")).
		DefaultFunc(prefix.NewNanoID).
		Match(regexp.MustCompile("^" + string(prefix) + "_[A-Za-z0-9]{19,25}$")).
		NotEmpty().
		Immutable().
                Annotations(
	        	entsql.Checks(map[string]string{
		        	fmt.Sprintf(`%v_valid_key`, fieldname):        fmt.Sprintf(`(%v ~ '^%v_[A-Za-z0-9]*$')`, fieldname, string(prefix)),
			       fmt.Sprintf(`%v_non_empty_string`, fieldname): fmt.Sprintf(`(utils.null_or_non_empty_trimmed_string(%v))`, fieldname),
	      }),
	)
}

```

makes it possible to reduce the field definition on each schema to one line (and remains expandable). E.g.
```go
customfield.PrimaryNanoID(prefixes.FileID).Comment("This is the primary key")
```


