### PR TITLE
doc/md/ci: fix broken link for ent/contrib/ci action's repo

### DIFF
--- a/doc/md/ci.mdx
+++ b/doc/md/ci.mdx
@@ -26,7 +26,7 @@ Ent-specific verifications into their workflows.
 
 To support the community with this effort we have started this guide which
 documents common best practices to verify in CI and introduces
-[ent/contrib/ci](https://github.com/ent/contrib/ci) a GitHub Action
+[ent/contrib/ci](https://github.com/ent/contrib/tree/master/ci) a GitHub Action
 we maintain that codifies them.
 
 ## Verify all generated files are checked in


### PR DESCRIPTION
The link for ent/contrib/ci is broken on https://entgo.io/docs/ci/ . So I fixed it.

![after](https://user-images.githubusercontent.com/32762324/234436242-bc4b39b9-8e26-448a-926a-c18f6759f69a.gif)

