### PR TITLE
Fix dialect client open options order

### DIFF
--- a/entc/gen/template/dialect/gremlin/open.tmpl
+++ b/entc/gen/template/dialect/gremlin/open.tmpl
@@ -20,5 +20,5 @@ in the LICENSE file in the root directory of this source tree.
 		return nil, err
 	}
 	drv := gremlin.NewDriver(c)
-	return NewClient(append(options, Driver(drv))...), nil
+	return NewClient(append([]Option{Driver(drv)}, options...)...), nil
 {{ end }}

--- a/entc/gen/template/dialect/sql/open.tmpl
+++ b/entc/gen/template/dialect/sql/open.tmpl
@@ -11,5 +11,5 @@ in the LICENSE file in the root directory of this source tree.
 	if err != nil {
 		return nil, err
 	}
-	return NewClient(append(options, Driver(drv))...), nil
+	return NewClient(append([]Option{Driver(drv)}, options...)...), nil
 {{ end }}

--- a/examples/edgeindex/ent/client.go
+++ b/examples/edgeindex/ent/client.go
@@ -107,7 +107,7 @@ func Open(driverName, dataSourceName string, options ...Option) (*Client, error)
 		if err != nil {
 			return nil, err
 		}
-		return NewClient(append(options, Driver(drv))...), nil
+		return NewClient(append([]Option{Driver(drv)}, options...)...), nil
 	default:
 		return nil, fmt.Errorf("unsupported driver: %q", driverName)
 	}

--- a/examples/encryptfield/ent/client.go
+++ b/examples/encryptfield/ent/client.go
@@ -111,7 +111,7 @@ func Open(driverName, dataSourceName string, options ...Option) (*Client, error)
 		if err != nil {
 			return nil, err
 		}
-		return NewClient(append(options, Driver(drv))...), nil
+		return NewClient(append([]Option{Driver(drv)}, options...)...), nil
 	default:
 		return nil, fmt.Errorf("unsupported driver: %q", driverName)
 	}

--- a/examples/entcpkg/ent/client.go
+++ b/examples/entcpkg/ent/client.go
@@ -121,7 +121,7 @@ func Open(driverName, dataSourceName string, options ...Option) (*Client, error)
 		if err != nil {
 			return nil, err
 		}
-		return NewClient(append(options, Driver(drv))...), nil
+		return NewClient(append([]Option{Driver(drv)}, options...)...), nil
 	default:
 		return nil, fmt.Errorf("unsupported driver: %q", driverName)
 	}

--- a/examples/fs/ent/client.go
+++ b/examples/fs/ent/client.go
@@ -103,7 +103,7 @@ func Open(driverName, dataSourceName string, options ...Option) (*Client, error)
 		if err != nil {
 			return nil, err
 		}
-		return NewClient(append(options, Driver(drv))...), nil
+		return NewClient(append([]Option{Driver(drv)}, options...)...), nil
 	default:
 		return nil, fmt.Errorf("unsupported driver: %q", driverName)
 	}

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -1313,6 +1313,7 @@ github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOA
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/mattn/go-shellwords v1.0.6/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
@@ -1389,6 +1390,7 @@ github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQ
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/onsi/ginkgo v0.0.0-20151202141238-7f8ab55aaf3b/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -1603,11 +1605,13 @@ github.com/spf13/cobra v0.0.2-0.20171109065643-2da4a54c5cee/go.mod h1:1l0Ry5zgKv
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
+github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.1-0.20171106142849-4c012f6dcd95/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
@@ -2274,6 +2278,7 @@ golang.org/x/tools v0.1.9/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
 golang.org/x/tools v0.1.10/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.2.0/go.mod h1:y4OqIKeOV/fWJetJ8bXPU1sEVniLMIyDAZWeHdV+NTA=
