### PR TITLE
dialect/sql: support auto_increment in cluster

### DIFF
--- a/dialect/sql/sqlgraph/graph.go
+++ b/dialect/sql/sqlgraph/graph.go
@@ -1637,13 +1637,38 @@ func (c *batchCreator) insertLastIDs(ctx context.Context, tx dialect.ExecQuerier
 		if err != nil {
 			return err
 		}
+
+		increment, err := getIncrement(ctx, tx)
+		if err != nil {
+			return err
+		}
+
 		// Assume the ID field is AUTO_INCREMENT
 		// if its type is numeric.
 		for i := 0; int64(i) < affected && i < len(c.Nodes); i++ {
-			c.Nodes[i].ID.Value = id + int64(i)
+			c.Nodes[i].ID.Value = id + int64(i*increment)
 		}
 	}
 	return nil
+}
+
+func getIncrement(ctx context.Context, tx dialect.ExecQuerier) (int, error) {
+	var rows sql.Rows
+	if err := tx.Query(ctx, "SELECT @@auto_increment_increment", []any{}, &rows); err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+
+	if !rows.Next() {
+		return 0, fmt.Errorf("no auto_increment_increment")
+	}
+
+	var increment int
+	if err := rows.Scan(&increment); err != nil {
+		return 0, err
+	}
+
+	return increment, nil
 }
 
 // rollback calls to tx.Rollback and wraps the given error with the rollback error if occurred.


### PR DESCRIPTION
When using Galera or other multi-master cluster support, AUTO_INCREMENT is not always guaranteed to be 1, which can result in incorrect computed IDs. This can be a significant issue in a clustered environment and may lead to unexpected Update and Delete operations.