### PR TITLE
Enhancing Performance by Adding Concurrency and Optional Features

### DIFF
--- a/cmd/internal/base/base.go
+++ b/cmd/internal/base/base.go
@@ -200,6 +200,8 @@ func GenerateCmd(postRun ...func(*gen.Config)) *cobra.Command {
 	cmd.Flags().StringVar(&storage, "storage", "sql", "storage driver to support in codegen")
 	cmd.Flags().StringVar(&cfg.Header, "header", "", "override codegen header")
 	cmd.Flags().StringVar(&cfg.Target, "target", "", "target directory for codegen")
+	cmd.Flags().BoolVar(&cfg.Format, "format", true, "format generated files")
+	cmd.Flags().BoolVar(&cfg.ConcurrentTemplateExecution, "concurrent-template-execution", false, "enable to improve generate speed if needed, can break certain custom templates")
 	cmd.Flags().StringSliceVarP(&features, "feature", "", nil, "extend codegen with additional features")
 	cmd.Flags().StringSliceVarP(&templates, "template", "", nil, "external templates to execute")
 	// The --idtype flag predates the field.<Type>("id") option.


### PR DESCRIPTION
This PR introduces several huge performance improvements to the code generation process. As my project size grew, the generation time has been found to scale linearly, resulting in less efficient generation for larger projects. These improvements should eliminate this issue and provide a faster generation.

## Key Changes:

1. **Concurrency in formatting:** The `assets.format` method, which was previously executing serially for all files, has been updated to process files concurrently, resulting in significant time savings. The execution time for a project with 50 nodes reduced from 9 seconds to approx 2.5 seconds.

2. **Optional Formatting:** A new flag named `format` has been introduced, which when toggled off, further optimizes the generation process by skipping the formatting, reducing the time taken for a 50 node project from 2.5 seconds to just 1 second. For frequent generations this saves time, since go fmt is only required when comitting changes.

3. **Concurrent Template Execution:** The template execution has been made concurrent, with an optional flag named `concurrent-template-execution`. This flag is `false` by default to prevent breaking anything if any template modifies code - which they hopefully don't and I am not 100% familar with the codebase. This furthed reduced the total execution time, down to 0.57 seconds for a 50 node project.

These changes have been tested in multiple personal projects. All project tests passed.

This PR does not include changes to documentation. However, comments have been added to the code to explain the changes and their purpose.

I look forward to hearing your thoughts and feedback on these improvements and if I need to do anything else or you take over my PR now.
