### PR TITLE
dialect/sql/schema: Atlas cleanSchema should handle non-existent tables

### DIFF
--- a/dialect/sql/schema/atlas.go
+++ b/dialect/sql/schema/atlas.go
@@ -211,7 +211,7 @@ func (a *Atlas) cleanSchema(ctx context.Context, name string, err0 error) (err e
 	}
 	drop := make([]schema.Change, len(s.Tables))
 	for i, t := range s.Tables {
-		drop[i] = &schema.DropTable{T: t}
+		drop[i] = &schema.DropTable{T: t, Extra: []schema.Clause{&schema.IfExists{}}}
 	}
 	return a.atDriver.ApplyChanges(ctx, drop)
 }


### PR DESCRIPTION
sqlite fts5 virtual tables create additional tables that are automatically deleted when the virtual table is deleted.

This will cause "no such table" errors when trying to drop them when creating a new migration.