### PR TITLE
Feat: added nil checks to sqlgraph constraint errors

### DIFF
--- a/dialect/sql/sqlgraph/errors.go
+++ b/dialect/sql/sqlgraph/errors.go
@@ -21,7 +21,6 @@ func IsUniqueConstraintError(err error) bool {
 	if err == nil {
 		return false
 	}
-
 	for _, s := range []string{
 		"Error 1062",                 // MySQL
 		"violates unique constraint", // Postgres
@@ -40,7 +39,6 @@ func IsForeignKeyConstraintError(err error) bool {
 	if err == nil {
 		return false
 	}
-
 	for _, s := range []string{
 		"Error 1451",                      // MySQL (Cannot delete or update a parent row).
 		"Error 1452",                      // MySQL (Cannot add or update a child row).

--- a/dialect/sql/sqlgraph/errors.go
+++ b/dialect/sql/sqlgraph/errors.go
@@ -18,6 +18,10 @@ func IsConstraintError(err error) bool {
 // IsUniqueConstraintError reports if the error resulted from a DB uniqueness constraint violation.
 // e.g. duplicate value in unique index.
 func IsUniqueConstraintError(err error) bool {
+	if err == nil {
+		return false
+	}
+
 	for _, s := range []string{
 		"Error 1062",                 // MySQL
 		"violates unique constraint", // Postgres
@@ -33,6 +37,10 @@ func IsUniqueConstraintError(err error) bool {
 // IsForeignKeyConstraintError reports if the error resulted from a database foreign-key constraint violation.
 // e.g. parent row does not exist.
 func IsForeignKeyConstraintError(err error) bool {
+	if err == nil {
+		return false
+	}
+
 	for _, s := range []string{
 		"Error 1451",                      // MySQL (Cannot delete or update a parent row).
 		"Error 1452",                      // MySQL (Cannot add or update a child row).


### PR DESCRIPTION
Adding these checks makes sure that when the error is nil these do not panic because of a nil pointer exception.
It is just a minor thing but something that bugged me when using these functions.

The ```IsConstraintError``` does not need it due to the use of ```errors.As``` which has these same checks.