### PR TITLE
Make entql.FieldIn fallback to sql.False with empty args

### DIFF
--- a/dialect/sql/sqlgraph/entql.go
+++ b/dialect/sql/sqlgraph/entql.go
@@ -237,6 +237,8 @@ func (e *state) evalBinary(expr *entql.BinaryExpr) *sql.Predicate {
 				})
 			}
 
+			// if no arguments were provided, append the FALSE constants,
+			// since we can't apply "IN ()". This will make this predicate falsy.
 			if len(vs) == 0 {
 				return sql.False()
 			}

--- a/dialect/sql/sqlgraph/entql.go
+++ b/dialect/sql/sqlgraph/entql.go
@@ -223,15 +223,26 @@ func (e *state) evalBinary(expr *entql.BinaryExpr) *sql.Predicate {
 		if !ok {
 			_, ok = expr.Y.(*entql.Value)
 		}
-		expect(ok, "expr.Y to be *entql.Field or *entql.Value (got %T)", expr.X)
+		expect(ok, "expr.Y to be *entql.Field or *entql.Value (got %T)", expr.Y)
 		switch x := expr.Y.(type) {
 		case *entql.Field:
 			return sql.ColumnsOp(e.field(field), e.field(x), binary[expr.Op])
 		case *entql.Value:
 			c := e.field(field)
+
+			vs, ok := x.V.([]any)
+			if !ok {
+				return sql.P(func(b *sql.Builder) {
+					b.Ident(c).WriteOp(binary[expr.Op]).Arg(x.V)
+				})
+			}
+
+			if len(vs) == 0 {
+				return sql.False()
+			}
+
 			return sql.P(func(b *sql.Builder) {
-				b.Ident(c).WriteOp(binary[expr.Op])
-				args(b, x)
+				b.Ident(c).WriteOp(binary[expr.Op]).WriteByte('(').Args(vs...).WriteByte(')')
 			})
 		default:
 			panic("unreachable")
@@ -297,15 +308,6 @@ func (e *state) field(f *entql.Field) string {
 	_, ok := e.context.Fields[f.Name]
 	expect(ok || e.context.ID.Column == f.Name, "field %q was not found for node %q", f.Name, e.context.Type)
 	return e.selector.C(f.Name)
-}
-
-func args(b *sql.Builder, v *entql.Value) {
-	vs, ok := v.V.([]any)
-	if !ok {
-		b.Arg(v.V)
-		return
-	}
-	b.WriteByte('(').Args(vs...).WriteByte(')')
 }
 
 // expect panics if the condition is false.

--- a/dialect/sql/sqlgraph/entql_test.go
+++ b/dialect/sql/sqlgraph/entql_test.go
@@ -158,6 +158,17 @@ func TestGraph_EvalP(t *testing.T) {
 			wantQuery: `SELECT * FROM "users" WHERE "active" AND "users"."uid" IN (SELECT "pets"."owner_id" FROM "pets" WHERE "pets"."name" = $1 AND "owner_id" = $2)`,
 			wantArgs:  []any{"pedro", 10},
 		},
+		{
+			s:         sql.Dialect(dialect.Postgres).Select().From(sql.Table("users")),
+			p:         entql.FieldIn("name", []any{"pedro", "xabi"}...),
+			wantQuery: `SELECT * FROM "users" WHERE "users"."name" IN ($1, $2)`,
+			wantArgs:  []any{"pedro", "xabi"},
+		},
+		{
+			s:         sql.Dialect(dialect.Postgres).Select().From(sql.Table("users")),
+			p:         entql.FieldIn("name", []any{}...),
+			wantQuery: `SELECT * FROM "users" WHERE FALSE`,
+		},
 	}
 	for i, tt := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {


### PR DESCRIPTION
`entql.FieldIn("col", []any{}...)` would result in an SQL syntax error in postgres `SELECT * from table where col in ()`. 

This pr makes the sql code generation fallback to sql.False(), which is also done for `sql.In` (#2735).

An alternative fix could have been to change the implementation of entql.FieldIn to output a false constant directly, lmk if that solution would be preferred.
