### PR TITLE
Fix go install instruction for atlas

### DIFF
--- a/doc/md/components/_installation_instructions.mdx
+++ b/doc/md/components/_installation_instructions.mdx
@@ -30,7 +30,7 @@ brew install ariga/tap/atlas
 <TabItem value="go">
 
 ```shell
-go install ariga.io/atlas/cmd/atlas@master
+go install ariga.io/atlas/cmd/atlas@latest
 ```
 
 </TabItem>


### PR DESCRIPTION
Thank you for the great project! I found the provided go install instruction for atlas may not be right. Please let me propose a fix.

```console
$ go install ariga.io/atlas/cmd/atlas@master
go: downloading ariga.io/atlas/cmd/atlas v0.10.2-0.20230506210831-e5c646bc8170
...
# ariga.io/atlas/cmd/atlas/internal/cmdapi
../../../../../go/pkg/mod/ariga.io/atlas/cmd/atlas@v0.10.2-0.20230506210831-e5c646bc8170/internal/cmdapi/project.go:261:8: opts.Extra undefined (type *"ariga.io/atlas/sql/schema".DiffOptions has no field or method Extra)


$ go install ariga.io/atlas/cmd/atlas@latest
go: downloading ariga.io/atlas/cmd/atlas v0.10.1
go: downloading ariga.io/atlas v0.10.1
go: downloading ariga.io/atlas v0.10.1-0.20230404183748-023b08ad359c
go: downloading golang.org/x/mod v0.8.0
go: downloading entgo.io/ent v0.11.10-0.20230304080653-f16451eab831
go: downloading golang.org/x/tools v0.6.1-0.20230222164832-25d2519c8696
```