### PR TITLE
doc: Fix the MapCreate Bulk section in crud.mdx

### DIFF
--- a/doc/md/crud.mdx
+++ b/doc/md/crud.mdx
@@ -168,7 +168,7 @@ pets, err := client.Pet.CreateBulk(
 
 names := []string{"pedro", "xabi", "layla"}
 pets, err := client.Pet.MapCreateBulk(names, func(c *ent.PetCreate, i int) {
-    client.Pet.Create().SetName(names[i]).SetOwner(a8m)
+    c.SetName(names[i]).SetOwner(a8m)
 }).Save(ctx)
 ```
 


### PR DESCRIPTION
I think you should probably use the argument 'c' in this line: https://github.com/ent/ent/blob/797534a0d1ca64505deff92cff39418ca2f67eeb/entc/integration/integration_test.go#L2223.