### PR TITLE
Postgres: shorten index name by symbol function

### DIFF
--- a/dialect/sql/schema/atlas.go
+++ b/dialect/sql/schema/atlas.go
@@ -1086,7 +1086,7 @@ func (a *Atlas) entDialect(ctx context.Context, drv dialect.Driver) (sqlDialect,
 	case dialect.SQLite:
 		d = &SQLite{Driver: drv, WithForeignKeys: a.withForeignKeys}
 	case dialect.Postgres:
-		d = &Postgres{Driver: drv}
+		d = &Postgres{Driver: drv, symbolFunc: a.symbol}
 	default:
 		return nil, fmt.Errorf("sql/schema: unsupported dialect %q", a.dialect)
 	}

--- a/dialect/sql/schema/postgres.go
+++ b/dialect/sql/schema/postgres.go
@@ -24,8 +24,9 @@ import (
 // Postgres is a postgres migration driver.
 type Postgres struct {
 	dialect.Driver
-	schema  string
-	version string
+	schema     string
+	version    string
+	symbolFunc func(string) string
 }
 
 // init loads the Postgres version from the database for later use in the migration process.
@@ -757,7 +758,11 @@ func (d *Postgres) atUniqueC(t1 *Table, c1 *Column, t2 *schema.Table, c2 *schema
 			return
 		}
 	}
-	t2.AddIndexes(schema.NewUniqueIndex(fmt.Sprintf("%s_%s_key", t1.Name, c1.Name)).AddColumns(c2))
+	idxName := fmt.Sprintf("%s_%s_key", t1.Name, c1.Name)
+	if d.symbolFunc != nil {
+		idxName = d.symbolFunc(idxName)
+	}
+	t2.AddIndexes(schema.NewUniqueIndex(idxName).AddColumns(c2))
 }
 
 func (d *Postgres) atImplicitIndexName(idx *Index, t1 *Table, c1 *Column) bool {


### PR DESCRIPTION
## WHAT

Shorten unique index name by using `symbol` function

### Background

When there is too long name column with unique constraint and enabled Atlas migration(not legacy), ent try to make the index name of `<table>_<column>_key`.
Since Postgres will truncate last N chars to fit the limit of length internally but ent doesn't know which behavior, 2nd time of migration will be failed by `ERROR: relation "INDEX_NAME" already exists (SQLSTATE 42P07)`.

This PR truncate extra last characters from index name of unique column by using implemented [symbol](https://github.com/ent/ent/blob/master/dialect/sql/schema/atlas.go#L1069) function.

### How to reproduce

The most easiest way is adding unique column which name is near 63 chars(but not over) with enabling Atlas migration
```go
package schema

import (
    "entgo.io/ent"
    "entgo.io/ent/schema/field"
)

type User struct {
    ent.Schema
}

func (User) Fields() []ent.Field {
    return []ent.Field{
        field.String("this_column_name_is_about_61_characters_xxxxxxxxxxxxxxxxxxxxx").Unique(),
        // "CREATE UNIQUE INDEX \"users_this_column_name_is_about_61_characters_xxxxxxxxxxxxxxxxxxxxx_key\" ON \"users\" (\"this_column_name_is_about_61_characters_xxxxxxxxxxxxxxxxxxxxx\");"
    }
}

/*
test=# CREATE TABLE "users" ("id" bigint NOT NULL GENERATED BY DEFAULT AS IDENTITY, "this_column_name_is_about_61_characters_xxxxxxxxxxxxxxxxxxxxx" character varying NOT NULL, PRIMARY KEY ("id"));
CREATE TABLE
test=# CREATE UNIQUE INDEX "users_this_column_name_is_about_61_characters_xxxxxxxxxxxxxxxxxxxxx_key" ON "users" ("this_column_name_is_about_61_characters_xxxxxxxxxxxxxxxxxxxxx");
NOTICE:  identifier "users_this_column_name_is_about_61_characters_xxxxxxxxxxxxxxxxxxxxx_key" will be truncated to "users_this_column_name_is_about_61_characters_xxxxxxxxxxxxxxxxx"
CREATE INDEX
test=# \d users;
                                                            Table "public.users"
                            Column                             |       Type        | Collation | Nullable |             Default
---------------------------------------------------------------+-------------------+-----------+----------+----------------------------------
 id                                                            | bigint            |           | not null | generated by default as identity
 this_column_name_is_about_61_characters_xxxxxxxxxxxxxxxxxxxxx | character varying |           | not null |
Indexes:
    "users_pkey" PRIMARY KEY, btree (id)
    "users_this_column_name_is_about_61_characters_xxxxxxxxxxxxxxxxx" UNIQUE, btree (this_column_name_is_about_61_characters_xxxxxxxxxxxxxxxxxxxxx)
*/
```

## WHY

Solve the duplicate relation error.
