### PR TITLE
cmd/ent: hide the --idtype flag from generate command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
+      - name: Run cmd tests
+        run: go test -race ./...
+        working-directory: cmd
       - name: Run dialect tests
         run: go test -race ./...
         working-directory: dialect

--- a/cmd/ent/ent_test.go
+++ b/cmd/ent/ent_test.go
@@ -15,12 +15,12 @@ import (
 
 func TestCmd(t *testing.T) {
 	defer os.RemoveAll("ent")
-	cmd := exec.Command("go", "run", "entgo.io/ent/cmd/ent", "init", "User")
+	cmd := exec.Command("go", "run", "entgo.io/ent/cmd/ent", "new", "User")
 	stderr := bytes.NewBuffer(nil)
 	cmd.Stderr = stderr
 	require.NoError(t, cmd.Run())
 	require.Zero(t, stderr.String())
-	cmd = exec.Command("go", "run", "entgo.io/ent/cmd/ent", "init", "User")
+	cmd = exec.Command("go", "run", "entgo.io/ent/cmd/ent", "new", "User")
 	require.Error(t, cmd.Run())
 
 	_, err := os.Stat("ent/generate.go")

--- a/cmd/entc/entc_test.go
+++ b/cmd/entc/entc_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestCmd(t *testing.T) {
 	defer os.RemoveAll("ent")
-	cmd := exec.Command("go", "run", "entgo.io/ent/cmd/entc", "init", "User")
+	cmd := exec.Command("go", "run", "entgo.io/ent/cmd/entc", "new", "User")
 	stderr := bytes.NewBuffer(nil)
 	cmd.Stderr = stderr
 	require.NoError(t, cmd.Run(), stderr.String())

--- a/cmd/internal/base/base.go
+++ b/cmd/internal/base/base.go
@@ -202,10 +202,13 @@ func GenerateCmd(postRun ...func(*gen.Config)) *cobra.Command {
 	cmd.Flags().StringVar(&cfg.Target, "target", "", "target directory for codegen")
 	cmd.Flags().StringSliceVarP(&features, "feature", "", nil, "extend codegen with additional features")
 	cmd.Flags().StringSliceVarP(&templates, "template", "", nil, "external templates to execute")
+	// The --idtype flag predates the field.<Type>("id") option.
+	// See, https://entgo.io/docs/schema-fields#id-field.
+	cobra.CheckErr(cmd.Flags().MarkHidden("idtype"))
 	return cmd
 }
 
-// newEnv create an new environment for ent codegen.
+// newEnv create a new environment for ent codegen.
 func newEnv(target string, names []string, tmpl *template.Template) error {
 	if err := createDir(target); err != nil {
 		return fmt.Errorf("create dir %s: %w", target, err)

--- a/doc/md/code-gen.md
+++ b/doc/md/code-gen.md
@@ -92,7 +92,6 @@ Flags:
       --feature strings       extend codegen with additional features
       --header string         override codegen header
   -h, --help                  help for generate
-      --idtype [int string]   type of the id field (default int)
       --storage string        storage driver to support in codegen (default "sql")
       --target string         target directory for codegen
       --template strings      external templates to execute


### PR DESCRIPTION
The --idtype flag predates the field.<Type>(id) option. See, https://entgo.io/docs/schema-fields\#id-field.