### PR TITLE
Support for NULLS FIRST/LAST in MySQL

### DIFF
--- a/dialect/sql/sql.go
+++ b/dialect/sql/sql.go
@@ -397,14 +397,31 @@ func OrderByRand() func(*Selector) {
 func (f *OrderFieldTerm) ToFunc() func(*Selector) {
 	return func(s *Selector) {
 		s.OrderExprFunc(func(b *Builder) {
-			b.WriteString(s.C(f.Field))
-			if f.Desc {
-				b.WriteString(" DESC")
-			}
-			if f.NullsFirst {
-				b.WriteString(" NULLS FIRST")
-			} else if f.NullsLast {
-				b.WriteString(" NULLS LAST")
+			if b.Dialect() == dialect.MySQL {
+				// MySQL does not support the NULLS FIRST/LAST functionality.
+				// In MySQL, ordering is represented in ascending order by default.
+				if f.NullsFirst {
+					// If 'f' is null, the result is 0; otherwise 1.
+					b.WriteString(s.C(f.Field)).WriteString(" IS NOT NULL").Comma()
+				}
+				if f.NullsLast {
+					// If 'f' is null, the result is 1; otherwise 0.
+					b.WriteString(s.C(f.Field)).WriteString(" IS NULL").Comma()
+				}
+				b.WriteString(s.C(f.Field))
+				if f.Desc {
+					b.WriteString(" DESC")
+				}
+			} else {
+				b.WriteString(s.C(f.Field))
+				if f.Desc {
+					b.WriteString(" DESC")
+				}
+				if f.NullsFirst {
+					b.WriteString(" NULLS FIRST")
+				} else if f.NullsLast {
+					b.WriteString(" NULLS LAST")
+				}
 			}
 		})
 	}

--- a/entc/integration/entql_test.go
+++ b/entc/integration/entql_test.go
@@ -8,13 +8,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/uuid"
-
+	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/entc/integration/ent"
+	"entgo.io/ent/entc/integration/ent/comment"
 	"entgo.io/ent/entc/integration/ent/pet"
 	"entgo.io/ent/entc/integration/ent/user"
 	"entgo.io/ent/entql"
-
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -94,4 +94,11 @@ func EntQL(t *testing.T, client *ent.Client) {
 	uq = uq.QueryFriends()
 	uq.Filter().WhereName(entql.StringEQ(nati.Name))
 	require.Equal(luna.ID, uq.QueryPets().OnlyIDX(ctx))
+
+	client.Comment.Create().SetUniqueInt(1).SetUniqueFloat(1.0).SaveX(ctx)
+	client.Comment.Create().SetUniqueInt(2).SetUniqueFloat(2.0).SetNillableInt(1).SaveX(ctx)
+
+	comments := client.Comment.Query().Order(comment.ByNillableInt(sql.OrderNullsFirst())).AllX(ctx)
+	require.True(comments[0].NillableInt == nil)
+	require.True(*comments[1].NillableInt == 1)
 }


### PR DESCRIPTION
Currently, MySQL cannot interpret the NULLS FIRST directive, leading to the following SQL syntax error:

```
You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'NULLS FIRST' at line 1
```

To address this, we've implemented an alternative method for MySQL. Instead of using NULLS FIRST, we convert the ordering logic to: `ORDER BY field IS NULL`  which essentially translates the sorting criteria into 0's and 1's.

This solution is expected to address the issue documented here: [Issue #3737](https://github.com/ent/ent/issues/3737).

For reference, here's an example of a test that was failing prior to this change: [Failed Test](https://github.com/yuki2006/ent/actions/runs/6170092579/job/16745671930).

