### PR TITLE
feat: do not add a group by clause to O2O-edges for order by neighbor…

### DIFF
--- a/dialect/sql/sqlgraph/graph.go
+++ b/dialect/sql/sqlgraph/graph.go
@@ -512,8 +512,10 @@ func OrderByNeighborTerms(q *sql.Selector, s *Step, opts ...sql.OrderTerm) {
 	case s.ToEdgeOwner():
 		toT := build.Table(s.Edge.Table).Schema(s.Edge.Schema)
 		join = build.Select(toT.C(s.Edge.Columns[0])).
-			From(toT).
-			GroupBy(toT.C(s.Edge.Columns[0]))
+			From(toT)
+		if s.Edge.Rel != O2O {
+			join = join.GroupBy(toT.C(s.Edge.Columns[0]))
+		}
 		selectTerms(join, opts)
 		q.LeftJoin(join).
 			On(q.C(s.From.Column), join.C(s.Edge.Columns[0]))
@@ -1153,8 +1155,8 @@ func (u *updater) nodes(ctx context.Context, drv dialect.Driver) (int, error) {
 		multiple   = hasExternalEdges(addEdges, clearEdges)
 		update     = u.builder.Update(u.Node.Table).Schema(u.Node.Schema)
 		selector   = u.builder.Select().
-				From(u.builder.Table(u.Node.Table).Schema(u.Node.Schema)).
-				WithContext(ctx)
+			From(u.builder.Table(u.Node.Table).Schema(u.Node.Schema)).
+			WithContext(ctx)
 	)
 	switch {
 	// In case it is not an edge schema, the id holds the PK of


### PR DESCRIPTION
… terms

this prevents issues with databases that require all selected terms be included in the group by clause. the group by clause is not required if the relationship is O2O, because only one row will be returned if we join on fks.