### PR TITLE
typo fix for the simple cms entry

### DIFF
--- a/doc/website/blog/2023-02-23-simple-cms-with-ent.mdx
+++ b/doc/website/blog/2023-02-23-simple-cms-with-ent.mdx
@@ -159,7 +159,8 @@ func (Post) Fields() []ent.Field {
    }  
 }  
   
-// Edges of the Post.func (Post) Edges() []ent.Edge {  
+// Edges of the Post.
+func (Post) Edges() []ent.Edge {  
    return []ent.Edge{  
       edge.From("author", User.Type).  
          Unique().  


### PR DESCRIPTION
I'm fixing a typo fix described in the #3836

![image](https://github.com/ent/ent/assets/424073/db7164fd-c95d-4319-af61-fb7c74c1dc19)

Please check it out when you have some time. And thanks again for creating and maintaining this, hope to use this in the future and to follow up on helping in anything I can. 