### PR TITLE
entc/gen: allow skipping of format step

### DIFF
--- a/entc/gen/feature.go
+++ b/entc/gen/feature.go
@@ -51,6 +51,14 @@ var (
 		Description: "NamedEdges provides an API for eager-loading edges with dynamic names",
 	}
 
+	// FeatureSkipFormat provides a feature-flag for skipping the format phase of code generation.
+	FeatureSkipFormat = Feature{
+		Name:        "skipformat",
+		Stage:       Experimental,
+		Default:     false,
+		Description: "SkipFormat allows you to skip the auto-formatting stage of code generation for development iteration speed",
+	}
+
 	// FeatureSnapshot stores a snapshot of ent/schema and auto-solve merge-conflict (issue #852).
 	FeatureSnapshot = Feature{
 		Name:        "schema/snapshot",
@@ -142,6 +150,7 @@ var (
 		FeatureNamedEdges,
 		FeatureSnapshot,
 		FeatureSchemaConfig,
+		FeatureSkipFormat,
 		FeatureLock,
 		FeatureModifier,
 		FeatureExecQuery,

--- a/entc/gen/graph.go
+++ b/entc/gen/graph.go
@@ -274,6 +274,10 @@ func generate(g *Graph) error {
 	// We can't run "imports" on files when the state is not completed.
 	// Because, "goimports" will drop undefined package. Therefore, it
 	// is suspended to the end of the writing.
+	skipFormat := g.Config.featureEnabled(FeatureSkipFormat)
+	if skipFormat {
+		return nil
+	}
 	return assets.format()
 }
 


### PR DESCRIPTION
In the development cycle, sometimes it is needed to run Ent generate multiple times in a row (such as when rebasing), and this can be quite costly in terms of time (in my case, on the order of minutes for each generation). A large amount of the time is just spent running `goimports` on all the files, so this feature allows the user to skip that step for the sake of time.

For my particular use case, we would just be running `goimports` later in a CI step required before merging, so it just moves it out of the critical path of development iteration and into the "ready to merge" phase.