+golang.org/x/tools v0.8.1-0.20230428195545-5283a0178901 h1:0wxTF6pSjIIhNt7mo9GvjDfzyCOiWhmICgtO/Ah948s=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/examples/jsonencode/ent/client.go
+++ b/examples/jsonencode/ent/client.go
@@ -111,7 +111,7 @@ func Open(driverName, dataSourceName string, options ...Option) (*Client, error)
 		if err != nil {
 			return nil, err
 		}
-		return NewClient(append(options, Driver(drv))...), nil
+		return NewClient(append([]Option{Driver(drv)}, options...)...), nil
 	default:
 		return nil, fmt.Errorf("unsupported driver: %q", driverName)
 	}

--- a/examples/m2m2types/ent/client.go
+++ b/examples/m2m2types/ent/client.go
@@ -107,7 +107,7 @@ func Open(driverName, dataSourceName string, options ...Option) (*Client, error)
 		if err != nil {
 			return nil, err
 		}
-		return NewClient(append(options, Driver(drv))...), nil
+		return NewClient(append([]Option{Driver(drv)}, options...)...), nil
 	default:
 		return nil, fmt.Errorf("unsupported driver: %q", driverName)
 	}

--- a/examples/m2mbidi/ent/client.go
+++ b/examples/m2mbidi/ent/client.go
@@ -103,7 +103,7 @@ func Open(driverName, dataSourceName string, options ...Option) (*Client, error)
 		if err != nil {
 			return nil, err
 		}
-		return NewClient(append(options, Driver(drv))...), nil
+		return NewClient(append([]Option{Driver(drv)}, options...)...), nil
 	default:
 		return nil, fmt.Errorf("unsupported driver: %q", driverName)
 	}

--- a/examples/m2mrecur/ent/client.go
+++ b/examples/m2mrecur/ent/client.go
@@ -103,7 +103,7 @@ func Open(driverName, dataSourceName string, options ...Option) (*Client, error)
 		if err != nil {
 			return nil, err
 		}
-		return NewClient(append(options, Driver(drv))...), nil
+		return NewClient(append([]Option{Driver(drv)}, options...)...), nil
 	default:
 		return nil, fmt.Errorf("unsupported driver: %q", driverName)
 	}

--- a/examples/migration/ent/client.go
+++ b/examples/migration/ent/client.go
@@ -112,7 +112,7 @@ func Open(driverName, dataSourceName string, options ...Option) (*Client, error)
 		if err != nil {
 			return nil, err
 		}
-		return NewClient(append(options, Driver(drv))...), nil
+		return NewClient(append([]Option{Driver(drv)}, options...)...), nil
 	default:
 		return nil, fmt.Errorf("unsupported driver: %q", driverName)
 	}

--- a/examples/o2m2types/ent/client.go
+++ b/examples/o2m2types/ent/client.go
@@ -107,7 +107,7 @@ func Open(driverName, dataSourceName string, options ...Option) (*Client, error)
 		if err != nil {
 			return nil, err
 		}
-		return NewClient(append(options, Driver(drv))...), nil
+		return NewClient(append([]Option{Driver(drv)}, options...)...), nil
 	default:
 		return nil, fmt.Errorf("unsupported driver: %q", driverName)
 	}

--- a/examples/o2mrecur/ent/client.go
+++ b/examples/o2mrecur/ent/client.go
@@ -103,7 +103,7 @@ func Open(driverName, dataSourceName string, options ...Option) (*Client, error)
 		if err != nil {
 			return nil, err
 		}
-		return NewClient(append(options, Driver(drv))...), nil
+		return NewClient(append([]Option{Driver(drv)}, options...)...), nil
 	default:
 		return nil, fmt.Errorf("unsupported driver: %q", driverName)
 	}

--- a/examples/o2o2types/ent/client.go
+++ b/examples/o2o2types/ent/client.go
@@ -107,7 +107,7 @@ func Open(driverName, dataSourceName string, options ...Option) (*Client, error)
 		if err != nil {
 			return nil, err
 		}
