### PR TITLE
dialect/sql/sqlgraph: fix CreateBulk when Fields in BatchCreateSpec is empty

### DIFF
--- a/dialect/sql/sqlgraph/graph.go
+++ b/dialect/sql/sqlgraph/graph.go
@@ -1477,7 +1477,7 @@ func (c *batchCreator) nodes(ctx context.Context, drv dialect.Driver) error {
 			return fmt.Errorf("more than 1 table for batch insert: %q != %q", node.Table, c.Nodes[i-1].Table)
 		}
 		values[i] = make(map[string]driver.Value)
-		if node.ID != nil && node.ID.Value != nil {
+		if node.ID != nil && (node.ID.Value != nil || len(node.Fields) == 0) {
 			columns[node.ID.Column] = struct{}{}
 			values[i][node.ID.Column] = node.ID.Value
 		}

--- a/dialect/sql/sqlgraph/graph_test.go
+++ b/dialect/sql/sqlgraph/graph_test.go
@@ -1595,6 +1595,52 @@ func TestBatchCreate(t *testing.T) {
 			},
 		},
 		{
+			name: "empty fields",
+			spec: &BatchCreateSpec{
+				Nodes: []*CreateSpec{
+					{
+						Table:  "users",
+						ID:     &FieldSpec{Column: "id", Type: field.TypeInt},
+						Fields: []*FieldSpec{},
+						Edges: []*EdgeSpec{
+							{Rel: M2M, Inverse: true, Table: "group_users", Columns: []string{"group_id", "user_id"}, Target: &EdgeTarget{Nodes: []driver.Value{2}, IDSpec: &FieldSpec{Column: "id"}}},
+							{Rel: M2M, Table: "user_products", Columns: []string{"user_id", "product_id"}, Target: &EdgeTarget{Nodes: []driver.Value{2}, IDSpec: &FieldSpec{Column: "id"}}},
+							{Rel: M2M, Table: "user_friends", Bidi: true, Columns: []string{"user_id", "friend_id"}, Target: &EdgeTarget{IDSpec: &FieldSpec{Column: "id", Type: field.TypeInt}, Nodes: []driver.Value{2}}},
+						},
+					},
+					{
+						Table:  "users",
+						ID:     &FieldSpec{Column: "id", Type: field.TypeInt},
+						Fields: []*FieldSpec{},
+						Edges: []*EdgeSpec{
+							{Rel: M2M, Inverse: true, Table: "group_users", Columns: []string{"group_id", "user_id"}, Target: &EdgeTarget{Nodes: []driver.Value{2}, IDSpec: &FieldSpec{Column: "id"}}},
+							{Rel: M2M, Table: "user_products", Columns: []string{"user_id", "product_id"}, Target: &EdgeTarget{Nodes: []driver.Value{2}, IDSpec: &FieldSpec{Column: "id"}}},
+							{Rel: M2M, Table: "user_friends", Bidi: true, Columns: []string{"user_id", "friend_id"}, Target: &EdgeTarget{IDSpec: &FieldSpec{Column: "id", Type: field.TypeInt}, Nodes: []driver.Value{2}}},
+						},
+					},
+				},
+			},
+			expect: func(m sqlmock.Sqlmock) {
+				m.ExpectBegin()
+				// Insert nodes with FKs.
+				m.ExpectExec(escape("INSERT INTO `users` (`id`) VALUES (NULL), (NULL)")).
+					WillReturnResult(sqlmock.NewResult(10, 2))
+				// Insert M2M inverse-edges.
+				m.ExpectExec(escape("INSERT INTO `group_users` (`group_id`, `user_id`) VALUES (?, ?), (?, ?) ON DUPLICATE KEY UPDATE `group_id` = `group_users`.`group_id`, `user_id` = `group_users`.`user_id`")).
+					WithArgs(2, 10, 2, 11).
+					WillReturnResult(sqlmock.NewResult(2, 2))
+				// Insert M2M bidirectional edges.
+				m.ExpectExec(escape("INSERT INTO `user_friends` (`user_id`, `friend_id`) VALUES (?, ?), (?, ?), (?, ?), (?, ?) ON DUPLICATE KEY UPDATE `user_id` = `user_friends`.`user_id`, `friend_id` = `user_friends`.`friend_id`")).
+					WithArgs(10, 2, 2, 10, 11, 2, 2, 11).
+					WillReturnResult(sqlmock.NewResult(2, 2))
+				// Insert M2M edges.
+				m.ExpectExec(escape("INSERT INTO `user_products` (`user_id`, `product_id`) VALUES (?, ?), (?, ?) ON DUPLICATE KEY UPDATE `user_id` = `user_products`.`user_id`, `product_id` = `user_products`.`product_id`")).
+					WithArgs(10, 2, 11, 2).
+					WillReturnResult(sqlmock.NewResult(2, 2))
+				m.ExpectCommit()
+			},
+		},
+		{
 			name: "multiple",
 			spec: &BatchCreateSpec{
 				Nodes: []*CreateSpec{


### PR DESCRIPTION
Fixed #3944  Issue in CreateBulk() for m2m edges

CraeteBulk() always generates wrong query when Fields in batchCreateSpec.Nodes is empty 
```
query=INSERT INTO `groups` VALUES () args=[]
````
This query is generated by:
https://github.com/ent/ent/blob/d4560fae6215a2d039a8cab219a667b7a0e972e9/dialect/sql/sqlgraph/graph.go#L1508

If defaults is true and len(sorted) (i.e. len(columns)) is zero, insert builder exec writeDefault(), 
https://github.com/ent/ent/blob/d4560fae6215a2d039a8cab219a667b7a0e972e9/dialect/sql/builder.go#L963-L965
https://github.com/ent/ent/blob/d4560fae6215a2d039a8cab219a667b7a0e972e9/dialect/sql/builder.go#L982-L989

With this PR, we  try to avoid execution of writeDefault.
If we want to insert 3 records through  CreateBulk(), the query is:
````
query=INSERT INTO `groups` (`id`) VALUES (NULL), (NULL), (NULL) args=[]
````