### PR TITLE
dialect/sql/schema: allow ariga.io/atlas schema diff to be extended

### DIFF
--- a/dialect/sql/builder.go
+++ b/dialect/sql/builder.go
@@ -2748,7 +2748,7 @@ type (
 		// custom clause for locking.
 		clause string
 	}
-	// LockOption allows configuring the LockConfig using functional options.
+	// LockOption allows configuring the LockOptions using functional options.
 	LockOption func(*LockOptions)
 )
 

--- a/dialect/sql/schema/atlas.go
+++ b/dialect/sql/schema/atlas.go
@@ -1153,7 +1153,9 @@ func (r *diffDriver) RealmDiff(_, _ *schema.Realm) ([]schema.Change, error) {
 
 // SchemaDiff creates the diff between two schemas, but includes "diff hooks".
 func (r *diffDriver) SchemaDiff(from, to *schema.Schema) ([]schema.Change, error) {
-	var d Differ = DiffFunc(r.Driver.SchemaDiff)
+	var d Differ = DiffFunc(func(current, desired *schema.Schema) ([]schema.Change, error) {
+		return r.Driver.SchemaDiff(current, desired)
+	})
 	for i := len(r.hooks) - 1; i >= 0; i-- {
 		d = r.hooks[i](d)
 	}


### PR DESCRIPTION
By not relying on the SchemaDiff signature, we allow the schema.Differ to be extended without introducing breaking changes to ent