### PR TITLE
dialect/sql/sqlgraph: allow OrderByField without aggregate function on OrderByNeighborTerms/O2M

### DIFF
--- a/dialect/sql/sqlgraph/graph.go
+++ b/dialect/sql/sqlgraph/graph.go
@@ -511,9 +511,13 @@ func OrderByNeighborTerms(q *sql.Selector, s *Step, opts ...sql.OrderTerm) {
 			On(q.C(s.From.Column), join.C(pk2))
 	case s.ToEdgeOwner():
 		toT := build.Table(s.Edge.Table).Schema(s.Edge.Schema)
+		var groupByColumns []string
+		for _, c := range s.Edge.Columns {
+			groupByColumns = append(groupByColumns, toT.C(c))
+		}
 		join = build.Select(toT.C(s.Edge.Columns[0])).
 			From(toT).
-			GroupBy(toT.C(s.Edge.Columns[0]))
+			GroupBy(groupByColumns...)
 		selectTerms(join, opts)
 		q.LeftJoin(join).
 			On(q.C(s.From.Column), join.C(s.Edge.Columns[0]))

--- a/entc/integration/integration_test.go
+++ b/entc/integration/integration_test.go
@@ -2777,6 +2777,21 @@ func OrderByEdgeTerms(t *testing.T, client *ent.Client) {
 			IDsX(ctx)
 		require.Equal(t, tt.ids, ids)
 	}
+	// O2M edge.
+	ids := client.User.Query().
+		Order(func(s *sql.Selector) {
+			sqlgraph.OrderByNeighborTerms(s,
+				sqlgraph.NewStep(
+					sqlgraph.From(user.Table, user.FieldID),
+					sqlgraph.To(pet.Table, pet.FieldID),
+					sqlgraph.Edge(sqlgraph.O2M, false, pet.Table, pet.OwnerColumn, pet.FieldAge),
+				),
+				sql.OrderByField(pet.FieldAge, sql.OrderDesc()),
+			)
+		}).
+		Order(ent.Asc(user.FieldID)).
+		IDsX(ctx)
+	require.Equal(t, []int{users[2].ID, users[1].ID, users[0].ID, users[3].ID}, ids)
 	// O2M edge (aggregation).
 	for _, tt := range []struct {
 		opt sql.OrderTerm


### PR DESCRIPTION
This allows for a fix to #3722

```go
client.Card.Query().Order(func(s *sql.Selector) {
	sqlgraph.OrderByNeighborTerms(s,
		sqlgraph.NewStep(
			sqlgraph.From(card.Table, card.FieldID),
			sqlgraph.To(user.Table, user.FieldID),
			sqlgraph.Edge(
				sqlgraph.O2M,
				false,
				card.OwnerTable,
				card.OwnerColumn,
				card.FieldNumber, // <--- This PR adds support for this. 
			),
		),
		sql.OrderByField(card.FieldNumber, sql.OrderDesc()),
	)
}).IDsX(ctx)
```

Previous the query generated was:
```sql
SELECT "cards"."id" FROM "cards" LEFT JOIN (SELECT "cards"."owner_id", "cards"."number" FROM "cards" GROUP BY "cards"."owner_id") AS "t1" ON "cards"."id" = "t1"."owner_id" ORDER BY "t1"."number" DESC NULLS LAST
```

Generating the error:
```
ERROR: column "cards.number" must appear in the GROUP BY clause or be used in an aggregate function (SQLSTATE 42803)
```

With this PR, the query generate is:
```sql
SELECT "cards"."id" FROM "cards" LEFT JOIN (SELECT "cards"."owner_id", "cards"."number" FROM "cards" GROUP BY "cards"."owner_id", "cards"."number") AS "t1" ON "cards"."id" = "t1"."owner_id" ORDER BY "t1"."number" DESC NULLS LAST
```

**This PR will not solve the problem when using `ByCardField` method, it only allows for possible fix using Ent constructors.**