-		return NewClient(append(options, Driver(drv))...), nil
+		return NewClient(append([]Option{Driver(drv)}, options...)...), nil
 	default:
 		return nil, fmt.Errorf("unsupported driver: %q", driverName)
 	}

--- a/examples/o2obidi/ent/client.go
+++ b/examples/o2obidi/ent/client.go
@@ -103,7 +103,7 @@ func Open(driverName, dataSourceName string, options ...Option) (*Client, error)
 		if err != nil {
 			return nil, err
 		}
-		return NewClient(append(options, Driver(drv))...), nil
+		return NewClient(append([]Option{Driver(drv)}, options...)...), nil
 	default:
 		return nil, fmt.Errorf("unsupported driver: %q", driverName)
 	}

--- a/examples/o2orecur/ent/client.go
+++ b/examples/o2orecur/ent/client.go
@@ -103,7 +103,7 @@ func Open(driverName, dataSourceName string, options ...Option) (*Client, error)
 		if err != nil {
 			return nil, err
 		}
-		return NewClient(append(options, Driver(drv))...), nil
+		return NewClient(append([]Option{Driver(drv)}, options...)...), nil
 	default:
 		return nil, fmt.Errorf("unsupported driver: %q", driverName)
 	}

--- a/examples/privacyadmin/ent/client.go
+++ b/examples/privacyadmin/ent/client.go
@@ -102,7 +102,7 @@ func Open(driverName, dataSourceName string, options ...Option) (*Client, error)
 		if err != nil {
 			return nil, err
 		}
-		return NewClient(append(options, Driver(drv))...), nil
+		return NewClient(append([]Option{Driver(drv)}, options...)...), nil
 	default:
 		return nil, fmt.Errorf("unsupported driver: %q", driverName)
 	}

--- a/examples/privacytenant/ent/client.go
+++ b/examples/privacytenant/ent/client.go
@@ -111,7 +111,7 @@ func Open(driverName, dataSourceName string, options ...Option) (*Client, error)
 		if err != nil {
 			return nil, err
 		}
-		return NewClient(append(options, Driver(drv))...), nil
+		return NewClient(append([]Option{Driver(drv)}, options...)...), nil
 	default:
 		return nil, fmt.Errorf("unsupported driver: %q", driverName)
 	}

--- a/examples/start/ent/client.go
+++ b/examples/start/ent/client.go
@@ -111,7 +111,7 @@ func Open(driverName, dataSourceName string, options ...Option) (*Client, error)
 		if err != nil {
 			return nil, err
 		}
-		return NewClient(append(options, Driver(drv))...), nil
+		return NewClient(append([]Option{Driver(drv)}, options...)...), nil
 	default:
 		return nil, fmt.Errorf("unsupported driver: %q", driverName)
 	}

--- a/examples/traversal/ent/client.go
+++ b/examples/traversal/ent/client.go
@@ -111,7 +111,7 @@ func Open(driverName, dataSourceName string, options ...Option) (*Client, error)
 		if err != nil {
 			return nil, err
 		}
-		return NewClient(append(options, Driver(drv))...), nil
+		return NewClient(append([]Option{Driver(drv)}, options...)...), nil
 	default:
 		return nil, fmt.Errorf("unsupported driver: %q", driverName)
 	}

--- a/examples/version/ent/client.go
+++ b/examples/version/ent/client.go
@@ -102,7 +102,7 @@ func Open(driverName, dataSourceName string, options ...Option) (*Client, error)
 		if err != nil {
 			return nil, err
 		}
-		return NewClient(append(options, Driver(drv))...), nil
+		return NewClient(append([]Option{Driver(drv)}, options...)...), nil
 	default:
 		return nil, fmt.Errorf("unsupported driver: %q", driverName)
 	}


### PR DESCRIPTION
Fixes https://github.com/ent/ent/issues/3554

Prepends the default driver to the additional options provided to `Open()` rather than appending it.

I also fixed the same issue gremlin driver while I was at it.