### PR TITLE
entc/gen: alias user-provided imports when they conflict with internal imports

### DIFF
--- a/entc/gen/func.go
+++ b/entc/gen/func.go
@@ -413,9 +413,10 @@ func hasField(v any, name string) bool {
 }
 
 // hasImport reports if the package name exists in the predefined import packages.
-func hasImport(name string) bool {
-	_, ok := importPkg[name]
-	return ok
+func hasImport(path string) bool {
+	name := filepath.Base(path)
+	existingPath, ok := importPkg[name]
+	return ok && path == existingPath
 }
 
 // trimPackage trims the package name from the given identifier.

--- a/entc/gen/template/import.tmpl
+++ b/entc/gen/template/import.tmpl
@@ -49,7 +49,7 @@ import (
 	{{- $fields := $.Fields }}{{ if $.HasOneFieldID }}{{ if $.ID.UserDefined }}{{ $fields = append $fields $.ID }}{{ end }}{{ end }}
 	{{- range $f := $fields }}
 		{{- $pkg := $f.Type.PkgPath }}
-		{{- if and $pkg (not (hasImport (base $pkg))) (not (hasKey $seen $pkg)) }}
+		{{- if and $pkg (not (hasImport $pkg)) (not (hasKey $seen $pkg)) }}
 			{{- $name := $f.Type.PkgName }}
 			{{ if ne $name (base $pkg) }}{{ $name }} {{ end}}"{{ $pkg }}"
 			{{- $seen = set $seen $pkg true }}

--- a/entc/integration/json/ent/migrate/schema.go
+++ b/entc/integration/json/ent/migrate/schema.go
@@ -24,6 +24,7 @@ var (
 		{Name: "floats", Type: field.TypeJSON, Nullable: true},
 		{Name: "strings", Type: field.TypeJSON, Nullable: true},
 		{Name: "addr", Type: field.TypeJSON, Nullable: true},
+		{Name: "test_field", Type: field.TypeJSON, Nullable: true},
 		{Name: "unknown", Type: field.TypeJSON, Nullable: true},
 	}
 	// UsersTable holds the schema information for the "users" table.

--- a/entc/integration/json/ent/mutation.go
+++ b/entc/integration/json/ent/mutation.go
@@ -20,6 +20,7 @@ import (
 	"entgo.io/ent/entc/integration/json/ent/predicate"
 	"entgo.io/ent/entc/integration/json/ent/schema"
 	"entgo.io/ent/entc/integration/json/ent/user"
+	extfield "entgo.io/ent/entc/integration/json/field"
 )
 
 const (
@@ -55,6 +56,7 @@ type UserMutation struct {
 	strings       *[]string
 	appendstrings []string
 	addr          *schema.Addr
+	testField     *extfield.TestField
 	unknown       *any
 	clearedFields map[string]struct{}
 	done          bool
@@ -683,6 +685,55 @@ func (m *UserMutation) ResetAddr() {
 	delete(m.clearedFields, user.FieldAddr)
 }
 
+// SetTestField sets the "testField" field.
+func (m *UserMutation) SetTestField(ef extfield.TestField) {
+	m.testField = &ef
+}
+
+// TestField returns the value of the "testField" field in the mutation.
+func (m *UserMutation) TestField() (r extfield.TestField, exists bool) {
+	v := m.testField
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldTestField returns the old "testField" field's value of the User entity.
+// If the User object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *UserMutation) OldTestField(ctx context.Context) (v extfield.TestField, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldTestField is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldTestField requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldTestField: %w", err)
+	}
+	return oldValue.TestField, nil
+}
+
+// ClearTestField clears the value of the "testField" field.
+func (m *UserMutation) ClearTestField() {
+	m.testField = nil
+	m.clearedFields[user.FieldTestField] = struct{}{}
+}
+
+// TestFieldCleared returns if the "testField" field was cleared in this mutation.
+func (m *UserMutation) TestFieldCleared() bool {
+	_, ok := m.clearedFields[user.FieldTestField]
+	return ok
+}
+
+// ResetTestField resets all changes to the "testField" field.
+func (m *UserMutation) ResetTestField() {
+	m.testField = nil
+	delete(m.clearedFields, user.FieldTestField)
+}
+
 // SetUnknown sets the "unknown" field.
 func (m *UserMutation) SetUnknown(a any) {
 	m.unknown = &a
@@ -766,7 +817,7 @@ func (m *UserMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *UserMutation) Fields() []string {
-	fields := make([]string, 0, 10)
+	fields := make([]string, 0, 11)
 	if m.t != nil {
 		fields = append(fields, user.FieldT)
 	}
@@ -793,6 +844,9 @@ func (m *UserMutation) Fields() []string {
 	}
 	if m.addr != nil {
 		fields = append(fields, user.FieldAddr)
+	}
+	if m.testField != nil {
+		fields = append(fields, user.FieldTestField)
 	}
 	if m.unknown != nil {
 		fields = append(fields, user.FieldUnknown)
@@ -823,6 +877,8 @@ func (m *UserMutation) Field(name string) (ent.Value, bool) {
 		return m.Strings()
 	case user.FieldAddr:
 		return m.Addr()
+	case user.FieldTestField:
+		return m.TestField()
 	case user.FieldUnknown:
 		return m.Unknown()
 	}
@@ -852,6 +908,8 @@ func (m *UserMutation) OldField(ctx context.Context, name string) (ent.Value, er
 		return m.OldStrings(ctx)
 	case user.FieldAddr:
 		return m.OldAddr(ctx)
+	case user.FieldTestField:
+		return m.OldTestField(ctx)
 	case user.FieldUnknown:
 		return m.OldUnknown(ctx)
 	}
@@ -926,6 +984,13 @@ func (m *UserMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetAddr(v)
 		return nil
+	case user.FieldTestField:
+		v, ok := value.(extfield.TestField)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetTestField(v)
+		return nil
 	case user.FieldUnknown:
 		v, ok := value.(any)
 		if !ok {
@@ -987,6 +1052,9 @@ func (m *UserMutation) ClearedFields() []string {
 	if m.FieldCleared(user.FieldAddr) {
 		fields = append(fields, user.FieldAddr)
 	}
+	if m.FieldCleared(user.FieldTestField) {
+		fields = append(fields, user.FieldTestField)
+	}
 	if m.FieldCleared(user.FieldUnknown) {
 		fields = append(fields, user.FieldUnknown)
 	}
@@ -1028,6 +1096,9 @@ func (m *UserMutation) ClearField(name string) error {
 	case user.FieldAddr:
 		m.ClearAddr()
 		return nil
+	case user.FieldTestField:
+		m.ClearTestField()
+		return nil
 	case user.FieldUnknown:
 		m.ClearUnknown()
 		return nil
@@ -1065,6 +1136,9 @@ func (m *UserMutation) ResetField(name string) error {
 		return nil
 	case user.FieldAddr:
 		m.ResetAddr()
+		return nil
+	case user.FieldTestField:
+		m.ResetTestField()
 		return nil
 	case user.FieldUnknown:
 		m.ResetUnknown()

--- a/entc/integration/json/ent/schema/user.go
+++ b/entc/integration/json/ent/schema/user.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 
 	"entgo.io/ent"
+	f "entgo.io/ent/entc/integration/json/field"
 	"entgo.io/ent/schema/field"
 )
 
@@ -47,6 +48,8 @@ func (User) Fields() []ent.Field {
 			Optional(),
 		field.JSON("addr", Addr{}).
 			Sensitive().
+			Optional(),
+		field.JSON("testField", f.TestField{}).
 			Optional(),
 		field.Any("unknown").
 			Optional(),

--- a/entc/integration/json/ent/user.go
+++ b/entc/integration/json/ent/user.go
@@ -17,6 +17,7 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/entc/integration/json/ent/schema"
 	"entgo.io/ent/entc/integration/json/ent/user"
+	extfield "entgo.io/ent/entc/integration/json/field"
 )
 
 // User is the model entity for the User schema.
@@ -42,6 +43,8 @@ type User struct {
 	Strings []string `json:"strings,omitempty"`
 	// Addr holds the value of the "addr" field.
 	Addr schema.Addr `json:"-"`
+	// TestField holds the value of the "testField" field.
+	TestField extfield.TestField `json:"testField,omitempty"`
 	// Unknown holds the value of the "unknown" field.
 	Unknown      any `json:"unknown,omitempty"`
 	selectValues sql.SelectValues
@@ -52,7 +55,7 @@ func (*User) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case user.FieldT, user.FieldURL, user.FieldURLs, user.FieldRaw, user.FieldDirs, user.FieldInts, user.FieldFloats, user.FieldStrings, user.FieldAddr, user.FieldUnknown:
+		case user.FieldT, user.FieldURL, user.FieldURLs, user.FieldRaw, user.FieldDirs, user.FieldInts, user.FieldFloats, user.FieldStrings, user.FieldAddr, user.FieldTestField, user.FieldUnknown:
 			values[i] = new([]byte)
 		case user.FieldID:
 			values[i] = new(sql.NullInt64)
@@ -149,6 +152,14 @@ func (u *User) assignValues(columns []string, values []any) error {
 					return fmt.Errorf("unmarshal field addr: %w", err)
 				}
 			}
+		case user.FieldTestField:
+			if value, ok := values[i].(*[]byte); !ok {
+				return fmt.Errorf("unexpected type %T for field testField", values[i])
+			} else if value != nil && len(*value) > 0 {
+				if err := json.Unmarshal(*value, &u.TestField); err != nil {
+					return fmt.Errorf("unmarshal field testField: %w", err)
+				}
+			}
 		case user.FieldUnknown:
 			if value, ok := values[i].(*[]byte); !ok {
 				return fmt.Errorf("unexpected type %T for field unknown", values[i])
@@ -218,6 +229,9 @@ func (u *User) String() string {
 	builder.WriteString(fmt.Sprintf("%v", u.Strings))
 	builder.WriteString(", ")
 	builder.WriteString("addr=<sensitive>")
+	builder.WriteString(", ")
+	builder.WriteString("testField=")
+	builder.WriteString(fmt.Sprintf("%v", u.TestField))
 	builder.WriteString(", ")
 	builder.WriteString("unknown=")
 	builder.WriteString(fmt.Sprintf("%v", u.Unknown))

--- a/entc/integration/json/ent/user/user.go
+++ b/entc/integration/json/ent/user/user.go
@@ -35,6 +35,8 @@ const (
 	FieldStrings = "strings"
 	// FieldAddr holds the string denoting the addr field in the database.
 	FieldAddr = "addr"
+	// FieldTestField holds the string denoting the testfield field in the database.
+	FieldTestField = "test_field"
 	// FieldUnknown holds the string denoting the unknown field in the database.
 	FieldUnknown = "unknown"
 	// Table holds the table name of the user in the database.
@@ -53,6 +55,7 @@ var Columns = []string{
 	FieldFloats,
 	FieldStrings,
 	FieldAddr,
+	FieldTestField,
 	FieldUnknown,
 }
 

--- a/entc/integration/json/ent/user/where.go
+++ b/entc/integration/json/ent/user/where.go
@@ -136,6 +136,16 @@ func AddrNotNil() predicate.User {
 	return predicate.User(sql.FieldNotNull(FieldAddr))
 }
 
+// TestFieldIsNil applies the IsNil predicate on the "testField" field.
+func TestFieldIsNil() predicate.User {
+	return predicate.User(sql.FieldIsNull(FieldTestField))
+}
+
+// TestFieldNotNil applies the NotNil predicate on the "testField" field.
+func TestFieldNotNil() predicate.User {
+	return predicate.User(sql.FieldNotNull(FieldTestField))
+}
+
 // UnknownIsNil applies the IsNil predicate on the "unknown" field.
 func UnknownIsNil() predicate.User {
 	return predicate.User(sql.FieldIsNull(FieldUnknown))

--- a/entc/integration/json/ent/user_create.go
+++ b/entc/integration/json/ent/user_create.go
@@ -17,6 +17,7 @@ import (
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/entc/integration/json/ent/schema"
 	"entgo.io/ent/entc/integration/json/ent/user"
+	extfield "entgo.io/ent/entc/integration/json/field"
 	"entgo.io/ent/schema/field"
 )
 
@@ -85,6 +86,20 @@ func (uc *UserCreate) SetAddr(s schema.Addr) *UserCreate {
 func (uc *UserCreate) SetNillableAddr(s *schema.Addr) *UserCreate {
 	if s != nil {
 		uc.SetAddr(*s)
+	}
+	return uc
+}
+
+// SetTestField sets the "testField" field.
+func (uc *UserCreate) SetTestField(ef extfield.TestField) *UserCreate {
+	uc.mutation.SetTestField(ef)
+	return uc
+}
+
+// SetNillableTestField sets the "testField" field if the given value is not nil.
+func (uc *UserCreate) SetNillableTestField(ef *extfield.TestField) *UserCreate {
+	if ef != nil {
+		uc.SetTestField(*ef)
 	}
 	return uc
 }
@@ -206,6 +221,10 @@ func (uc *UserCreate) createSpec() (*User, *sqlgraph.CreateSpec) {
 	if value, ok := uc.mutation.Addr(); ok {
 		_spec.SetField(user.FieldAddr, field.TypeJSON, value)
 		_node.Addr = value
+	}
+	if value, ok := uc.mutation.TestField(); ok {
+		_spec.SetField(user.FieldTestField, field.TypeJSON, value)
+		_node.TestField = value
 	}
 	if value, ok := uc.mutation.Unknown(); ok {
 		_spec.SetField(user.FieldUnknown, field.TypeJSON, value)

--- a/entc/integration/json/ent/user_update.go
+++ b/entc/integration/json/ent/user_update.go
@@ -20,6 +20,7 @@ import (
 	"entgo.io/ent/entc/integration/json/ent/predicate"
 	"entgo.io/ent/entc/integration/json/ent/schema"
 	"entgo.io/ent/entc/integration/json/ent/user"
+	extfield "entgo.io/ent/entc/integration/json/field"
 	"entgo.io/ent/schema/field"
 )
 
@@ -183,6 +184,26 @@ func (uu *UserUpdate) ClearAddr() *UserUpdate {
 	return uu
 }
 
+// SetTestField sets the "testField" field.
+func (uu *UserUpdate) SetTestField(ef extfield.TestField) *UserUpdate {
+	uu.mutation.SetTestField(ef)
+	return uu
+}
+
+// SetNillableTestField sets the "testField" field if the given value is not nil.
+func (uu *UserUpdate) SetNillableTestField(ef *extfield.TestField) *UserUpdate {
+	if ef != nil {
+		uu.SetTestField(*ef)
+	}
+	return uu
+}
+
+// ClearTestField clears the value of the "testField" field.
+func (uu *UserUpdate) ClearTestField() *UserUpdate {
+	uu.mutation.ClearTestField()
+	return uu
+}
+
 // SetUnknown sets the "unknown" field.
 func (uu *UserUpdate) SetUnknown(a any) *UserUpdate {
 	uu.mutation.SetUnknown(a)
@@ -322,6 +343,12 @@ func (uu *UserUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if uu.mutation.AddrCleared() {
 		_spec.ClearField(user.FieldAddr, field.TypeJSON)
+	}
+	if value, ok := uu.mutation.TestField(); ok {
+		_spec.SetField(user.FieldTestField, field.TypeJSON, value)
+	}
+	if uu.mutation.TestFieldCleared() {
+		_spec.ClearField(user.FieldTestField, field.TypeJSON)
 	}
 	if value, ok := uu.mutation.Unknown(); ok {
 		_spec.SetField(user.FieldUnknown, field.TypeJSON, value)
@@ -497,6 +524,26 @@ func (uuo *UserUpdateOne) ClearAddr() *UserUpdateOne {
 	return uuo
 }
 
+// SetTestField sets the "testField" field.
+func (uuo *UserUpdateOne) SetTestField(ef extfield.TestField) *UserUpdateOne {
+	uuo.mutation.SetTestField(ef)
+	return uuo
+}
+
+// SetNillableTestField sets the "testField" field if the given value is not nil.
+func (uuo *UserUpdateOne) SetNillableTestField(ef *extfield.TestField) *UserUpdateOne {
+	if ef != nil {
+		uuo.SetTestField(*ef)
+	}
+	return uuo
+}
+
+// ClearTestField clears the value of the "testField" field.
+func (uuo *UserUpdateOne) ClearTestField() *UserUpdateOne {
+	uuo.mutation.ClearTestField()
+	return uuo
+}
+
 // SetUnknown sets the "unknown" field.
 func (uuo *UserUpdateOne) SetUnknown(a any) *UserUpdateOne {
 	uuo.mutation.SetUnknown(a)
@@ -666,6 +713,12 @@ func (uuo *UserUpdateOne) sqlSave(ctx context.Context) (_node *User, err error) 
 	}
 	if uuo.mutation.AddrCleared() {
 		_spec.ClearField(user.FieldAddr, field.TypeJSON)
+	}
+	if value, ok := uuo.mutation.TestField(); ok {
+		_spec.SetField(user.FieldTestField, field.TypeJSON, value)
+	}
+	if uuo.mutation.TestFieldCleared() {
+		_spec.ClearField(user.FieldTestField, field.TypeJSON)
 	}
 	if value, ok := uuo.mutation.Unknown(); ok {
 		_spec.SetField(user.FieldUnknown, field.TypeJSON, value)

--- a/entc/integration/json/field/field.go
+++ b/entc/integration/json/field/field.go
@@ -1,0 +1,5 @@
+package field
+
+type TestField struct {
+	A string `json:"a"`
+}

--- a/entc/integration/json/json_test.go
+++ b/entc/integration/json/json_test.go
@@ -21,6 +21,7 @@ import (
 	"entgo.io/ent/entc/integration/json/ent/migrate"
 	"entgo.io/ent/entc/integration/json/ent/schema"
 	"entgo.io/ent/entc/integration/json/ent/user"
+	"entgo.io/ent/entc/integration/json/field"
 
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"
@@ -45,6 +46,7 @@ func TestMySQL(t *testing.T) {
 
 			URL(t, client)
 			Dirs(t, client)
+			Field(t, client)
 			Floats(t, client)
 			NetAddr(t, client)
 			RawMessage(t, client)
@@ -84,6 +86,7 @@ func TestMaria(t *testing.T) {
 			URL(t, client)
 			Dirs(t, client)
 			Ints(t, client)
+			Field(t, client)
 			Floats(t, client)
 			Strings(t, client)
 			NetAddr(t, client)
@@ -118,6 +121,7 @@ func TestPostgres(t *testing.T) {
 			URLs(t, client)
 			Dirs(t, client)
 			Ints(t, client)
+			Field(t, client)
 			Floats(t, client)
 			Strings(t, client)
 			NetAddr(t, client)
@@ -141,6 +145,7 @@ func TestSQLite(t *testing.T) {
 	URLs(t, client)
 	Dirs(t, client)
 	Ints(t, client)
+	Field(t, client)
 	Floats(t, client)
 	Strings(t, client)
 	NetAddr(t, client)
@@ -298,6 +303,19 @@ func NetAddr(t *testing.T, client *ent.Client) {
 	f, ok := reflect.TypeOf(ent.User{}).FieldByName("Addr")
 	require.True(t, ok)
 	require.Equal(t, "-", f.Tag.Get("json"))
+}
+
+func Field(t *testing.T, client *ent.Client) {
+	ctx := context.Background()
+	f := field.TestField{A: "test"}
+	usr := client.User.Create().SetTestField(f).SaveX(ctx)
+	require.Equal(t, f, usr.TestField)
+	require.Equal(t, f, client.User.GetX(ctx, usr.ID).TestField)
+
+	usr = client.User.Create().SaveX(ctx)
+	require.Equal(t, field.TestField{}, usr.TestField)
+	usr = client.User.GetX(ctx, usr.ID)
+	require.Equal(t, field.TestField{}, usr.TestField)
 }
 
 func Dirs(t *testing.T, client *ent.Client) {


### PR DESCRIPTION
Currently fields utilizing imported packages where the package name conflicts with a generator import package result in broken code.

For example given an (aliased) user-provided `field` package `field.MetaField` like so:
```go
package schema

import (
	bugfield "entgo.io/bug/field"
	"entgo.io/bug/other"
	"entgo.io/ent"
	"entgo.io/ent/schema/field"
)

// User holds the schema definition for the User entity.
type User struct {
	ent.Schema
}

// Fields of the User.
func (User) Fields() []ent.Field {
	return []ent.Field{
		field.Int("age"),
		field.String("name"),
		field.JSON("metafield", bugfield.MetaField{}),
		field.JSON("otherfield", other.OtherField{}),
	}
}

// Edges of the User.
func (User) Edges() []ent.Edge {
	return nil
}
```
The following broken code is generated in `ent/user.go` (among others) due to a conflict between the user-provided `field` package and the internal package `entgo.io/ent/schema/field`:
```go
// Code generated by ent, DO NOT EDIT.

package ent

import (
	"encoding/json"
	"fmt"
	"strings"

	"entgo.io/bug/ent/user"
	"entgo.io/bug/other"
	"entgo.io/ent/dialect/sql"
	"entgo.io/ent/schema/field"
)

// User is the model entity for the User schema.
type User struct {
	config `json:"-"`
	// ID of the ent.
	ID int `json:"id,omitempty"`
	// Age holds the value of the "age" field.
	Age int `json:"age,omitempty"`
	// Name holds the value of the "name" field.
	Name string `json:"name,omitempty"`
	// Metafield holds the value of the "metafield" field.
	Metafield field.MetaField `json:"metafield,omitempty"`
	// Otherfield holds the value of the "otherfield" field.
	Otherfield other.OtherField `json:"otherfield,omitempty"`
}
```
This MR aliases conflicting user-provided packages by prefixing the identifier with `ext` and results in the following (now working) code in `ent/user.go`: 
```go
// Code generated by ent, DO NOT EDIT.

package ent

import (
	"encoding/json"
	"fmt"
	"strings"

	"entgo.io/bug/ent/user"
	extfield "entgo.io/bug/field"
	"entgo.io/bug/other"
	"entgo.io/ent"
	"entgo.io/ent/dialect/sql"
)

// User is the model entity for the User schema.
type User struct {
	config `json:"-"`
	// ID of the ent.
	ID int `json:"id,omitempty"`
	// Age holds the value of the "age" field.
	Age int `json:"age,omitempty"`
	// Name holds the value of the "name" field.
	Name string `json:"name,omitempty"`
	// Metafield holds the value of the "metafield" field.
	Metafield extfield.MetaField `json:"metafield,omitempty"`
	// Otherfield holds the value of the "otherfield" field.
	Otherfield   other.OtherField `json:"otherfield,omitempty"`
	selectValues sql.SelectValues
}
```

Feedback welcome!