### PR TITLE
fix: swap the order of handling order and pred  in the graph select func

### DIFF
--- a/dialect/sql/sqlgraph/graph.go
+++ b/dialect/sql/sqlgraph/graph.go
@@ -1034,11 +1034,11 @@ func (q *query) selector(ctx context.Context) (*sql.Selector, error) {
 		selector = q.From
 	}
 	selector.Select(selector.Columns(q.Node.Columns...)...)
-	if pred := q.Predicate; pred != nil {
-		pred(selector)
-	}
 	if order := q.Order; order != nil {
 		order(selector)
+	}
+	if pred := q.Predicate; pred != nil {
+		pred(selector)
 	}
 	if q.Offset != 0 {
 		// Limit is mandatory for the offset clause. We start


### PR DESCRIPTION
multi order may generate predicates, so running the order funcs first allows reusing aliases. 

If the predicates run first if there is a multiOrder field that generates it's own predicates, the predicates are unable to find the alias of the join and errors not finding the column on the table.


Related to: https://github.com/ent/contrib/pull/559