### PR TITLE
doc/md: fix edge.Annotations method name typo

### DIFF
--- a/doc/md/tutorial-todo-gql-paginate.md
+++ b/doc/md/tutorial-todo-gql-paginate.md
@@ -220,7 +220,7 @@ func (Todo) Edges() []ent.Edge {
 			edge.To("parent", Todo.Type).
 				Unique().
 				From("children").
-				Annotation(entgql.RelayConnection()),
+				Annotations(entgql.RelayConnection()),
 	}
 }
 ```

--- a/doc/md/tutorial-todo-gql-schema-generator.md
+++ b/doc/md/tutorial-todo-gql-schema-generator.md
@@ -68,7 +68,7 @@ func (Todo) Edges() []ent.Edge {
 		edge.To("parent", Todo.Type).
 			Unique().
 			From("children").
-			Annotation(entgql.RelayConnection()),
+			Annotations(entgql.RelayConnection()),
 	}
 }
 ```

--- a/doc/website/blog/2021-11-15-announcing-entoas.md
+++ b/doc/website/blog/2021-11-15-announcing-entoas.md
@@ -253,7 +253,7 @@ func (Fridge) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.To("compartments", Compartment.Type).
 			// Do not generate an endpoint for POST /fridges/{id}/compartments
-			Annotation(
+			Annotations(
 				entoas.CreateOperation(
 					entoas.OperationPolicy(entoas.PolicyExclude),
 				),


### PR DESCRIPTION
Fix from `Annotation()` to `Annotations()` as the correct edge.assocBuilder method name.