### PR TITLE
dialect/sql: support capturing predicates in selectors

### DIFF
--- a/entc/gen/template/dialect/sql/predicate.tmpl
+++ b/entc/gen/template/dialect/sql/predicate.tmpl
@@ -78,30 +78,13 @@ in the LICENSE file in the root directory of this source tree.
 {{- end }}
 
 {{ define "dialect/sql/predicate/and" -}}
-	func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	}
+	sql.AndPredicates(predicates...)
 {{- end }}
 
 {{ define "dialect/sql/predicate/or" -}}
-	func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	}
+	sql.OrPredicates(predicates...)
 {{- end }}
 
 {{ define "dialect/sql/predicate/not" -}}
-	func(s *sql.Selector) {
-		p(s.Not())
-	}
+	sql.NotPredicates(p)
 {{- end }}

--- a/entc/integration/cascadelete/ent/comment/where.go
+++ b/entc/integration/cascadelete/ent/comment/where.go
@@ -177,32 +177,15 @@ func HasPostWith(preds ...predicate.Post) predicate.Comment {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Comment) predicate.Comment {
-	return predicate.Comment(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Comment(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Comment) predicate.Comment {
-	return predicate.Comment(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Comment(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Comment) predicate.Comment {
-	return predicate.Comment(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Comment(sql.NotPredicates(p))
 }

--- a/entc/integration/cascadelete/ent/post/where.go
+++ b/entc/integration/cascadelete/ent/post/where.go
@@ -210,32 +210,15 @@ func HasCommentsWith(preds ...predicate.Comment) predicate.Post {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Post) predicate.Post {
-	return predicate.Post(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Post(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Post) predicate.Post {
-	return predicate.Post(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Post(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Post) predicate.Post {
-	return predicate.Post(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Post(sql.NotPredicates(p))
 }

--- a/entc/integration/cascadelete/ent/user/where.go
+++ b/entc/integration/cascadelete/ent/user/where.go
@@ -152,32 +152,15 @@ func HasPostsWith(preds ...predicate.Post) predicate.User {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.User(sql.NotPredicates(p))
 }

--- a/entc/integration/config/ent/user/where.go
+++ b/entc/integration/config/ent/user/where.go
@@ -213,32 +213,15 @@ func LabelContainsFold(v string) predicate.User {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.User(sql.NotPredicates(p))
 }

--- a/entc/integration/customid/ent/account/where.go
+++ b/entc/integration/customid/ent/account/where.go
@@ -153,32 +153,15 @@ func HasTokenWith(preds ...predicate.Token) predicate.Account {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Account) predicate.Account {
-	return predicate.Account(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Account(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Account) predicate.Account {
-	return predicate.Account(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Account(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Account) predicate.Account {
-	return predicate.Account(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Account(sql.NotPredicates(p))
 }

--- a/entc/integration/customid/ent/blob/where.go
+++ b/entc/integration/customid/ent/blob/where.go
@@ -219,32 +219,15 @@ func HasBlobLinksWith(preds ...predicate.BlobLink) predicate.Blob {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Blob) predicate.Blob {
-	return predicate.Blob(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Blob(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Blob) predicate.Blob {
-	return predicate.Blob(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Blob(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Blob) predicate.Blob {
-	return predicate.Blob(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Blob(sql.NotPredicates(p))
 }

--- a/entc/integration/customid/ent/bloblink/where.go
+++ b/entc/integration/customid/ent/bloblink/where.go
@@ -158,32 +158,15 @@ func HasLinkWith(preds ...predicate.Blob) predicate.BlobLink {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.BlobLink) predicate.BlobLink {
-	return predicate.BlobLink(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.BlobLink(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.BlobLink) predicate.BlobLink {
-	return predicate.BlobLink(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.BlobLink(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.BlobLink) predicate.BlobLink {
-	return predicate.BlobLink(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.BlobLink(sql.NotPredicates(p))
 }

--- a/entc/integration/customid/ent/car/where.go
+++ b/entc/integration/customid/ent/car/where.go
@@ -262,32 +262,15 @@ func HasOwnerWith(preds ...predicate.Pet) predicate.Car {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Car) predicate.Car {
-	return predicate.Car(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Car(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Car) predicate.Car {
-	return predicate.Car(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Car(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Car) predicate.Car {
-	return predicate.Car(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Car(sql.NotPredicates(p))
 }

--- a/entc/integration/customid/ent/device/where.go
+++ b/entc/integration/customid/ent/device/where.go
@@ -106,32 +106,15 @@ func HasSessionsWith(preds ...predicate.Session) predicate.Device {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Device) predicate.Device {
-	return predicate.Device(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Device(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Device) predicate.Device {
-	return predicate.Device(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Device(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Device) predicate.Device {
-	return predicate.Device(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Device(sql.NotPredicates(p))
 }

--- a/entc/integration/customid/ent/doc/where.go
+++ b/entc/integration/customid/ent/doc/where.go
@@ -209,32 +209,15 @@ func HasRelatedWith(preds ...predicate.Doc) predicate.Doc {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Doc) predicate.Doc {
-	return predicate.Doc(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Doc(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Doc) predicate.Doc {
-	return predicate.Doc(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Doc(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Doc) predicate.Doc {
-	return predicate.Doc(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Doc(sql.NotPredicates(p))
 }

--- a/entc/integration/customid/ent/group/where.go
+++ b/entc/integration/customid/ent/group/where.go
@@ -82,32 +82,15 @@ func HasUsersWith(preds ...predicate.User) predicate.Group {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Group(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Group(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Group(sql.NotPredicates(p))
 }

--- a/entc/integration/customid/ent/intsid/where.go
+++ b/entc/integration/customid/ent/intsid/where.go
@@ -106,32 +106,15 @@ func HasChildrenWith(preds ...predicate.IntSID) predicate.IntSID {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.IntSID) predicate.IntSID {
-	return predicate.IntSID(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.IntSID(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.IntSID) predicate.IntSID {
-	return predicate.IntSID(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.IntSID(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.IntSID) predicate.IntSID {
-	return predicate.IntSID(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.IntSID(sql.NotPredicates(p))
 }

--- a/entc/integration/customid/ent/link/where.go
+++ b/entc/integration/customid/ent/link/where.go
@@ -59,32 +59,15 @@ func IDLTE(id uuidc.UUIDC) predicate.Link {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Link) predicate.Link {
-	return predicate.Link(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Link(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Link) predicate.Link {
-	return predicate.Link(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Link(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Link) predicate.Link {
-	return predicate.Link(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Link(sql.NotPredicates(p))
 }

--- a/entc/integration/customid/ent/mixinid/where.go
+++ b/entc/integration/customid/ent/mixinid/where.go
@@ -199,32 +199,15 @@ func MixinFieldContainsFold(v string) predicate.MixinID {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.MixinID) predicate.MixinID {
-	return predicate.MixinID(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.MixinID(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.MixinID) predicate.MixinID {
-	return predicate.MixinID(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.MixinID(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.MixinID) predicate.MixinID {
-	return predicate.MixinID(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.MixinID(sql.NotPredicates(p))
 }

--- a/entc/integration/customid/ent/note/where.go
+++ b/entc/integration/customid/ent/note/where.go
@@ -186,32 +186,15 @@ func HasChildrenWith(preds ...predicate.Note) predicate.Note {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Note) predicate.Note {
-	return predicate.Note(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Note(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Note) predicate.Note {
-	return predicate.Note(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Note(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Note) predicate.Note {
-	return predicate.Note(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Note(sql.NotPredicates(p))
 }

--- a/entc/integration/customid/ent/other/where.go
+++ b/entc/integration/customid/ent/other/where.go
@@ -59,32 +59,15 @@ func IDLTE(id sid.ID) predicate.Other {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Other) predicate.Other {
-	return predicate.Other(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Other(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Other) predicate.Other {
-	return predicate.Other(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Other(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Other) predicate.Other {
-	return predicate.Other(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Other(sql.NotPredicates(p))
 }

--- a/entc/integration/customid/ent/pet/where.go
+++ b/entc/integration/customid/ent/pet/where.go
@@ -161,32 +161,15 @@ func HasBestFriendWith(preds ...predicate.Pet) predicate.Pet {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Pet(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Pet(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Pet(sql.NotPredicates(p))
 }

--- a/entc/integration/customid/ent/revision/where.go
+++ b/entc/integration/customid/ent/revision/where.go
@@ -68,32 +68,15 @@ func IDContainsFold(id string) predicate.Revision {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Revision) predicate.Revision {
-	return predicate.Revision(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Revision(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Revision) predicate.Revision {
-	return predicate.Revision(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Revision(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Revision) predicate.Revision {
-	return predicate.Revision(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Revision(sql.NotPredicates(p))
 }

--- a/entc/integration/customid/ent/session/where.go
+++ b/entc/integration/customid/ent/session/where.go
@@ -83,32 +83,15 @@ func HasDeviceWith(preds ...predicate.Device) predicate.Session {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Session) predicate.Session {
-	return predicate.Session(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Session(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Session) predicate.Session {
-	return predicate.Session(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Session(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Session) predicate.Session {
-	return predicate.Session(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Session(sql.NotPredicates(p))
 }

--- a/entc/integration/customid/ent/token/where.go
+++ b/entc/integration/customid/ent/token/where.go
@@ -153,32 +153,15 @@ func HasAccountWith(preds ...predicate.Account) predicate.Token {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Token) predicate.Token {
-	return predicate.Token(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Token(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Token) predicate.Token {
-	return predicate.Token(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Token(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Token) predicate.Token {
-	return predicate.Token(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Token(sql.NotPredicates(p))
 }

--- a/entc/integration/customid/ent/user/where.go
+++ b/entc/integration/customid/ent/user/where.go
@@ -151,32 +151,15 @@ func HasPetsWith(preds ...predicate.Pet) predicate.User {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.User(sql.NotPredicates(p))
 }

--- a/entc/integration/edgefield/ent/car/where.go
+++ b/entc/integration/edgefield/ent/car/where.go
@@ -163,32 +163,15 @@ func HasRentalsWith(preds ...predicate.Rental) predicate.Car {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Car) predicate.Car {
-	return predicate.Car(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Car(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Car) predicate.Car {
-	return predicate.Car(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Car(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Car) predicate.Car {
-	return predicate.Car(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Car(sql.NotPredicates(p))
 }

--- a/entc/integration/edgefield/ent/card/where.go
+++ b/entc/integration/edgefield/ent/card/where.go
@@ -197,32 +197,15 @@ func HasOwnerWith(preds ...predicate.User) predicate.Card {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Card) predicate.Card {
-	return predicate.Card(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Card(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Card) predicate.Card {
-	return predicate.Card(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Card(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Card) predicate.Card {
-	return predicate.Card(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Card(sql.NotPredicates(p))
 }

--- a/entc/integration/edgefield/ent/info/where.go
+++ b/entc/integration/edgefield/ent/info/where.go
@@ -82,32 +82,15 @@ func HasUserWith(preds ...predicate.User) predicate.Info {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Info) predicate.Info {
-	return predicate.Info(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Info(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Info) predicate.Info {
-	return predicate.Info(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Info(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Info) predicate.Info {
-	return predicate.Info(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Info(sql.NotPredicates(p))
 }

--- a/entc/integration/edgefield/ent/metadata/where.go
+++ b/entc/integration/edgefield/ent/metadata/where.go
@@ -208,32 +208,15 @@ func HasParentWith(preds ...predicate.Metadata) predicate.Metadata {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Metadata) predicate.Metadata {
-	return predicate.Metadata(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Metadata(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Metadata) predicate.Metadata {
-	return predicate.Metadata(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Metadata(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Metadata) predicate.Metadata {
-	return predicate.Metadata(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Metadata(sql.NotPredicates(p))
 }

--- a/entc/integration/edgefield/ent/node/where.go
+++ b/entc/integration/edgefield/ent/node/where.go
@@ -185,32 +185,15 @@ func HasNextWith(preds ...predicate.Node) predicate.Node {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Node) predicate.Node {
-	return predicate.Node(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Node(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Node) predicate.Node {
-	return predicate.Node(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Node(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Node) predicate.Node {
-	return predicate.Node(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Node(sql.NotPredicates(p))
 }

--- a/entc/integration/edgefield/ent/pet/where.go
+++ b/entc/integration/edgefield/ent/pet/where.go
@@ -117,32 +117,15 @@ func HasOwnerWith(preds ...predicate.User) predicate.Pet {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Pet(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Pet(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Pet(sql.NotPredicates(p))
 }

--- a/entc/integration/edgefield/ent/post/where.go
+++ b/entc/integration/edgefield/ent/post/where.go
@@ -187,32 +187,15 @@ func HasAuthorWith(preds ...predicate.User) predicate.Post {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Post) predicate.Post {
-	return predicate.Post(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Post(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Post) predicate.Post {
-	return predicate.Post(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Post(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Post) predicate.Post {
-	return predicate.Post(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Post(sql.NotPredicates(p))
 }

--- a/entc/integration/edgefield/ent/rental/where.go
+++ b/entc/integration/edgefield/ent/rental/where.go
@@ -203,32 +203,15 @@ func HasCarWith(preds ...predicate.Car) predicate.Rental {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Rental) predicate.Rental {
-	return predicate.Rental(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Rental(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Rental) predicate.Rental {
-	return predicate.Rental(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Rental(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Rental) predicate.Rental {
-	return predicate.Rental(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Rental(sql.NotPredicates(p))
 }

--- a/entc/integration/edgefield/ent/user/where.go
+++ b/entc/integration/edgefield/ent/user/where.go
@@ -313,32 +313,15 @@ func HasRentalsWith(preds ...predicate.Rental) predicate.User {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.User(sql.NotPredicates(p))
 }

--- a/entc/integration/edgeschema/ent/attachedfile/where.go
+++ b/entc/integration/edgeschema/ent/attachedfile/where.go
@@ -202,32 +202,15 @@ func HasProcWith(preds ...predicate.Process) predicate.AttachedFile {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.AttachedFile) predicate.AttachedFile {
-	return predicate.AttachedFile(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.AttachedFile(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.AttachedFile) predicate.AttachedFile {
-	return predicate.AttachedFile(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.AttachedFile(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.AttachedFile) predicate.AttachedFile {
-	return predicate.AttachedFile(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.AttachedFile(sql.NotPredicates(p))
 }

--- a/entc/integration/edgeschema/ent/file/where.go
+++ b/entc/integration/edgeschema/ent/file/where.go
@@ -152,32 +152,15 @@ func HasProcessesWith(preds ...predicate.Process) predicate.File {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.File) predicate.File {
-	return predicate.File(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.File(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.File) predicate.File {
-	return predicate.File(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.File(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.File) predicate.File {
-	return predicate.File(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.File(sql.NotPredicates(p))
 }

--- a/entc/integration/edgeschema/ent/friendship/where.go
+++ b/entc/integration/edgeschema/ent/friendship/where.go
@@ -247,32 +247,15 @@ func HasFriendWith(preds ...predicate.User) predicate.Friendship {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Friendship) predicate.Friendship {
-	return predicate.Friendship(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Friendship(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Friendship) predicate.Friendship {
-	return predicate.Friendship(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Friendship(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Friendship) predicate.Friendship {
-	return predicate.Friendship(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Friendship(sql.NotPredicates(p))
 }

--- a/entc/integration/edgeschema/ent/group/where.go
+++ b/entc/integration/edgeschema/ent/group/where.go
@@ -221,32 +221,15 @@ func HasGroupTagsWith(preds ...predicate.GroupTag) predicate.Group {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Group(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Group(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Group(sql.NotPredicates(p))
 }

--- a/entc/integration/edgeschema/ent/grouptag/where.go
+++ b/entc/integration/edgeschema/ent/grouptag/where.go
@@ -155,32 +155,15 @@ func HasGroupWith(preds ...predicate.Group) predicate.GroupTag {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.GroupTag) predicate.GroupTag {
-	return predicate.GroupTag(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.GroupTag(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.GroupTag) predicate.GroupTag {
-	return predicate.GroupTag(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.GroupTag(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.GroupTag) predicate.GroupTag {
-	return predicate.GroupTag(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.GroupTag(sql.NotPredicates(p))
 }

--- a/entc/integration/edgeschema/ent/process/where.go
+++ b/entc/integration/edgeschema/ent/process/where.go
@@ -105,32 +105,15 @@ func HasAttachedFilesWith(preds ...predicate.AttachedFile) predicate.Process {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Process) predicate.Process {
-	return predicate.Process(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Process(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Process) predicate.Process {
-	return predicate.Process(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Process(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Process) predicate.Process {
-	return predicate.Process(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Process(sql.NotPredicates(p))
 }

--- a/entc/integration/edgeschema/ent/relationship/where.go
+++ b/entc/integration/edgeschema/ent/relationship/where.go
@@ -213,32 +213,15 @@ func HasInfoWith(preds ...predicate.RelationshipInfo) predicate.Relationship {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Relationship) predicate.Relationship {
-	return predicate.Relationship(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Relationship(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Relationship) predicate.Relationship {
-	return predicate.Relationship(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Relationship(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Relationship) predicate.Relationship {
-	return predicate.Relationship(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Relationship(sql.NotPredicates(p))
 }

--- a/entc/integration/edgeschema/ent/relationshipinfo/where.go
+++ b/entc/integration/edgeschema/ent/relationshipinfo/where.go
@@ -128,32 +128,15 @@ func TextContainsFold(v string) predicate.RelationshipInfo {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.RelationshipInfo) predicate.RelationshipInfo {
-	return predicate.RelationshipInfo(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.RelationshipInfo(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.RelationshipInfo) predicate.RelationshipInfo {
-	return predicate.RelationshipInfo(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.RelationshipInfo(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.RelationshipInfo) predicate.RelationshipInfo {
-	return predicate.RelationshipInfo(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.RelationshipInfo(sql.NotPredicates(p))
 }

--- a/entc/integration/edgeschema/ent/role/where.go
+++ b/entc/integration/edgeschema/ent/role/where.go
@@ -222,32 +222,15 @@ func HasRolesUsersWith(preds ...predicate.RoleUser) predicate.Role {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Role) predicate.Role {
-	return predicate.Role(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Role(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Role) predicate.Role {
-	return predicate.Role(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Role(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Role) predicate.Role {
-	return predicate.Role(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Role(sql.NotPredicates(p))
 }

--- a/entc/integration/edgeschema/ent/roleuser/where.go
+++ b/entc/integration/edgeschema/ent/roleuser/where.go
@@ -157,32 +157,15 @@ func HasUserWith(preds ...predicate.User) predicate.RoleUser {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.RoleUser) predicate.RoleUser {
-	return predicate.RoleUser(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.RoleUser(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.RoleUser) predicate.RoleUser {
-	return predicate.RoleUser(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.RoleUser(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.RoleUser) predicate.RoleUser {
-	return predicate.RoleUser(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.RoleUser(sql.NotPredicates(p))
 }

--- a/entc/integration/edgeschema/ent/tag/where.go
+++ b/entc/integration/edgeschema/ent/tag/where.go
@@ -221,32 +221,15 @@ func HasGroupTagsWith(preds ...predicate.GroupTag) predicate.Tag {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Tag) predicate.Tag {
-	return predicate.Tag(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Tag(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Tag) predicate.Tag {
-	return predicate.Tag(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Tag(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Tag) predicate.Tag {
-	return predicate.Tag(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Tag(sql.NotPredicates(p))
 }

--- a/entc/integration/edgeschema/ent/tweet/where.go
+++ b/entc/integration/edgeschema/ent/tweet/where.go
@@ -267,32 +267,15 @@ func HasTweetTagsWith(preds ...predicate.TweetTag) predicate.Tweet {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Tweet) predicate.Tweet {
-	return predicate.Tweet(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Tweet(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Tweet) predicate.Tweet {
-	return predicate.Tweet(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Tweet(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Tweet) predicate.Tweet {
-	return predicate.Tweet(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Tweet(sql.NotPredicates(p))
 }

--- a/entc/integration/edgeschema/ent/tweetlike/where.go
+++ b/entc/integration/edgeschema/ent/tweetlike/where.go
@@ -157,32 +157,15 @@ func HasUserWith(preds ...predicate.User) predicate.TweetLike {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.TweetLike) predicate.TweetLike {
-	return predicate.TweetLike(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.TweetLike(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.TweetLike) predicate.TweetLike {
-	return predicate.TweetLike(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.TweetLike(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.TweetLike) predicate.TweetLike {
-	return predicate.TweetLike(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.TweetLike(sql.NotPredicates(p))
 }

--- a/entc/integration/edgeschema/ent/tweettag/where.go
+++ b/entc/integration/edgeschema/ent/tweettag/where.go
@@ -203,32 +203,15 @@ func HasTweetWith(preds ...predicate.Tweet) predicate.TweetTag {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.TweetTag) predicate.TweetTag {
-	return predicate.TweetTag(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.TweetTag(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.TweetTag) predicate.TweetTag {
-	return predicate.TweetTag(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.TweetTag(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.TweetTag) predicate.TweetTag {
-	return predicate.TweetTag(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.TweetTag(sql.NotPredicates(p))
 }

--- a/entc/integration/edgeschema/ent/user/where.go
+++ b/entc/integration/edgeschema/ent/user/where.go
@@ -405,32 +405,15 @@ func HasRolesUsersWith(preds ...predicate.RoleUser) predicate.User {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.User(sql.NotPredicates(p))
 }

--- a/entc/integration/edgeschema/ent/usergroup/where.go
+++ b/entc/integration/edgeschema/ent/usergroup/where.go
@@ -202,32 +202,15 @@ func HasGroupWith(preds ...predicate.Group) predicate.UserGroup {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.UserGroup) predicate.UserGroup {
-	return predicate.UserGroup(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.UserGroup(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.UserGroup) predicate.UserGroup {
-	return predicate.UserGroup(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.UserGroup(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.UserGroup) predicate.UserGroup {
-	return predicate.UserGroup(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.UserGroup(sql.NotPredicates(p))
 }

--- a/entc/integration/edgeschema/ent/usertweet/where.go
+++ b/entc/integration/edgeschema/ent/usertweet/where.go
@@ -202,32 +202,15 @@ func HasTweetWith(preds ...predicate.Tweet) predicate.UserTweet {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.UserTweet) predicate.UserTweet {
-	return predicate.UserTweet(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.UserTweet(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.UserTweet) predicate.UserTweet {
-	return predicate.UserTweet(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.UserTweet(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.UserTweet) predicate.UserTweet {
-	return predicate.UserTweet(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.UserTweet(sql.NotPredicates(p))
 }

--- a/entc/integration/ent/api/where.go
+++ b/entc/integration/ent/api/where.go
@@ -58,32 +58,15 @@ func IDLTE(id int) predicate.Api {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Api) predicate.Api {
-	return predicate.Api(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Api(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Api) predicate.Api {
-	return predicate.Api(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Api(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Api) predicate.Api {
-	return predicate.Api(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Api(sql.NotPredicates(p))
 }

--- a/entc/integration/ent/builder/where.go
+++ b/entc/integration/ent/builder/where.go
@@ -58,32 +58,15 @@ func IDLTE(id int) predicate.Builder {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Builder) predicate.Builder {
-	return predicate.Builder(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Builder(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Builder) predicate.Builder {
-	return predicate.Builder(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Builder(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Builder) predicate.Builder {
-	return predicate.Builder(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Builder(sql.NotPredicates(p))
 }

--- a/entc/integration/ent/card/where.go
+++ b/entc/integration/ent/card/where.go
@@ -392,32 +392,15 @@ func HasSpecWith(preds ...predicate.Spec) predicate.Card {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Card) predicate.Card {
-	return predicate.Card(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Card(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Card) predicate.Card {
-	return predicate.Card(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Card(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Card) predicate.Card {
-	return predicate.Card(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Card(sql.NotPredicates(p))
 }

--- a/entc/integration/ent/comment/where.go
+++ b/entc/integration/ent/comment/where.go
@@ -368,32 +368,15 @@ func ClientContainsFold(v string) predicate.Comment {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Comment) predicate.Comment {
-	return predicate.Comment(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Comment(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Comment) predicate.Comment {
-	return predicate.Comment(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Comment(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Comment) predicate.Comment {
-	return predicate.Comment(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Comment(sql.NotPredicates(p))
 }

--- a/entc/integration/ent/exvaluescan/where.go
+++ b/entc/integration/ent/exvaluescan/where.go
@@ -932,32 +932,15 @@ func CustomOptionalContainsFold(v string) predicate.ExValueScan {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.ExValueScan) predicate.ExValueScan {
-	return predicate.ExValueScan(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.ExValueScan(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.ExValueScan) predicate.ExValueScan {
-	return predicate.ExValueScan(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.ExValueScan(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.ExValueScan) predicate.ExValueScan {
-	return predicate.ExValueScan(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.ExValueScan(sql.NotPredicates(p))
 }

--- a/entc/integration/ent/fieldtype/where.go
+++ b/entc/integration/ent/fieldtype/where.go
@@ -3801,32 +3801,15 @@ func PasswordOtherNotNil() predicate.FieldType {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.FieldType) predicate.FieldType {
-	return predicate.FieldType(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.FieldType(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.FieldType) predicate.FieldType {
-	return predicate.FieldType(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.FieldType(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.FieldType) predicate.FieldType {
-	return predicate.FieldType(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.FieldType(sql.NotPredicates(p))
 }

--- a/entc/integration/ent/file/where.go
+++ b/entc/integration/ent/file/where.go
@@ -478,32 +478,15 @@ func HasFieldWith(preds ...predicate.FieldType) predicate.File {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.File) predicate.File {
-	return predicate.File(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.File(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.File) predicate.File {
-	return predicate.File(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.File(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.File) predicate.File {
-	return predicate.File(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.File(sql.NotPredicates(p))
 }

--- a/entc/integration/ent/filetype/where.go
+++ b/entc/integration/ent/filetype/where.go
@@ -192,32 +192,15 @@ func HasFilesWith(preds ...predicate.File) predicate.FileType {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.FileType) predicate.FileType {
-	return predicate.FileType(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.FileType(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.FileType) predicate.FileType {
-	return predicate.FileType(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.FileType(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.FileType) predicate.FileType {
-	return predicate.FileType(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.FileType(sql.NotPredicates(p))
 }

--- a/entc/integration/ent/goods/where.go
+++ b/entc/integration/ent/goods/where.go
@@ -58,32 +58,15 @@ func IDLTE(id int) predicate.Goods {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Goods) predicate.Goods {
-	return predicate.Goods(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Goods(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Goods) predicate.Goods {
-	return predicate.Goods(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Goods(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Goods) predicate.Goods {
-	return predicate.Goods(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Goods(sql.NotPredicates(p))
 }

--- a/entc/integration/ent/group/where.go
+++ b/entc/integration/ent/group/where.go
@@ -418,32 +418,15 @@ func HasInfoWith(preds ...predicate.GroupInfo) predicate.Group {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Group(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Group(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Group(sql.NotPredicates(p))
 }

--- a/entc/integration/ent/groupinfo/where.go
+++ b/entc/integration/ent/groupinfo/where.go
@@ -197,32 +197,15 @@ func HasGroupsWith(preds ...predicate.Group) predicate.GroupInfo {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.GroupInfo) predicate.GroupInfo {
-	return predicate.GroupInfo(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.GroupInfo(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.GroupInfo) predicate.GroupInfo {
-	return predicate.GroupInfo(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.GroupInfo(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.GroupInfo) predicate.GroupInfo {
-	return predicate.GroupInfo(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.GroupInfo(sql.NotPredicates(p))
 }

--- a/entc/integration/ent/item/where.go
+++ b/entc/integration/ent/item/where.go
@@ -148,32 +148,15 @@ func TextContainsFold(v string) predicate.Item {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Item) predicate.Item {
-	return predicate.Item(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Item(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Item) predicate.Item {
-	return predicate.Item(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Item(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Item) predicate.Item {
-	return predicate.Item(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Item(sql.NotPredicates(p))
 }

--- a/entc/integration/ent/license/where.go
+++ b/entc/integration/ent/license/where.go
@@ -150,32 +150,15 @@ func UpdateTimeLTE(v time.Time) predicate.License {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.License) predicate.License {
-	return predicate.License(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.License(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.License) predicate.License {
-	return predicate.License(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.License(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.License) predicate.License {
-	return predicate.License(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.License(sql.NotPredicates(p))
 }

--- a/entc/integration/ent/node/where.go
+++ b/entc/integration/ent/node/where.go
@@ -217,32 +217,15 @@ func HasNextWith(preds ...predicate.Node) predicate.Node {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Node) predicate.Node {
-	return predicate.Node(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Node(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Node) predicate.Node {
-	return predicate.Node(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Node(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Node) predicate.Node {
-	return predicate.Node(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Node(sql.NotPredicates(p))
 }

--- a/entc/integration/ent/pc/where.go
+++ b/entc/integration/ent/pc/where.go
@@ -58,32 +58,15 @@ func IDLTE(id int) predicate.PC {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.PC) predicate.PC {
-	return predicate.PC(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.PC(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.PC) predicate.PC {
-	return predicate.PC(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.PC(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.PC) predicate.PC {
-	return predicate.PC(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.PC(sql.NotPredicates(p))
 }

--- a/entc/integration/ent/pet/where.go
+++ b/entc/integration/ent/pet/where.go
@@ -371,32 +371,15 @@ func HasOwnerWith(preds ...predicate.User) predicate.Pet {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Pet(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Pet(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Pet(sql.NotPredicates(p))
 }

--- a/entc/integration/ent/spec/where.go
+++ b/entc/integration/ent/spec/where.go
@@ -82,32 +82,15 @@ func HasCardWith(preds ...predicate.Card) predicate.Spec {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Spec) predicate.Spec {
-	return predicate.Spec(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Spec(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Spec) predicate.Spec {
-	return predicate.Spec(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Spec(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Spec) predicate.Spec {
-	return predicate.Spec(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Spec(sql.NotPredicates(p))
 }

--- a/entc/integration/ent/task/where.go
+++ b/entc/integration/ent/task/where.go
@@ -511,32 +511,15 @@ func OpContainsFold(v string) predicate.Task {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Task) predicate.Task {
-	return predicate.Task(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Task(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Task) predicate.Task {
-	return predicate.Task(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Task(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Task) predicate.Task {
-	return predicate.Task(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Task(sql.NotPredicates(p))
 }

--- a/entc/integration/ent/user/where.go
+++ b/entc/integration/ent/user/where.go
@@ -1047,32 +1047,15 @@ func HasParentWith(preds ...predicate.User) predicate.User {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.User(sql.NotPredicates(p))
 }

--- a/entc/integration/hooks/ent/card/where.go
+++ b/entc/integration/hooks/ent/card/where.go
@@ -404,32 +404,15 @@ func HasOwnerWith(preds ...predicate.User) predicate.Card {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Card) predicate.Card {
-	return predicate.Card(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Card(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Card) predicate.Card {
-	return predicate.Card(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Card(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Card) predicate.Card {
-	return predicate.Card(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Card(sql.NotPredicates(p))
 }

--- a/entc/integration/hooks/ent/pet/where.go
+++ b/entc/integration/hooks/ent/pet/where.go
@@ -219,32 +219,15 @@ func HasOwnerWith(preds ...predicate.User) predicate.Pet {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Pet(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Pet(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Pet(sql.NotPredicates(p))
 }

--- a/entc/integration/hooks/ent/user/where.go
+++ b/entc/integration/hooks/ent/user/where.go
@@ -416,32 +416,15 @@ func HasBestFriendWith(preds ...predicate.User) predicate.User {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.User(sql.NotPredicates(p))
 }

--- a/entc/integration/idtype/ent/user/where.go
+++ b/entc/integration/idtype/ent/user/where.go
@@ -198,32 +198,15 @@ func HasFollowingWith(preds ...predicate.User) predicate.User {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.User(sql.NotPredicates(p))
 }

--- a/entc/integration/json/ent/user/where.go
+++ b/entc/integration/json/ent/user/where.go
@@ -178,32 +178,15 @@ func UnknownNotNil() predicate.User {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.User(sql.NotPredicates(p))
 }

--- a/entc/integration/migrate/entv1/car/where.go
+++ b/entc/integration/migrate/entv1/car/where.go
@@ -82,32 +82,15 @@ func HasOwnerWith(preds ...predicate.User) predicate.Car {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Car) predicate.Car {
-	return predicate.Car(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Car(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Car) predicate.Car {
-	return predicate.Car(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Car(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Car) predicate.Car {
-	return predicate.Car(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Car(sql.NotPredicates(p))
 }

--- a/entc/integration/migrate/entv1/conversion/where.go
+++ b/entc/integration/migrate/entv1/conversion/where.go
@@ -578,32 +578,15 @@ func Uint64ToStringNotNil() predicate.Conversion {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Conversion) predicate.Conversion {
-	return predicate.Conversion(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Conversion(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Conversion) predicate.Conversion {
-	return predicate.Conversion(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Conversion(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Conversion) predicate.Conversion {
-	return predicate.Conversion(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Conversion(sql.NotPredicates(p))
 }

--- a/entc/integration/migrate/entv1/customtype/where.go
+++ b/entc/integration/migrate/entv1/customtype/where.go
@@ -138,32 +138,15 @@ func CustomContainsFold(v string) predicate.CustomType {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.CustomType) predicate.CustomType {
-	return predicate.CustomType(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.CustomType(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.CustomType) predicate.CustomType {
-	return predicate.CustomType(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.CustomType(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.CustomType) predicate.CustomType {
-	return predicate.CustomType(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.CustomType(sql.NotPredicates(p))
 }

--- a/entc/integration/migrate/entv1/user/where.go
+++ b/entc/integration/migrate/entv1/user/where.go
@@ -971,32 +971,15 @@ func HasCarWith(preds ...predicate.Car) predicate.User {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.User(sql.NotPredicates(p))
 }

--- a/entc/integration/migrate/entv2/blog/where.go
+++ b/entc/integration/migrate/entv2/blog/where.go
@@ -127,32 +127,15 @@ func HasAdminsWith(preds ...predicate.User) predicate.Blog {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Blog) predicate.Blog {
-	return predicate.Blog(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Blog(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Blog) predicate.Blog {
-	return predicate.Blog(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Blog(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Blog) predicate.Blog {
-	return predicate.Blog(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Blog(sql.NotPredicates(p))
 }

--- a/entc/integration/migrate/entv2/car/where.go
+++ b/entc/integration/migrate/entv2/car/where.go
@@ -162,32 +162,15 @@ func HasOwnerWith(preds ...predicate.User) predicate.Car {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Car) predicate.Car {
-	return predicate.Car(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Car(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Car) predicate.Car {
-	return predicate.Car(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Car(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Car) predicate.Car {
-	return predicate.Car(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Car(sql.NotPredicates(p))
 }

--- a/entc/integration/migrate/entv2/conversion/where.go
+++ b/entc/integration/migrate/entv2/conversion/where.go
@@ -778,32 +778,15 @@ func Uint64ToStringContainsFold(v string) predicate.Conversion {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Conversion) predicate.Conversion {
-	return predicate.Conversion(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Conversion(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Conversion) predicate.Conversion {
-	return predicate.Conversion(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Conversion(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Conversion) predicate.Conversion {
-	return predicate.Conversion(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Conversion(sql.NotPredicates(p))
 }

--- a/entc/integration/migrate/entv2/customtype/where.go
+++ b/entc/integration/migrate/entv2/customtype/where.go
@@ -250,32 +250,15 @@ func Tz3NotNil() predicate.CustomType {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.CustomType) predicate.CustomType {
-	return predicate.CustomType(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.CustomType(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.CustomType) predicate.CustomType {
-	return predicate.CustomType(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.CustomType(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.CustomType) predicate.CustomType {
-	return predicate.CustomType(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.CustomType(sql.NotPredicates(p))
 }

--- a/entc/integration/migrate/entv2/group/where.go
+++ b/entc/integration/migrate/entv2/group/where.go
@@ -58,32 +58,15 @@ func IDLTE(id int) predicate.Group {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Group(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Group(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Group(sql.NotPredicates(p))
 }

--- a/entc/integration/migrate/entv2/media/where.go
+++ b/entc/integration/migrate/entv2/media/where.go
@@ -298,32 +298,15 @@ func TextContainsFold(v string) predicate.Media {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Media) predicate.Media {
-	return predicate.Media(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Media(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Media) predicate.Media {
-	return predicate.Media(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Media(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Media) predicate.Media {
-	return predicate.Media(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Media(sql.NotPredicates(p))
 }

--- a/entc/integration/migrate/entv2/pet/where.go
+++ b/entc/integration/migrate/entv2/pet/where.go
@@ -162,32 +162,15 @@ func HasOwnerWith(preds ...predicate.User) predicate.Pet {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Pet(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Pet(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Pet(sql.NotPredicates(p))
 }

--- a/entc/integration/migrate/entv2/user/where.go
+++ b/entc/integration/migrate/entv2/user/where.go
@@ -1325,32 +1325,15 @@ func HasFriendsWith(preds ...predicate.User) predicate.User {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.User(sql.NotPredicates(p))
 }

--- a/entc/integration/migrate/entv2/zoo/where.go
+++ b/entc/integration/migrate/entv2/zoo/where.go
@@ -58,32 +58,15 @@ func IDLTE(id int) predicate.Zoo {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Zoo) predicate.Zoo {
-	return predicate.Zoo(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Zoo(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Zoo) predicate.Zoo {
-	return predicate.Zoo(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Zoo(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Zoo) predicate.Zoo {
-	return predicate.Zoo(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Zoo(sql.NotPredicates(p))
 }

--- a/entc/integration/migrate/versioned/group/where.go
+++ b/entc/integration/migrate/versioned/group/where.go
@@ -128,32 +128,15 @@ func NameContainsFold(v string) predicate.Group {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Group(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Group(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Group(sql.NotPredicates(p))
 }

--- a/entc/integration/migrate/versioned/user/where.go
+++ b/entc/integration/migrate/versioned/user/where.go
@@ -253,32 +253,15 @@ func AddressContainsFold(v string) predicate.User {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.User(sql.NotPredicates(p))
 }

--- a/entc/integration/multischema/ent/friendship/where.go
+++ b/entc/integration/multischema/ent/friendship/where.go
@@ -260,32 +260,15 @@ func HasFriendWith(preds ...predicate.User) predicate.Friendship {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Friendship) predicate.Friendship {
-	return predicate.Friendship(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Friendship(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Friendship) predicate.Friendship {
-	return predicate.Friendship(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Friendship(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Friendship) predicate.Friendship {
-	return predicate.Friendship(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Friendship(sql.NotPredicates(p))
 }

--- a/entc/integration/multischema/ent/group/where.go
+++ b/entc/integration/multischema/ent/group/where.go
@@ -159,32 +159,15 @@ func HasUsersWith(preds ...predicate.User) predicate.Group {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Group(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Group(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Group(sql.NotPredicates(p))
 }

--- a/entc/integration/multischema/ent/pet/where.go
+++ b/entc/integration/multischema/ent/pet/where.go
@@ -194,32 +194,15 @@ func HasOwnerWith(preds ...predicate.User) predicate.Pet {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Pet(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Pet(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Pet(sql.NotPredicates(p))
 }

--- a/entc/integration/multischema/ent/user/where.go
+++ b/entc/integration/multischema/ent/user/where.go
@@ -246,32 +246,15 @@ func HasFriendshipsWith(preds ...predicate.Friendship) predicate.User {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.User(sql.NotPredicates(p))
 }

--- a/entc/integration/privacy/ent/task/where.go
+++ b/entc/integration/privacy/ent/task/where.go
@@ -331,32 +331,15 @@ func HasOwnerWith(preds ...predicate.User) predicate.Task {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Task) predicate.Task {
-	return predicate.Task(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Task(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Task) predicate.Task {
-	return predicate.Task(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Task(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Task) predicate.Task {
-	return predicate.Task(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Task(sql.NotPredicates(p))
 }

--- a/entc/integration/privacy/ent/team/where.go
+++ b/entc/integration/privacy/ent/team/where.go
@@ -175,32 +175,15 @@ func HasUsersWith(preds ...predicate.User) predicate.Team {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Team) predicate.Team {
-	return predicate.Team(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Team(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Team) predicate.Team {
-	return predicate.Team(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Team(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Team) predicate.Team {
-	return predicate.Team(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Team(sql.NotPredicates(p))
 }

--- a/entc/integration/privacy/ent/user/where.go
+++ b/entc/integration/privacy/ent/user/where.go
@@ -230,32 +230,15 @@ func HasTasksWith(preds ...predicate.Task) predicate.User {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.User(sql.NotPredicates(p))
 }

--- a/entc/integration/template/ent/group/where.go
+++ b/entc/integration/template/ent/group/where.go
@@ -103,32 +103,15 @@ func MaxUsersLTE(v int) predicate.Group {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Group(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Group(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Group(sql.NotPredicates(p))
 }

--- a/entc/integration/template/ent/pet/where.go
+++ b/entc/integration/template/ent/pet/where.go
@@ -184,32 +184,15 @@ func HasOwnerWith(preds ...predicate.User) predicate.Pet {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Pet(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Pet(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Pet(sql.NotPredicates(p))
 }

--- a/entc/integration/template/ent/user/where.go
+++ b/entc/integration/template/ent/user/where.go
@@ -175,34 +175,17 @@ func HasFriendsWith(preds ...predicate.User) predicate.User {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.User(sql.NotPredicates(p))
 }
 
 // NameGlob applies the Glob predicate on the "name" field.

--- a/examples/edgeindex/ent/city/where.go
+++ b/examples/edgeindex/ent/city/where.go
@@ -152,32 +152,15 @@ func HasStreetsWith(preds ...predicate.Street) predicate.City {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.City) predicate.City {
-	return predicate.City(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.City(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.City) predicate.City {
-	return predicate.City(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.City(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.City) predicate.City {
-	return predicate.City(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.City(sql.NotPredicates(p))
 }

--- a/examples/edgeindex/ent/street/where.go
+++ b/examples/edgeindex/ent/street/where.go
@@ -152,32 +152,15 @@ func HasCityWith(preds ...predicate.City) predicate.Street {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Street) predicate.Street {
-	return predicate.Street(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Street(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Street) predicate.Street {
-	return predicate.Street(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Street(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Street) predicate.Street {
-	return predicate.Street(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Street(sql.NotPredicates(p))
 }

--- a/examples/encryptfield/ent/user/where.go
+++ b/examples/encryptfield/ent/user/where.go
@@ -208,32 +208,15 @@ func NicknameContainsFold(v string) predicate.User {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.User(sql.NotPredicates(p))
 }

--- a/examples/entcpkg/ent/user/where.go
+++ b/examples/entcpkg/ent/user/where.go
@@ -193,32 +193,15 @@ func AgeNotNil() predicate.User {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.User(sql.NotPredicates(p))
 }

--- a/examples/fs/ent/file/where.go
+++ b/examples/fs/ent/file/where.go
@@ -225,32 +225,15 @@ func HasChildrenWith(preds ...predicate.File) predicate.File {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.File) predicate.File {
-	return predicate.File(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.File(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.File) predicate.File {
-	return predicate.File(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.File(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.File) predicate.File {
-	return predicate.File(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.File(sql.NotPredicates(p))
 }

--- a/examples/jsonencode/ent/card/where.go
+++ b/examples/jsonencode/ent/card/where.go
@@ -128,32 +128,15 @@ func NumberContainsFold(v string) predicate.Card {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Card) predicate.Card {
-	return predicate.Card(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Card(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Card) predicate.Card {
-	return predicate.Card(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Card(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Card) predicate.Card {
-	return predicate.Card(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Card(sql.NotPredicates(p))
 }

--- a/examples/jsonencode/ent/pet/where.go
+++ b/examples/jsonencode/ent/pet/where.go
@@ -222,32 +222,15 @@ func HasOwnerWith(preds ...predicate.User) predicate.Pet {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Pet(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Pet(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Pet(sql.NotPredicates(p))
 }

--- a/examples/jsonencode/ent/user/where.go
+++ b/examples/jsonencode/ent/user/where.go
@@ -197,32 +197,15 @@ func HasPetsWith(preds ...predicate.Pet) predicate.User {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.User(sql.NotPredicates(p))
 }

--- a/examples/m2m2types/ent/group/where.go
+++ b/examples/m2m2types/ent/group/where.go
@@ -152,32 +152,15 @@ func HasUsersWith(preds ...predicate.User) predicate.Group {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Group(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Group(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Group(sql.NotPredicates(p))
 }

--- a/examples/m2m2types/ent/user/where.go
+++ b/examples/m2m2types/ent/user/where.go
@@ -197,32 +197,15 @@ func HasGroupsWith(preds ...predicate.Group) predicate.User {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.User(sql.NotPredicates(p))
 }

--- a/examples/m2mbidi/ent/user/where.go
+++ b/examples/m2mbidi/ent/user/where.go
@@ -197,32 +197,15 @@ func HasFriendsWith(preds ...predicate.User) predicate.User {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.User(sql.NotPredicates(p))
 }

--- a/examples/m2mrecur/ent/user/where.go
+++ b/examples/m2mrecur/ent/user/where.go
@@ -220,32 +220,15 @@ func HasFollowingWith(preds ...predicate.User) predicate.User {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.User(sql.NotPredicates(p))
 }

--- a/examples/migration/ent/card/where.go
+++ b/examples/migration/ent/card/where.go
@@ -107,32 +107,15 @@ func HasOwnerWith(preds ...predicate.User) predicate.Card {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Card) predicate.Card {
-	return predicate.Card(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Card(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Card) predicate.Card {
-	return predicate.Card(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Card(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Card) predicate.Card {
-	return predicate.Card(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Card(sql.NotPredicates(p))
 }

--- a/examples/migration/ent/pet/where.go
+++ b/examples/migration/ent/pet/where.go
@@ -156,32 +156,15 @@ func HasOwnerWith(preds ...predicate.User) predicate.Pet {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Pet(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Pet(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Pet(sql.NotPredicates(p))
 }

--- a/examples/migration/ent/user/where.go
+++ b/examples/migration/ent/user/where.go
@@ -207,32 +207,15 @@ func HasCardsWith(preds ...predicate.Card) predicate.User {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.User(sql.NotPredicates(p))
 }

--- a/examples/o2m2types/ent/pet/where.go
+++ b/examples/o2m2types/ent/pet/where.go
@@ -152,32 +152,15 @@ func HasOwnerWith(preds ...predicate.User) predicate.Pet {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Pet(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Pet(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Pet(sql.NotPredicates(p))
 }

--- a/examples/o2m2types/ent/user/where.go
+++ b/examples/o2m2types/ent/user/where.go
@@ -197,32 +197,15 @@ func HasPetsWith(preds ...predicate.Pet) predicate.User {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.User(sql.NotPredicates(p))
 }

--- a/examples/o2mrecur/ent/node/where.go
+++ b/examples/o2mrecur/ent/node/where.go
@@ -185,32 +185,15 @@ func HasChildrenWith(preds ...predicate.Node) predicate.Node {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Node) predicate.Node {
-	return predicate.Node(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Node(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Node) predicate.Node {
-	return predicate.Node(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Node(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Node) predicate.Node {
-	return predicate.Node(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Node(sql.NotPredicates(p))
 }

--- a/examples/o2o2types/ent/card/where.go
+++ b/examples/o2o2types/ent/card/where.go
@@ -199,32 +199,15 @@ func HasOwnerWith(preds ...predicate.User) predicate.Card {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Card) predicate.Card {
-	return predicate.Card(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Card(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Card) predicate.Card {
-	return predicate.Card(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Card(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Card) predicate.Card {
-	return predicate.Card(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Card(sql.NotPredicates(p))
 }

--- a/examples/o2o2types/ent/user/where.go
+++ b/examples/o2o2types/ent/user/where.go
@@ -197,32 +197,15 @@ func HasCardWith(preds ...predicate.Card) predicate.User {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.User(sql.NotPredicates(p))
 }

--- a/examples/o2obidi/ent/user/where.go
+++ b/examples/o2obidi/ent/user/where.go
@@ -197,32 +197,15 @@ func HasSpouseWith(preds ...predicate.User) predicate.User {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.User(sql.NotPredicates(p))
 }

--- a/examples/o2orecur/ent/node/where.go
+++ b/examples/o2orecur/ent/node/where.go
@@ -185,32 +185,15 @@ func HasNextWith(preds ...predicate.Node) predicate.Node {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Node) predicate.Node {
-	return predicate.Node(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Node(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Node) predicate.Node {
-	return predicate.Node(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Node(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Node) predicate.Node {
-	return predicate.Node(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Node(sql.NotPredicates(p))
 }

--- a/examples/privacyadmin/ent/user/where.go
+++ b/examples/privacyadmin/ent/user/where.go
@@ -128,32 +128,15 @@ func NameContainsFold(v string) predicate.User {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.User(sql.NotPredicates(p))
 }

--- a/examples/privacytenant/ent/group/where.go
+++ b/examples/privacytenant/ent/group/where.go
@@ -200,32 +200,15 @@ func HasUsersWith(preds ...predicate.User) predicate.Group {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Group(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Group(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Group(sql.NotPredicates(p))
 }

--- a/examples/privacytenant/ent/tenant/where.go
+++ b/examples/privacytenant/ent/tenant/where.go
@@ -128,32 +128,15 @@ func NameContainsFold(v string) predicate.Tenant {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Tenant) predicate.Tenant {
-	return predicate.Tenant(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Tenant(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Tenant) predicate.Tenant {
-	return predicate.Tenant(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Tenant(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Tenant) predicate.Tenant {
-	return predicate.Tenant(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Tenant(sql.NotPredicates(p))
 }

--- a/examples/privacytenant/ent/user/where.go
+++ b/examples/privacytenant/ent/user/where.go
@@ -210,32 +210,15 @@ func HasGroupsWith(preds ...predicate.Group) predicate.User {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.User(sql.NotPredicates(p))
 }

--- a/examples/start/ent/car/where.go
+++ b/examples/start/ent/car/where.go
@@ -199,32 +199,15 @@ func HasOwnerWith(preds ...predicate.User) predicate.Car {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Car) predicate.Car {
-	return predicate.Car(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Car(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Car) predicate.Car {
-	return predicate.Car(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Car(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Car) predicate.Car {
-	return predicate.Car(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Car(sql.NotPredicates(p))
 }

--- a/examples/start/ent/group/where.go
+++ b/examples/start/ent/group/where.go
@@ -152,32 +152,15 @@ func HasUsersWith(preds ...predicate.User) predicate.Group {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Group(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Group(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Group(sql.NotPredicates(p))
 }

--- a/examples/start/ent/user/where.go
+++ b/examples/start/ent/user/where.go
@@ -220,32 +220,15 @@ func HasGroupsWith(preds ...predicate.Group) predicate.User {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.User(sql.NotPredicates(p))
 }

--- a/examples/traversal/ent/group/where.go
+++ b/examples/traversal/ent/group/where.go
@@ -175,32 +175,15 @@ func HasAdminWith(preds ...predicate.User) predicate.Group {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Group(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Group(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Group) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Group(sql.NotPredicates(p))
 }

--- a/examples/traversal/ent/pet/where.go
+++ b/examples/traversal/ent/pet/where.go
@@ -175,32 +175,15 @@ func HasOwnerWith(preds ...predicate.User) predicate.Pet {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Pet(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.Pet(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.Pet) predicate.Pet {
-	return predicate.Pet(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.Pet(sql.NotPredicates(p))
 }

--- a/examples/traversal/ent/user/where.go
+++ b/examples/traversal/ent/user/where.go
@@ -266,32 +266,15 @@ func HasManageWith(preds ...predicate.Group) predicate.User {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.User(sql.NotPredicates(p))
 }

--- a/examples/version/ent/user/where.go
+++ b/examples/version/ent/user/where.go
@@ -123,32 +123,15 @@ func StatusNotIn(vs ...Status) predicate.User {
 
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for _, p := range predicates {
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.AndPredicates(predicates...))
 }
 
 // Or groups predicates with the OR operator between them.
 func Or(predicates ...predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		s1 := s.Clone().SetP(nil)
-		for i, p := range predicates {
-			if i > 0 {
-				s1.Or()
-			}
-			p(s1)
-		}
-		s.Where(s1.P())
-	})
+	return predicate.User(sql.OrPredicates(predicates...))
 }
 
 // Not applies the not operator on the given predicate.
 func Not(p predicate.User) predicate.User {
-	return predicate.User(func(s *sql.Selector) {
-		p(s.Not())
-	})
+	return predicate.User(sql.NotPredicates(p))
 }


### PR DESCRIPTION
This allows custom predicates mutating the root querying and still respect the AND/OR/NOT semantics