### PR TITLE
fix(entc/gen): string predicates missing from field ops

### DIFF
--- a/entc/gen/predicate.go
+++ b/entc/gen/predicate.go
@@ -67,6 +67,6 @@ var (
 	boolOps     = []Op{EQ, NEQ}
 	enumOps     = append(boolOps, In, NotIn)
 	numericOps  = append(enumOps, GT, GTE, LT, LTE)
-	stringOps   = append(numericOps, Contains, HasPrefix, HasSuffix)
+	stringOps   = append(numericOps, EqualFold, Contains, ContainsFold, HasPrefix, HasSuffix)
 	nillableOps = []Op{IsNil, NotNil}
 )

--- a/entc/gen/type.go
+++ b/entc/gen/type.go
@@ -13,6 +13,7 @@ import (
 	"go/types"
 	"path"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"unicode"
@@ -1854,7 +1855,11 @@ func (f Field) enums(lf *load.Field) ([]Enum, error) {
 func (f *Field) Ops() []Op {
 	ops := fieldOps(f)
 	if (f.Name != "id" || !f.HasGoType()) && f.cfg != nil && f.cfg.Storage.Ops != nil {
-		ops = append(ops, f.cfg.Storage.Ops(f)...)
+		for _, op := range f.cfg.Storage.Ops(f) {
+			if !slices.Contains(ops, op) {
+				ops = append(ops, op)
+			}
+		}
 	}
 	return ops
 }

--- a/entc/integration/cascadelete/ent/comment/where.go
+++ b/entc/integration/cascadelete/ent/comment/where.go
@@ -107,9 +107,19 @@ func TextLTE(v string) predicate.Comment {
 	return predicate.Comment(sql.FieldLTE(FieldText, v))
 }
 
+// TextEqualFold applies the EqualFold predicate on the "text" field.
+func TextEqualFold(v string) predicate.Comment {
+	return predicate.Comment(sql.FieldEqualFold(FieldText, v))
+}
+
 // TextContains applies the Contains predicate on the "text" field.
 func TextContains(v string) predicate.Comment {
 	return predicate.Comment(sql.FieldContains(FieldText, v))
+}
+
+// TextContainsFold applies the ContainsFold predicate on the "text" field.
+func TextContainsFold(v string) predicate.Comment {
+	return predicate.Comment(sql.FieldContainsFold(FieldText, v))
 }
 
 // TextHasPrefix applies the HasPrefix predicate on the "text" field.
@@ -120,16 +130,6 @@ func TextHasPrefix(v string) predicate.Comment {
 // TextHasSuffix applies the HasSuffix predicate on the "text" field.
 func TextHasSuffix(v string) predicate.Comment {
 	return predicate.Comment(sql.FieldHasSuffix(FieldText, v))
-}
-
-// TextEqualFold applies the EqualFold predicate on the "text" field.
-func TextEqualFold(v string) predicate.Comment {
-	return predicate.Comment(sql.FieldEqualFold(FieldText, v))
-}
-
-// TextContainsFold applies the ContainsFold predicate on the "text" field.
-func TextContainsFold(v string) predicate.Comment {
-	return predicate.Comment(sql.FieldContainsFold(FieldText, v))
 }
 
 // PostIDEQ applies the EQ predicate on the "post_id" field.

--- a/entc/integration/cascadelete/ent/post/where.go
+++ b/entc/integration/cascadelete/ent/post/where.go
@@ -107,9 +107,19 @@ func TextLTE(v string) predicate.Post {
 	return predicate.Post(sql.FieldLTE(FieldText, v))
 }
 
+// TextEqualFold applies the EqualFold predicate on the "text" field.
+func TextEqualFold(v string) predicate.Post {
+	return predicate.Post(sql.FieldEqualFold(FieldText, v))
+}
+
 // TextContains applies the Contains predicate on the "text" field.
 func TextContains(v string) predicate.Post {
 	return predicate.Post(sql.FieldContains(FieldText, v))
+}
+
+// TextContainsFold applies the ContainsFold predicate on the "text" field.
+func TextContainsFold(v string) predicate.Post {
+	return predicate.Post(sql.FieldContainsFold(FieldText, v))
 }
 
 // TextHasPrefix applies the HasPrefix predicate on the "text" field.
@@ -120,16 +130,6 @@ func TextHasPrefix(v string) predicate.Post {
 // TextHasSuffix applies the HasSuffix predicate on the "text" field.
 func TextHasSuffix(v string) predicate.Post {
 	return predicate.Post(sql.FieldHasSuffix(FieldText, v))
-}
-
-// TextEqualFold applies the EqualFold predicate on the "text" field.
-func TextEqualFold(v string) predicate.Post {
-	return predicate.Post(sql.FieldEqualFold(FieldText, v))
-}
-
-// TextContainsFold applies the ContainsFold predicate on the "text" field.
-func TextContainsFold(v string) predicate.Post {
-	return predicate.Post(sql.FieldContainsFold(FieldText, v))
 }
 
 // AuthorIDEQ applies the EQ predicate on the "author_id" field.

--- a/entc/integration/cascadelete/ent/user/where.go
+++ b/entc/integration/cascadelete/ent/user/where.go
@@ -102,9 +102,19 @@ func NameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -115,16 +125,6 @@ func NameHasPrefix(v string) predicate.User {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasPosts applies the HasEdge predicate on the "posts" edge.

--- a/entc/integration/config/ent/user/where.go
+++ b/entc/integration/config/ent/user/where.go
@@ -101,9 +101,19 @@ func NameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -124,16 +134,6 @@ func NameIsNil() predicate.User {
 // NameNotNil applies the NotNil predicate on the "name" field.
 func NameNotNil() predicate.User {
 	return predicate.User(sql.FieldNotNull(FieldName))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // LabelEQ applies the EQ predicate on the "label" field.
@@ -176,9 +176,19 @@ func LabelLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldLabel, v))
 }
 
+// LabelEqualFold applies the EqualFold predicate on the "label" field.
+func LabelEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldLabel, v))
+}
+
 // LabelContains applies the Contains predicate on the "label" field.
 func LabelContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldLabel, v))
+}
+
+// LabelContainsFold applies the ContainsFold predicate on the "label" field.
+func LabelContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldLabel, v))
 }
 
 // LabelHasPrefix applies the HasPrefix predicate on the "label" field.
@@ -199,16 +209,6 @@ func LabelIsNil() predicate.User {
 // LabelNotNil applies the NotNil predicate on the "label" field.
 func LabelNotNil() predicate.User {
 	return predicate.User(sql.FieldNotNull(FieldLabel))
-}
-
-// LabelEqualFold applies the EqualFold predicate on the "label" field.
-func LabelEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldLabel, v))
-}
-
-// LabelContainsFold applies the ContainsFold predicate on the "label" field.
-func LabelContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldLabel, v))
 }
 
 // And groups predicates with the AND operator between them.

--- a/entc/integration/customid/ent/account/where.go
+++ b/entc/integration/customid/ent/account/where.go
@@ -103,9 +103,19 @@ func EmailLTE(v string) predicate.Account {
 	return predicate.Account(sql.FieldLTE(FieldEmail, v))
 }
 
+// EmailEqualFold applies the EqualFold predicate on the "email" field.
+func EmailEqualFold(v string) predicate.Account {
+	return predicate.Account(sql.FieldEqualFold(FieldEmail, v))
+}
+
 // EmailContains applies the Contains predicate on the "email" field.
 func EmailContains(v string) predicate.Account {
 	return predicate.Account(sql.FieldContains(FieldEmail, v))
+}
+
+// EmailContainsFold applies the ContainsFold predicate on the "email" field.
+func EmailContainsFold(v string) predicate.Account {
+	return predicate.Account(sql.FieldContainsFold(FieldEmail, v))
 }
 
 // EmailHasPrefix applies the HasPrefix predicate on the "email" field.
@@ -116,16 +126,6 @@ func EmailHasPrefix(v string) predicate.Account {
 // EmailHasSuffix applies the HasSuffix predicate on the "email" field.
 func EmailHasSuffix(v string) predicate.Account {
 	return predicate.Account(sql.FieldHasSuffix(FieldEmail, v))
-}
-
-// EmailEqualFold applies the EqualFold predicate on the "email" field.
-func EmailEqualFold(v string) predicate.Account {
-	return predicate.Account(sql.FieldEqualFold(FieldEmail, v))
-}
-
-// EmailContainsFold applies the ContainsFold predicate on the "email" field.
-func EmailContainsFold(v string) predicate.Account {
-	return predicate.Account(sql.FieldContainsFold(FieldEmail, v))
 }
 
 // HasToken applies the HasEdge predicate on the "token" edge.

--- a/entc/integration/customid/ent/car/where.go
+++ b/entc/integration/customid/ent/car/where.go
@@ -212,9 +212,19 @@ func ModelLTE(v string) predicate.Car {
 	return predicate.Car(sql.FieldLTE(FieldModel, v))
 }
 
+// ModelEqualFold applies the EqualFold predicate on the "model" field.
+func ModelEqualFold(v string) predicate.Car {
+	return predicate.Car(sql.FieldEqualFold(FieldModel, v))
+}
+
 // ModelContains applies the Contains predicate on the "model" field.
 func ModelContains(v string) predicate.Car {
 	return predicate.Car(sql.FieldContains(FieldModel, v))
+}
+
+// ModelContainsFold applies the ContainsFold predicate on the "model" field.
+func ModelContainsFold(v string) predicate.Car {
+	return predicate.Car(sql.FieldContainsFold(FieldModel, v))
 }
 
 // ModelHasPrefix applies the HasPrefix predicate on the "model" field.
@@ -225,16 +235,6 @@ func ModelHasPrefix(v string) predicate.Car {
 // ModelHasSuffix applies the HasSuffix predicate on the "model" field.
 func ModelHasSuffix(v string) predicate.Car {
 	return predicate.Car(sql.FieldHasSuffix(FieldModel, v))
-}
-
-// ModelEqualFold applies the EqualFold predicate on the "model" field.
-func ModelEqualFold(v string) predicate.Car {
-	return predicate.Car(sql.FieldEqualFold(FieldModel, v))
-}
-
-// ModelContainsFold applies the ContainsFold predicate on the "model" field.
-func ModelContainsFold(v string) predicate.Car {
-	return predicate.Car(sql.FieldContainsFold(FieldModel, v))
 }
 
 // HasOwner applies the HasEdge predicate on the "owner" edge.

--- a/entc/integration/customid/ent/doc/where.go
+++ b/entc/integration/customid/ent/doc/where.go
@@ -103,9 +103,19 @@ func TextLTE(v string) predicate.Doc {
 	return predicate.Doc(sql.FieldLTE(FieldText, v))
 }
 
+// TextEqualFold applies the EqualFold predicate on the "text" field.
+func TextEqualFold(v string) predicate.Doc {
+	return predicate.Doc(sql.FieldEqualFold(FieldText, v))
+}
+
 // TextContains applies the Contains predicate on the "text" field.
 func TextContains(v string) predicate.Doc {
 	return predicate.Doc(sql.FieldContains(FieldText, v))
+}
+
+// TextContainsFold applies the ContainsFold predicate on the "text" field.
+func TextContainsFold(v string) predicate.Doc {
+	return predicate.Doc(sql.FieldContainsFold(FieldText, v))
 }
 
 // TextHasPrefix applies the HasPrefix predicate on the "text" field.
@@ -126,16 +136,6 @@ func TextIsNil() predicate.Doc {
 // TextNotNil applies the NotNil predicate on the "text" field.
 func TextNotNil() predicate.Doc {
 	return predicate.Doc(sql.FieldNotNull(FieldText))
-}
-
-// TextEqualFold applies the EqualFold predicate on the "text" field.
-func TextEqualFold(v string) predicate.Doc {
-	return predicate.Doc(sql.FieldEqualFold(FieldText, v))
-}
-
-// TextContainsFold applies the ContainsFold predicate on the "text" field.
-func TextContainsFold(v string) predicate.Doc {
-	return predicate.Doc(sql.FieldContainsFold(FieldText, v))
 }
 
 // HasParent applies the HasEdge predicate on the "parent" edge.

--- a/entc/integration/customid/ent/mixinid/where.go
+++ b/entc/integration/customid/ent/mixinid/where.go
@@ -107,9 +107,19 @@ func SomeFieldLTE(v string) predicate.MixinID {
 	return predicate.MixinID(sql.FieldLTE(FieldSomeField, v))
 }
 
+// SomeFieldEqualFold applies the EqualFold predicate on the "some_field" field.
+func SomeFieldEqualFold(v string) predicate.MixinID {
+	return predicate.MixinID(sql.FieldEqualFold(FieldSomeField, v))
+}
+
 // SomeFieldContains applies the Contains predicate on the "some_field" field.
 func SomeFieldContains(v string) predicate.MixinID {
 	return predicate.MixinID(sql.FieldContains(FieldSomeField, v))
+}
+
+// SomeFieldContainsFold applies the ContainsFold predicate on the "some_field" field.
+func SomeFieldContainsFold(v string) predicate.MixinID {
+	return predicate.MixinID(sql.FieldContainsFold(FieldSomeField, v))
 }
 
 // SomeFieldHasPrefix applies the HasPrefix predicate on the "some_field" field.
@@ -120,16 +130,6 @@ func SomeFieldHasPrefix(v string) predicate.MixinID {
 // SomeFieldHasSuffix applies the HasSuffix predicate on the "some_field" field.
 func SomeFieldHasSuffix(v string) predicate.MixinID {
 	return predicate.MixinID(sql.FieldHasSuffix(FieldSomeField, v))
-}
-
-// SomeFieldEqualFold applies the EqualFold predicate on the "some_field" field.
-func SomeFieldEqualFold(v string) predicate.MixinID {
-	return predicate.MixinID(sql.FieldEqualFold(FieldSomeField, v))
-}
-
-// SomeFieldContainsFold applies the ContainsFold predicate on the "some_field" field.
-func SomeFieldContainsFold(v string) predicate.MixinID {
-	return predicate.MixinID(sql.FieldContainsFold(FieldSomeField, v))
 }
 
 // MixinFieldEQ applies the EQ predicate on the "mixin_field" field.
@@ -172,9 +172,19 @@ func MixinFieldLTE(v string) predicate.MixinID {
 	return predicate.MixinID(sql.FieldLTE(FieldMixinField, v))
 }
 
+// MixinFieldEqualFold applies the EqualFold predicate on the "mixin_field" field.
+func MixinFieldEqualFold(v string) predicate.MixinID {
+	return predicate.MixinID(sql.FieldEqualFold(FieldMixinField, v))
+}
+
 // MixinFieldContains applies the Contains predicate on the "mixin_field" field.
 func MixinFieldContains(v string) predicate.MixinID {
 	return predicate.MixinID(sql.FieldContains(FieldMixinField, v))
+}
+
+// MixinFieldContainsFold applies the ContainsFold predicate on the "mixin_field" field.
+func MixinFieldContainsFold(v string) predicate.MixinID {
+	return predicate.MixinID(sql.FieldContainsFold(FieldMixinField, v))
 }
 
 // MixinFieldHasPrefix applies the HasPrefix predicate on the "mixin_field" field.
@@ -185,16 +195,6 @@ func MixinFieldHasPrefix(v string) predicate.MixinID {
 // MixinFieldHasSuffix applies the HasSuffix predicate on the "mixin_field" field.
 func MixinFieldHasSuffix(v string) predicate.MixinID {
 	return predicate.MixinID(sql.FieldHasSuffix(FieldMixinField, v))
-}
-
-// MixinFieldEqualFold applies the EqualFold predicate on the "mixin_field" field.
-func MixinFieldEqualFold(v string) predicate.MixinID {
-	return predicate.MixinID(sql.FieldEqualFold(FieldMixinField, v))
-}
-
-// MixinFieldContainsFold applies the ContainsFold predicate on the "mixin_field" field.
-func MixinFieldContainsFold(v string) predicate.MixinID {
-	return predicate.MixinID(sql.FieldContainsFold(FieldMixinField, v))
 }
 
 // And groups predicates with the AND operator between them.

--- a/entc/integration/customid/ent/note/where.go
+++ b/entc/integration/customid/ent/note/where.go
@@ -103,9 +103,19 @@ func TextLTE(v string) predicate.Note {
 	return predicate.Note(sql.FieldLTE(FieldText, v))
 }
 
+// TextEqualFold applies the EqualFold predicate on the "text" field.
+func TextEqualFold(v string) predicate.Note {
+	return predicate.Note(sql.FieldEqualFold(FieldText, v))
+}
+
 // TextContains applies the Contains predicate on the "text" field.
 func TextContains(v string) predicate.Note {
 	return predicate.Note(sql.FieldContains(FieldText, v))
+}
+
+// TextContainsFold applies the ContainsFold predicate on the "text" field.
+func TextContainsFold(v string) predicate.Note {
+	return predicate.Note(sql.FieldContainsFold(FieldText, v))
 }
 
 // TextHasPrefix applies the HasPrefix predicate on the "text" field.
@@ -126,16 +136,6 @@ func TextIsNil() predicate.Note {
 // TextNotNil applies the NotNil predicate on the "text" field.
 func TextNotNil() predicate.Note {
 	return predicate.Note(sql.FieldNotNull(FieldText))
-}
-
-// TextEqualFold applies the EqualFold predicate on the "text" field.
-func TextEqualFold(v string) predicate.Note {
-	return predicate.Note(sql.FieldEqualFold(FieldText, v))
-}
-
-// TextContainsFold applies the ContainsFold predicate on the "text" field.
-func TextContainsFold(v string) predicate.Note {
-	return predicate.Note(sql.FieldContainsFold(FieldText, v))
 }
 
 // HasParent applies the HasEdge predicate on the "parent" edge.

--- a/entc/integration/customid/ent/token/where.go
+++ b/entc/integration/customid/ent/token/where.go
@@ -103,9 +103,19 @@ func BodyLTE(v string) predicate.Token {
 	return predicate.Token(sql.FieldLTE(FieldBody, v))
 }
 
+// BodyEqualFold applies the EqualFold predicate on the "body" field.
+func BodyEqualFold(v string) predicate.Token {
+	return predicate.Token(sql.FieldEqualFold(FieldBody, v))
+}
+
 // BodyContains applies the Contains predicate on the "body" field.
 func BodyContains(v string) predicate.Token {
 	return predicate.Token(sql.FieldContains(FieldBody, v))
+}
+
+// BodyContainsFold applies the ContainsFold predicate on the "body" field.
+func BodyContainsFold(v string) predicate.Token {
+	return predicate.Token(sql.FieldContainsFold(FieldBody, v))
 }
 
 // BodyHasPrefix applies the HasPrefix predicate on the "body" field.
@@ -116,16 +126,6 @@ func BodyHasPrefix(v string) predicate.Token {
 // BodyHasSuffix applies the HasSuffix predicate on the "body" field.
 func BodyHasSuffix(v string) predicate.Token {
 	return predicate.Token(sql.FieldHasSuffix(FieldBody, v))
-}
-
-// BodyEqualFold applies the EqualFold predicate on the "body" field.
-func BodyEqualFold(v string) predicate.Token {
-	return predicate.Token(sql.FieldEqualFold(FieldBody, v))
-}
-
-// BodyContainsFold applies the ContainsFold predicate on the "body" field.
-func BodyContainsFold(v string) predicate.Token {
-	return predicate.Token(sql.FieldContainsFold(FieldBody, v))
 }
 
 // HasAccount applies the HasEdge predicate on the "account" edge.

--- a/entc/integration/edgefield/ent/car/where.go
+++ b/entc/integration/edgefield/ent/car/where.go
@@ -103,9 +103,19 @@ func NumberLTE(v string) predicate.Car {
 	return predicate.Car(sql.FieldLTE(FieldNumber, v))
 }
 
+// NumberEqualFold applies the EqualFold predicate on the "number" field.
+func NumberEqualFold(v string) predicate.Car {
+	return predicate.Car(sql.FieldEqualFold(FieldNumber, v))
+}
+
 // NumberContains applies the Contains predicate on the "number" field.
 func NumberContains(v string) predicate.Car {
 	return predicate.Car(sql.FieldContains(FieldNumber, v))
+}
+
+// NumberContainsFold applies the ContainsFold predicate on the "number" field.
+func NumberContainsFold(v string) predicate.Car {
+	return predicate.Car(sql.FieldContainsFold(FieldNumber, v))
 }
 
 // NumberHasPrefix applies the HasPrefix predicate on the "number" field.
@@ -126,16 +136,6 @@ func NumberIsNil() predicate.Car {
 // NumberNotNil applies the NotNil predicate on the "number" field.
 func NumberNotNil() predicate.Car {
 	return predicate.Car(sql.FieldNotNull(FieldNumber))
-}
-
-// NumberEqualFold applies the EqualFold predicate on the "number" field.
-func NumberEqualFold(v string) predicate.Car {
-	return predicate.Car(sql.FieldEqualFold(FieldNumber, v))
-}
-
-// NumberContainsFold applies the ContainsFold predicate on the "number" field.
-func NumberContainsFold(v string) predicate.Car {
-	return predicate.Car(sql.FieldContainsFold(FieldNumber, v))
 }
 
 // HasRentals applies the HasEdge predicate on the "rentals" edge.

--- a/entc/integration/edgefield/ent/card/where.go
+++ b/entc/integration/edgefield/ent/card/where.go
@@ -107,9 +107,19 @@ func NumberLTE(v string) predicate.Card {
 	return predicate.Card(sql.FieldLTE(FieldNumber, v))
 }
 
+// NumberEqualFold applies the EqualFold predicate on the "number" field.
+func NumberEqualFold(v string) predicate.Card {
+	return predicate.Card(sql.FieldEqualFold(FieldNumber, v))
+}
+
 // NumberContains applies the Contains predicate on the "number" field.
 func NumberContains(v string) predicate.Card {
 	return predicate.Card(sql.FieldContains(FieldNumber, v))
+}
+
+// NumberContainsFold applies the ContainsFold predicate on the "number" field.
+func NumberContainsFold(v string) predicate.Card {
+	return predicate.Card(sql.FieldContainsFold(FieldNumber, v))
 }
 
 // NumberHasPrefix applies the HasPrefix predicate on the "number" field.
@@ -130,16 +140,6 @@ func NumberIsNil() predicate.Card {
 // NumberNotNil applies the NotNil predicate on the "number" field.
 func NumberNotNil() predicate.Card {
 	return predicate.Card(sql.FieldNotNull(FieldNumber))
-}
-
-// NumberEqualFold applies the EqualFold predicate on the "number" field.
-func NumberEqualFold(v string) predicate.Card {
-	return predicate.Card(sql.FieldEqualFold(FieldNumber, v))
-}
-
-// NumberContainsFold applies the ContainsFold predicate on the "number" field.
-func NumberContainsFold(v string) predicate.Card {
-	return predicate.Card(sql.FieldContainsFold(FieldNumber, v))
 }
 
 // OwnerIDEQ applies the EQ predicate on the "owner_id" field.

--- a/entc/integration/edgefield/ent/post/where.go
+++ b/entc/integration/edgefield/ent/post/where.go
@@ -107,9 +107,19 @@ func TextLTE(v string) predicate.Post {
 	return predicate.Post(sql.FieldLTE(FieldText, v))
 }
 
+// TextEqualFold applies the EqualFold predicate on the "text" field.
+func TextEqualFold(v string) predicate.Post {
+	return predicate.Post(sql.FieldEqualFold(FieldText, v))
+}
+
 // TextContains applies the Contains predicate on the "text" field.
 func TextContains(v string) predicate.Post {
 	return predicate.Post(sql.FieldContains(FieldText, v))
+}
+
+// TextContainsFold applies the ContainsFold predicate on the "text" field.
+func TextContainsFold(v string) predicate.Post {
+	return predicate.Post(sql.FieldContainsFold(FieldText, v))
 }
 
 // TextHasPrefix applies the HasPrefix predicate on the "text" field.
@@ -120,16 +130,6 @@ func TextHasPrefix(v string) predicate.Post {
 // TextHasSuffix applies the HasSuffix predicate on the "text" field.
 func TextHasSuffix(v string) predicate.Post {
 	return predicate.Post(sql.FieldHasSuffix(FieldText, v))
-}
-
-// TextEqualFold applies the EqualFold predicate on the "text" field.
-func TextEqualFold(v string) predicate.Post {
-	return predicate.Post(sql.FieldEqualFold(FieldText, v))
-}
-
-// TextContainsFold applies the ContainsFold predicate on the "text" field.
-func TextContainsFold(v string) predicate.Post {
-	return predicate.Post(sql.FieldContainsFold(FieldText, v))
 }
 
 // AuthorIDEQ applies the EQ predicate on the "author_id" field.

--- a/entc/integration/edgeschema/ent/file/where.go
+++ b/entc/integration/edgeschema/ent/file/where.go
@@ -102,9 +102,19 @@ func NameLTE(v string) predicate.File {
 	return predicate.File(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.File {
+	return predicate.File(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.File {
 	return predicate.File(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.File {
+	return predicate.File(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -115,16 +125,6 @@ func NameHasPrefix(v string) predicate.File {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.File {
 	return predicate.File(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.File {
-	return predicate.File(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.File {
-	return predicate.File(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasProcesses applies the HasEdge predicate on the "processes" edge.

--- a/entc/integration/edgeschema/ent/group/where.go
+++ b/entc/integration/edgeschema/ent/group/where.go
@@ -102,9 +102,19 @@ func NameLTE(v string) predicate.Group {
 	return predicate.Group(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.Group {
+	return predicate.Group(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.Group {
 	return predicate.Group(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.Group {
+	return predicate.Group(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -115,16 +125,6 @@ func NameHasPrefix(v string) predicate.Group {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.Group {
 	return predicate.Group(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.Group {
-	return predicate.Group(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.Group {
-	return predicate.Group(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasUsers applies the HasEdge predicate on the "users" edge.

--- a/entc/integration/edgeschema/ent/relationshipinfo/where.go
+++ b/entc/integration/edgeschema/ent/relationshipinfo/where.go
@@ -101,9 +101,19 @@ func TextLTE(v string) predicate.RelationshipInfo {
 	return predicate.RelationshipInfo(sql.FieldLTE(FieldText, v))
 }
 
+// TextEqualFold applies the EqualFold predicate on the "text" field.
+func TextEqualFold(v string) predicate.RelationshipInfo {
+	return predicate.RelationshipInfo(sql.FieldEqualFold(FieldText, v))
+}
+
 // TextContains applies the Contains predicate on the "text" field.
 func TextContains(v string) predicate.RelationshipInfo {
 	return predicate.RelationshipInfo(sql.FieldContains(FieldText, v))
+}
+
+// TextContainsFold applies the ContainsFold predicate on the "text" field.
+func TextContainsFold(v string) predicate.RelationshipInfo {
+	return predicate.RelationshipInfo(sql.FieldContainsFold(FieldText, v))
 }
 
 // TextHasPrefix applies the HasPrefix predicate on the "text" field.
@@ -114,16 +124,6 @@ func TextHasPrefix(v string) predicate.RelationshipInfo {
 // TextHasSuffix applies the HasSuffix predicate on the "text" field.
 func TextHasSuffix(v string) predicate.RelationshipInfo {
 	return predicate.RelationshipInfo(sql.FieldHasSuffix(FieldText, v))
-}
-
-// TextEqualFold applies the EqualFold predicate on the "text" field.
-func TextEqualFold(v string) predicate.RelationshipInfo {
-	return predicate.RelationshipInfo(sql.FieldEqualFold(FieldText, v))
-}
-
-// TextContainsFold applies the ContainsFold predicate on the "text" field.
-func TextContainsFold(v string) predicate.RelationshipInfo {
-	return predicate.RelationshipInfo(sql.FieldContainsFold(FieldText, v))
 }
 
 // And groups predicates with the AND operator between them.

--- a/entc/integration/edgeschema/ent/role/where.go
+++ b/entc/integration/edgeschema/ent/role/where.go
@@ -109,9 +109,19 @@ func NameLTE(v string) predicate.Role {
 	return predicate.Role(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.Role {
+	return predicate.Role(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.Role {
 	return predicate.Role(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.Role {
+	return predicate.Role(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -122,16 +132,6 @@ func NameHasPrefix(v string) predicate.Role {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.Role {
 	return predicate.Role(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.Role {
-	return predicate.Role(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.Role {
-	return predicate.Role(sql.FieldContainsFold(FieldName, v))
 }
 
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.

--- a/entc/integration/edgeschema/ent/tag/where.go
+++ b/entc/integration/edgeschema/ent/tag/where.go
@@ -102,9 +102,19 @@ func ValueLTE(v string) predicate.Tag {
 	return predicate.Tag(sql.FieldLTE(FieldValue, v))
 }
 
+// ValueEqualFold applies the EqualFold predicate on the "value" field.
+func ValueEqualFold(v string) predicate.Tag {
+	return predicate.Tag(sql.FieldEqualFold(FieldValue, v))
+}
+
 // ValueContains applies the Contains predicate on the "value" field.
 func ValueContains(v string) predicate.Tag {
 	return predicate.Tag(sql.FieldContains(FieldValue, v))
+}
+
+// ValueContainsFold applies the ContainsFold predicate on the "value" field.
+func ValueContainsFold(v string) predicate.Tag {
+	return predicate.Tag(sql.FieldContainsFold(FieldValue, v))
 }
 
 // ValueHasPrefix applies the HasPrefix predicate on the "value" field.
@@ -115,16 +125,6 @@ func ValueHasPrefix(v string) predicate.Tag {
 // ValueHasSuffix applies the HasSuffix predicate on the "value" field.
 func ValueHasSuffix(v string) predicate.Tag {
 	return predicate.Tag(sql.FieldHasSuffix(FieldValue, v))
-}
-
-// ValueEqualFold applies the EqualFold predicate on the "value" field.
-func ValueEqualFold(v string) predicate.Tag {
-	return predicate.Tag(sql.FieldEqualFold(FieldValue, v))
-}
-
-// ValueContainsFold applies the ContainsFold predicate on the "value" field.
-func ValueContainsFold(v string) predicate.Tag {
-	return predicate.Tag(sql.FieldContainsFold(FieldValue, v))
 }
 
 // HasTweets applies the HasEdge predicate on the "tweets" edge.

--- a/entc/integration/edgeschema/ent/tweet/where.go
+++ b/entc/integration/edgeschema/ent/tweet/where.go
@@ -102,9 +102,19 @@ func TextLTE(v string) predicate.Tweet {
 	return predicate.Tweet(sql.FieldLTE(FieldText, v))
 }
 
+// TextEqualFold applies the EqualFold predicate on the "text" field.
+func TextEqualFold(v string) predicate.Tweet {
+	return predicate.Tweet(sql.FieldEqualFold(FieldText, v))
+}
+
 // TextContains applies the Contains predicate on the "text" field.
 func TextContains(v string) predicate.Tweet {
 	return predicate.Tweet(sql.FieldContains(FieldText, v))
+}
+
+// TextContainsFold applies the ContainsFold predicate on the "text" field.
+func TextContainsFold(v string) predicate.Tweet {
+	return predicate.Tweet(sql.FieldContainsFold(FieldText, v))
 }
 
 // TextHasPrefix applies the HasPrefix predicate on the "text" field.
@@ -115,16 +125,6 @@ func TextHasPrefix(v string) predicate.Tweet {
 // TextHasSuffix applies the HasSuffix predicate on the "text" field.
 func TextHasSuffix(v string) predicate.Tweet {
 	return predicate.Tweet(sql.FieldHasSuffix(FieldText, v))
-}
-
-// TextEqualFold applies the EqualFold predicate on the "text" field.
-func TextEqualFold(v string) predicate.Tweet {
-	return predicate.Tweet(sql.FieldEqualFold(FieldText, v))
-}
-
-// TextContainsFold applies the ContainsFold predicate on the "text" field.
-func TextContainsFold(v string) predicate.Tweet {
-	return predicate.Tweet(sql.FieldContainsFold(FieldText, v))
 }
 
 // HasLikedUsers applies the HasEdge predicate on the "liked_users" edge.

--- a/entc/integration/edgeschema/ent/user/where.go
+++ b/entc/integration/edgeschema/ent/user/where.go
@@ -102,9 +102,19 @@ func NameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -115,16 +125,6 @@ func NameHasPrefix(v string) predicate.User {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasGroups applies the HasEdge predicate on the "groups" edge.

--- a/entc/integration/ent/card/where.go
+++ b/entc/integration/ent/card/where.go
@@ -244,9 +244,19 @@ func NumberLTE(v string) predicate.Card {
 	return predicate.Card(sql.FieldLTE(FieldNumber, v))
 }
 
+// NumberEqualFold applies the EqualFold predicate on the "number" field.
+func NumberEqualFold(v string) predicate.Card {
+	return predicate.Card(sql.FieldEqualFold(FieldNumber, v))
+}
+
 // NumberContains applies the Contains predicate on the "number" field.
 func NumberContains(v string) predicate.Card {
 	return predicate.Card(sql.FieldContains(FieldNumber, v))
+}
+
+// NumberContainsFold applies the ContainsFold predicate on the "number" field.
+func NumberContainsFold(v string) predicate.Card {
+	return predicate.Card(sql.FieldContainsFold(FieldNumber, v))
 }
 
 // NumberHasPrefix applies the HasPrefix predicate on the "number" field.
@@ -257,16 +267,6 @@ func NumberHasPrefix(v string) predicate.Card {
 // NumberHasSuffix applies the HasSuffix predicate on the "number" field.
 func NumberHasSuffix(v string) predicate.Card {
 	return predicate.Card(sql.FieldHasSuffix(FieldNumber, v))
-}
-
-// NumberEqualFold applies the EqualFold predicate on the "number" field.
-func NumberEqualFold(v string) predicate.Card {
-	return predicate.Card(sql.FieldEqualFold(FieldNumber, v))
-}
-
-// NumberContainsFold applies the ContainsFold predicate on the "number" field.
-func NumberContainsFold(v string) predicate.Card {
-	return predicate.Card(sql.FieldContainsFold(FieldNumber, v))
 }
 
 // NameEQ applies the EQ predicate on the "name" field.
@@ -309,9 +309,19 @@ func NameLTE(v string) predicate.Card {
 	return predicate.Card(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.Card {
+	return predicate.Card(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.Card {
 	return predicate.Card(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.Card {
+	return predicate.Card(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -332,16 +342,6 @@ func NameIsNil() predicate.Card {
 // NameNotNil applies the NotNil predicate on the "name" field.
 func NameNotNil() predicate.Card {
 	return predicate.Card(sql.FieldNotNull(FieldName))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.Card {
-	return predicate.Card(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.Card {
-	return predicate.Card(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasOwner applies the HasEdge predicate on the "owner" edge.

--- a/entc/integration/ent/comment/where.go
+++ b/entc/integration/ent/comment/where.go
@@ -246,9 +246,19 @@ func TableLTE(v string) predicate.Comment {
 	return predicate.Comment(sql.FieldLTE(FieldTable, v))
 }
 
+// TableEqualFold applies the EqualFold predicate on the "table" field.
+func TableEqualFold(v string) predicate.Comment {
+	return predicate.Comment(sql.FieldEqualFold(FieldTable, v))
+}
+
 // TableContains applies the Contains predicate on the "table" field.
 func TableContains(v string) predicate.Comment {
 	return predicate.Comment(sql.FieldContains(FieldTable, v))
+}
+
+// TableContainsFold applies the ContainsFold predicate on the "table" field.
+func TableContainsFold(v string) predicate.Comment {
+	return predicate.Comment(sql.FieldContainsFold(FieldTable, v))
 }
 
 // TableHasPrefix applies the HasPrefix predicate on the "table" field.
@@ -269,16 +279,6 @@ func TableIsNil() predicate.Comment {
 // TableNotNil applies the NotNil predicate on the "table" field.
 func TableNotNil() predicate.Comment {
 	return predicate.Comment(sql.FieldNotNull(FieldTable))
-}
-
-// TableEqualFold applies the EqualFold predicate on the "table" field.
-func TableEqualFold(v string) predicate.Comment {
-	return predicate.Comment(sql.FieldEqualFold(FieldTable, v))
-}
-
-// TableContainsFold applies the ContainsFold predicate on the "table" field.
-func TableContainsFold(v string) predicate.Comment {
-	return predicate.Comment(sql.FieldContainsFold(FieldTable, v))
 }
 
 // DirIsNil applies the IsNil predicate on the "dir" field.
@@ -331,9 +331,19 @@ func ClientLTE(v string) predicate.Comment {
 	return predicate.Comment(sql.FieldLTE(FieldClient, v))
 }
 
+// ClientEqualFold applies the EqualFold predicate on the "client" field.
+func ClientEqualFold(v string) predicate.Comment {
+	return predicate.Comment(sql.FieldEqualFold(FieldClient, v))
+}
+
 // ClientContains applies the Contains predicate on the "client" field.
 func ClientContains(v string) predicate.Comment {
 	return predicate.Comment(sql.FieldContains(FieldClient, v))
+}
+
+// ClientContainsFold applies the ContainsFold predicate on the "client" field.
+func ClientContainsFold(v string) predicate.Comment {
+	return predicate.Comment(sql.FieldContainsFold(FieldClient, v))
 }
 
 // ClientHasPrefix applies the HasPrefix predicate on the "client" field.
@@ -354,16 +364,6 @@ func ClientIsNil() predicate.Comment {
 // ClientNotNil applies the NotNil predicate on the "client" field.
 func ClientNotNil() predicate.Comment {
 	return predicate.Comment(sql.FieldNotNull(FieldClient))
-}
-
-// ClientEqualFold applies the EqualFold predicate on the "client" field.
-func ClientEqualFold(v string) predicate.Comment {
-	return predicate.Comment(sql.FieldEqualFold(FieldClient, v))
-}
-
-// ClientContainsFold applies the ContainsFold predicate on the "client" field.
-func ClientContainsFold(v string) predicate.Comment {
-	return predicate.Comment(sql.FieldContainsFold(FieldClient, v))
 }
 
 // And groups predicates with the AND operator between them.

--- a/entc/integration/ent/exvaluescan/where.go
+++ b/entc/integration/ent/exvaluescan/where.go
@@ -166,6 +166,16 @@ func BinaryLTE(v *url.URL) predicate.ExValueScan {
 	return predicate.ExValueScanOrErr(sql.FieldLTE(FieldBinary, vc), err)
 }
 
+// BinaryEqualFold applies the EqualFold predicate on the "binary" field.
+func BinaryEqualFold(v *url.URL) predicate.ExValueScan {
+	vc, err := ValueScanner.Binary.Value(v)
+	vcs, ok := vc.(string)
+	if err == nil && !ok {
+		err = fmt.Errorf("binary value is not a string: %T", vc)
+	}
+	return predicate.ExValueScanOrErr(sql.FieldEqualFold(FieldBinary, vcs), err)
+}
+
 // BinaryContains applies the Contains predicate on the "binary" field.
 func BinaryContains(v *url.URL) predicate.ExValueScan {
 	vc, err := ValueScanner.Binary.Value(v)
@@ -174,6 +184,16 @@ func BinaryContains(v *url.URL) predicate.ExValueScan {
 		err = fmt.Errorf("binary value is not a string: %T", vc)
 	}
 	return predicate.ExValueScanOrErr(sql.FieldContains(FieldBinary, vcs), err)
+}
+
+// BinaryContainsFold applies the ContainsFold predicate on the "binary" field.
+func BinaryContainsFold(v *url.URL) predicate.ExValueScan {
+	vc, err := ValueScanner.Binary.Value(v)
+	vcs, ok := vc.(string)
+	if err == nil && !ok {
+		err = fmt.Errorf("binary value is not a string: %T", vc)
+	}
+	return predicate.ExValueScanOrErr(sql.FieldContainsFold(FieldBinary, vcs), err)
 }
 
 // BinaryHasPrefix applies the HasPrefix predicate on the "binary" field.
@@ -194,26 +214,6 @@ func BinaryHasSuffix(v *url.URL) predicate.ExValueScan {
 		err = fmt.Errorf("binary value is not a string: %T", vc)
 	}
 	return predicate.ExValueScanOrErr(sql.FieldHasSuffix(FieldBinary, vcs), err)
-}
-
-// BinaryEqualFold applies the EqualFold predicate on the "binary" field.
-func BinaryEqualFold(v *url.URL) predicate.ExValueScan {
-	vc, err := ValueScanner.Binary.Value(v)
-	vcs, ok := vc.(string)
-	if err == nil && !ok {
-		err = fmt.Errorf("binary value is not a string: %T", vc)
-	}
-	return predicate.ExValueScanOrErr(sql.FieldEqualFold(FieldBinary, vcs), err)
-}
-
-// BinaryContainsFold applies the ContainsFold predicate on the "binary" field.
-func BinaryContainsFold(v *url.URL) predicate.ExValueScan {
-	vc, err := ValueScanner.Binary.Value(v)
-	vcs, ok := vc.(string)
-	if err == nil && !ok {
-		err = fmt.Errorf("binary value is not a string: %T", vc)
-	}
-	return predicate.ExValueScanOrErr(sql.FieldContainsFold(FieldBinary, vcs), err)
 }
 
 // BinaryOptionalEQ applies the EQ predicate on the "binary_optional" field.
@@ -280,6 +280,16 @@ func BinaryOptionalLTE(v *url.URL) predicate.ExValueScan {
 	return predicate.ExValueScanOrErr(sql.FieldLTE(FieldBinaryOptional, vc), err)
 }
 
+// BinaryOptionalEqualFold applies the EqualFold predicate on the "binary_optional" field.
+func BinaryOptionalEqualFold(v *url.URL) predicate.ExValueScan {
+	vc, err := ValueScanner.BinaryOptional.Value(v)
+	vcs, ok := vc.(string)
+	if err == nil && !ok {
+		err = fmt.Errorf("binary_optional value is not a string: %T", vc)
+	}
+	return predicate.ExValueScanOrErr(sql.FieldEqualFold(FieldBinaryOptional, vcs), err)
+}
+
 // BinaryOptionalContains applies the Contains predicate on the "binary_optional" field.
 func BinaryOptionalContains(v *url.URL) predicate.ExValueScan {
 	vc, err := ValueScanner.BinaryOptional.Value(v)
@@ -288,6 +298,16 @@ func BinaryOptionalContains(v *url.URL) predicate.ExValueScan {
 		err = fmt.Errorf("binary_optional value is not a string: %T", vc)
 	}
 	return predicate.ExValueScanOrErr(sql.FieldContains(FieldBinaryOptional, vcs), err)
+}
+
+// BinaryOptionalContainsFold applies the ContainsFold predicate on the "binary_optional" field.
+func BinaryOptionalContainsFold(v *url.URL) predicate.ExValueScan {
+	vc, err := ValueScanner.BinaryOptional.Value(v)
+	vcs, ok := vc.(string)
+	if err == nil && !ok {
+		err = fmt.Errorf("binary_optional value is not a string: %T", vc)
+	}
+	return predicate.ExValueScanOrErr(sql.FieldContainsFold(FieldBinaryOptional, vcs), err)
 }
 
 // BinaryOptionalHasPrefix applies the HasPrefix predicate on the "binary_optional" field.
@@ -318,26 +338,6 @@ func BinaryOptionalIsNil() predicate.ExValueScan {
 // BinaryOptionalNotNil applies the NotNil predicate on the "binary_optional" field.
 func BinaryOptionalNotNil() predicate.ExValueScan {
 	return predicate.ExValueScan(sql.FieldNotNull(FieldBinaryOptional))
-}
-
-// BinaryOptionalEqualFold applies the EqualFold predicate on the "binary_optional" field.
-func BinaryOptionalEqualFold(v *url.URL) predicate.ExValueScan {
-	vc, err := ValueScanner.BinaryOptional.Value(v)
-	vcs, ok := vc.(string)
-	if err == nil && !ok {
-		err = fmt.Errorf("binary_optional value is not a string: %T", vc)
-	}
-	return predicate.ExValueScanOrErr(sql.FieldEqualFold(FieldBinaryOptional, vcs), err)
-}
-
-// BinaryOptionalContainsFold applies the ContainsFold predicate on the "binary_optional" field.
-func BinaryOptionalContainsFold(v *url.URL) predicate.ExValueScan {
-	vc, err := ValueScanner.BinaryOptional.Value(v)
-	vcs, ok := vc.(string)
-	if err == nil && !ok {
-		err = fmt.Errorf("binary_optional value is not a string: %T", vc)
-	}
-	return predicate.ExValueScanOrErr(sql.FieldContainsFold(FieldBinaryOptional, vcs), err)
 }
 
 // TextEQ applies the EQ predicate on the "text" field.
@@ -404,6 +404,16 @@ func TextLTE(v *big.Int) predicate.ExValueScan {
 	return predicate.ExValueScanOrErr(sql.FieldLTE(FieldText, vc), err)
 }
 
+// TextEqualFold applies the EqualFold predicate on the "text" field.
+func TextEqualFold(v *big.Int) predicate.ExValueScan {
+	vc, err := ValueScanner.Text.Value(v)
+	vcs, ok := vc.(string)
+	if err == nil && !ok {
+		err = fmt.Errorf("text value is not a string: %T", vc)
+	}
+	return predicate.ExValueScanOrErr(sql.FieldEqualFold(FieldText, vcs), err)
+}
+
 // TextContains applies the Contains predicate on the "text" field.
 func TextContains(v *big.Int) predicate.ExValueScan {
 	vc, err := ValueScanner.Text.Value(v)
@@ -412,6 +422,16 @@ func TextContains(v *big.Int) predicate.ExValueScan {
 		err = fmt.Errorf("text value is not a string: %T", vc)
 	}
 	return predicate.ExValueScanOrErr(sql.FieldContains(FieldText, vcs), err)
+}
+
+// TextContainsFold applies the ContainsFold predicate on the "text" field.
+func TextContainsFold(v *big.Int) predicate.ExValueScan {
+	vc, err := ValueScanner.Text.Value(v)
+	vcs, ok := vc.(string)
+	if err == nil && !ok {
+		err = fmt.Errorf("text value is not a string: %T", vc)
+	}
+	return predicate.ExValueScanOrErr(sql.FieldContainsFold(FieldText, vcs), err)
 }
 
 // TextHasPrefix applies the HasPrefix predicate on the "text" field.
@@ -432,26 +452,6 @@ func TextHasSuffix(v *big.Int) predicate.ExValueScan {
 		err = fmt.Errorf("text value is not a string: %T", vc)
 	}
 	return predicate.ExValueScanOrErr(sql.FieldHasSuffix(FieldText, vcs), err)
-}
-
-// TextEqualFold applies the EqualFold predicate on the "text" field.
-func TextEqualFold(v *big.Int) predicate.ExValueScan {
-	vc, err := ValueScanner.Text.Value(v)
-	vcs, ok := vc.(string)
-	if err == nil && !ok {
-		err = fmt.Errorf("text value is not a string: %T", vc)
-	}
-	return predicate.ExValueScanOrErr(sql.FieldEqualFold(FieldText, vcs), err)
-}
-
-// TextContainsFold applies the ContainsFold predicate on the "text" field.
-func TextContainsFold(v *big.Int) predicate.ExValueScan {
-	vc, err := ValueScanner.Text.Value(v)
-	vcs, ok := vc.(string)
-	if err == nil && !ok {
-		err = fmt.Errorf("text value is not a string: %T", vc)
-	}
-	return predicate.ExValueScanOrErr(sql.FieldContainsFold(FieldText, vcs), err)
 }
 
 // TextOptionalEQ applies the EQ predicate on the "text_optional" field.
@@ -518,6 +518,16 @@ func TextOptionalLTE(v *big.Int) predicate.ExValueScan {
 	return predicate.ExValueScanOrErr(sql.FieldLTE(FieldTextOptional, vc), err)
 }
 
+// TextOptionalEqualFold applies the EqualFold predicate on the "text_optional" field.
+func TextOptionalEqualFold(v *big.Int) predicate.ExValueScan {
+	vc, err := ValueScanner.TextOptional.Value(v)
+	vcs, ok := vc.(string)
+	if err == nil && !ok {
+		err = fmt.Errorf("text_optional value is not a string: %T", vc)
+	}
+	return predicate.ExValueScanOrErr(sql.FieldEqualFold(FieldTextOptional, vcs), err)
+}
+
 // TextOptionalContains applies the Contains predicate on the "text_optional" field.
 func TextOptionalContains(v *big.Int) predicate.ExValueScan {
 	vc, err := ValueScanner.TextOptional.Value(v)
@@ -526,6 +536,16 @@ func TextOptionalContains(v *big.Int) predicate.ExValueScan {
 		err = fmt.Errorf("text_optional value is not a string: %T", vc)
 	}
 	return predicate.ExValueScanOrErr(sql.FieldContains(FieldTextOptional, vcs), err)
+}
+
+// TextOptionalContainsFold applies the ContainsFold predicate on the "text_optional" field.
+func TextOptionalContainsFold(v *big.Int) predicate.ExValueScan {
+	vc, err := ValueScanner.TextOptional.Value(v)
+	vcs, ok := vc.(string)
+	if err == nil && !ok {
+		err = fmt.Errorf("text_optional value is not a string: %T", vc)
+	}
+	return predicate.ExValueScanOrErr(sql.FieldContainsFold(FieldTextOptional, vcs), err)
 }
 
 // TextOptionalHasPrefix applies the HasPrefix predicate on the "text_optional" field.
@@ -556,26 +576,6 @@ func TextOptionalIsNil() predicate.ExValueScan {
 // TextOptionalNotNil applies the NotNil predicate on the "text_optional" field.
 func TextOptionalNotNil() predicate.ExValueScan {
 	return predicate.ExValueScan(sql.FieldNotNull(FieldTextOptional))
-}
-
-// TextOptionalEqualFold applies the EqualFold predicate on the "text_optional" field.
-func TextOptionalEqualFold(v *big.Int) predicate.ExValueScan {
-	vc, err := ValueScanner.TextOptional.Value(v)
-	vcs, ok := vc.(string)
-	if err == nil && !ok {
-		err = fmt.Errorf("text_optional value is not a string: %T", vc)
-	}
-	return predicate.ExValueScanOrErr(sql.FieldEqualFold(FieldTextOptional, vcs), err)
-}
-
-// TextOptionalContainsFold applies the ContainsFold predicate on the "text_optional" field.
-func TextOptionalContainsFold(v *big.Int) predicate.ExValueScan {
-	vc, err := ValueScanner.TextOptional.Value(v)
-	vcs, ok := vc.(string)
-	if err == nil && !ok {
-		err = fmt.Errorf("text_optional value is not a string: %T", vc)
-	}
-	return predicate.ExValueScanOrErr(sql.FieldContainsFold(FieldTextOptional, vcs), err)
 }
 
 // Base64EQ applies the EQ predicate on the "base64" field.
@@ -642,6 +642,16 @@ func Base64LTE(v string) predicate.ExValueScan {
 	return predicate.ExValueScanOrErr(sql.FieldLTE(FieldBase64, vc), err)
 }
 
+// Base64EqualFold applies the EqualFold predicate on the "base64" field.
+func Base64EqualFold(v string) predicate.ExValueScan {
+	vc, err := ValueScanner.Base64.Value(v)
+	vcs, ok := vc.(string)
+	if err == nil && !ok {
+		err = fmt.Errorf("base64 value is not a string: %T", vc)
+	}
+	return predicate.ExValueScanOrErr(sql.FieldEqualFold(FieldBase64, vcs), err)
+}
+
 // Base64Contains applies the Contains predicate on the "base64" field.
 func Base64Contains(v string) predicate.ExValueScan {
 	vc, err := ValueScanner.Base64.Value(v)
@@ -650,6 +660,16 @@ func Base64Contains(v string) predicate.ExValueScan {
 		err = fmt.Errorf("base64 value is not a string: %T", vc)
 	}
 	return predicate.ExValueScanOrErr(sql.FieldContains(FieldBase64, vcs), err)
+}
+
+// Base64ContainsFold applies the ContainsFold predicate on the "base64" field.
+func Base64ContainsFold(v string) predicate.ExValueScan {
+	vc, err := ValueScanner.Base64.Value(v)
+	vcs, ok := vc.(string)
+	if err == nil && !ok {
+		err = fmt.Errorf("base64 value is not a string: %T", vc)
+	}
+	return predicate.ExValueScanOrErr(sql.FieldContainsFold(FieldBase64, vcs), err)
 }
 
 // Base64HasPrefix applies the HasPrefix predicate on the "base64" field.
@@ -670,26 +690,6 @@ func Base64HasSuffix(v string) predicate.ExValueScan {
 		err = fmt.Errorf("base64 value is not a string: %T", vc)
 	}
 	return predicate.ExValueScanOrErr(sql.FieldHasSuffix(FieldBase64, vcs), err)
-}
-
-// Base64EqualFold applies the EqualFold predicate on the "base64" field.
-func Base64EqualFold(v string) predicate.ExValueScan {
-	vc, err := ValueScanner.Base64.Value(v)
-	vcs, ok := vc.(string)
-	if err == nil && !ok {
-		err = fmt.Errorf("base64 value is not a string: %T", vc)
-	}
-	return predicate.ExValueScanOrErr(sql.FieldEqualFold(FieldBase64, vcs), err)
-}
-
-// Base64ContainsFold applies the ContainsFold predicate on the "base64" field.
-func Base64ContainsFold(v string) predicate.ExValueScan {
-	vc, err := ValueScanner.Base64.Value(v)
-	vcs, ok := vc.(string)
-	if err == nil && !ok {
-		err = fmt.Errorf("base64 value is not a string: %T", vc)
-	}
-	return predicate.ExValueScanOrErr(sql.FieldContainsFold(FieldBase64, vcs), err)
 }
 
 // CustomEQ applies the EQ predicate on the "custom" field.
@@ -756,6 +756,16 @@ func CustomLTE(v string) predicate.ExValueScan {
 	return predicate.ExValueScanOrErr(sql.FieldLTE(FieldCustom, vc), err)
 }
 
+// CustomEqualFold applies the EqualFold predicate on the "custom" field.
+func CustomEqualFold(v string) predicate.ExValueScan {
+	vc, err := ValueScanner.Custom.Value(v)
+	vcs, ok := vc.(string)
+	if err == nil && !ok {
+		err = fmt.Errorf("custom value is not a string: %T", vc)
+	}
+	return predicate.ExValueScanOrErr(sql.FieldEqualFold(FieldCustom, vcs), err)
+}
+
 // CustomContains applies the Contains predicate on the "custom" field.
 func CustomContains(v string) predicate.ExValueScan {
 	vc, err := ValueScanner.Custom.Value(v)
@@ -764,6 +774,16 @@ func CustomContains(v string) predicate.ExValueScan {
 		err = fmt.Errorf("custom value is not a string: %T", vc)
 	}
 	return predicate.ExValueScanOrErr(sql.FieldContains(FieldCustom, vcs), err)
+}
+
+// CustomContainsFold applies the ContainsFold predicate on the "custom" field.
+func CustomContainsFold(v string) predicate.ExValueScan {
+	vc, err := ValueScanner.Custom.Value(v)
+	vcs, ok := vc.(string)
+	if err == nil && !ok {
+		err = fmt.Errorf("custom value is not a string: %T", vc)
+	}
+	return predicate.ExValueScanOrErr(sql.FieldContainsFold(FieldCustom, vcs), err)
 }
 
 // CustomHasPrefix applies the HasPrefix predicate on the "custom" field.
@@ -784,26 +804,6 @@ func CustomHasSuffix(v string) predicate.ExValueScan {
 		err = fmt.Errorf("custom value is not a string: %T", vc)
 	}
 	return predicate.ExValueScanOrErr(sql.FieldHasSuffix(FieldCustom, vcs), err)
-}
-
-// CustomEqualFold applies the EqualFold predicate on the "custom" field.
-func CustomEqualFold(v string) predicate.ExValueScan {
-	vc, err := ValueScanner.Custom.Value(v)
-	vcs, ok := vc.(string)
-	if err == nil && !ok {
-		err = fmt.Errorf("custom value is not a string: %T", vc)
-	}
-	return predicate.ExValueScanOrErr(sql.FieldEqualFold(FieldCustom, vcs), err)
-}
-
-// CustomContainsFold applies the ContainsFold predicate on the "custom" field.
-func CustomContainsFold(v string) predicate.ExValueScan {
-	vc, err := ValueScanner.Custom.Value(v)
-	vcs, ok := vc.(string)
-	if err == nil && !ok {
-		err = fmt.Errorf("custom value is not a string: %T", vc)
-	}
-	return predicate.ExValueScanOrErr(sql.FieldContainsFold(FieldCustom, vcs), err)
 }
 
 // CustomOptionalEQ applies the EQ predicate on the "custom_optional" field.
@@ -870,6 +870,16 @@ func CustomOptionalLTE(v string) predicate.ExValueScan {
 	return predicate.ExValueScanOrErr(sql.FieldLTE(FieldCustomOptional, vc), err)
 }
 
+// CustomOptionalEqualFold applies the EqualFold predicate on the "custom_optional" field.
+func CustomOptionalEqualFold(v string) predicate.ExValueScan {
+	vc, err := ValueScanner.CustomOptional.Value(v)
+	vcs, ok := vc.(string)
+	if err == nil && !ok {
+		err = fmt.Errorf("custom_optional value is not a string: %T", vc)
+	}
+	return predicate.ExValueScanOrErr(sql.FieldEqualFold(FieldCustomOptional, vcs), err)
+}
+
 // CustomOptionalContains applies the Contains predicate on the "custom_optional" field.
 func CustomOptionalContains(v string) predicate.ExValueScan {
 	vc, err := ValueScanner.CustomOptional.Value(v)
@@ -878,6 +888,16 @@ func CustomOptionalContains(v string) predicate.ExValueScan {
 		err = fmt.Errorf("custom_optional value is not a string: %T", vc)
 	}
 	return predicate.ExValueScanOrErr(sql.FieldContains(FieldCustomOptional, vcs), err)
+}
+
+// CustomOptionalContainsFold applies the ContainsFold predicate on the "custom_optional" field.
+func CustomOptionalContainsFold(v string) predicate.ExValueScan {
+	vc, err := ValueScanner.CustomOptional.Value(v)
+	vcs, ok := vc.(string)
+	if err == nil && !ok {
+		err = fmt.Errorf("custom_optional value is not a string: %T", vc)
+	}
+	return predicate.ExValueScanOrErr(sql.FieldContainsFold(FieldCustomOptional, vcs), err)
 }
 
 // CustomOptionalHasPrefix applies the HasPrefix predicate on the "custom_optional" field.
@@ -908,26 +928,6 @@ func CustomOptionalIsNil() predicate.ExValueScan {
 // CustomOptionalNotNil applies the NotNil predicate on the "custom_optional" field.
 func CustomOptionalNotNil() predicate.ExValueScan {
 	return predicate.ExValueScan(sql.FieldNotNull(FieldCustomOptional))
-}
-
-// CustomOptionalEqualFold applies the EqualFold predicate on the "custom_optional" field.
-func CustomOptionalEqualFold(v string) predicate.ExValueScan {
-	vc, err := ValueScanner.CustomOptional.Value(v)
-	vcs, ok := vc.(string)
-	if err == nil && !ok {
-		err = fmt.Errorf("custom_optional value is not a string: %T", vc)
-	}
-	return predicate.ExValueScanOrErr(sql.FieldEqualFold(FieldCustomOptional, vcs), err)
-}
-
-// CustomOptionalContainsFold applies the ContainsFold predicate on the "custom_optional" field.
-func CustomOptionalContainsFold(v string) predicate.ExValueScan {
-	vc, err := ValueScanner.CustomOptional.Value(v)
-	vcs, ok := vc.(string)
-	if err == nil && !ok {
-		err = fmt.Errorf("custom_optional value is not a string: %T", vc)
-	}
-	return predicate.ExValueScanOrErr(sql.FieldContainsFold(FieldCustomOptional, vcs), err)
 }
 
 // And groups predicates with the AND operator between them.

--- a/entc/integration/ent/fieldtype/where.go
+++ b/entc/integration/ent/fieldtype/where.go
@@ -1549,9 +1549,19 @@ func TextLTE(v string) predicate.FieldType {
 	return predicate.FieldType(sql.FieldLTE(FieldText, v))
 }
 
+// TextEqualFold applies the EqualFold predicate on the "text" field.
+func TextEqualFold(v string) predicate.FieldType {
+	return predicate.FieldType(sql.FieldEqualFold(FieldText, v))
+}
+
 // TextContains applies the Contains predicate on the "text" field.
 func TextContains(v string) predicate.FieldType {
 	return predicate.FieldType(sql.FieldContains(FieldText, v))
+}
+
+// TextContainsFold applies the ContainsFold predicate on the "text" field.
+func TextContainsFold(v string) predicate.FieldType {
+	return predicate.FieldType(sql.FieldContainsFold(FieldText, v))
 }
 
 // TextHasPrefix applies the HasPrefix predicate on the "text" field.
@@ -1572,16 +1582,6 @@ func TextIsNil() predicate.FieldType {
 // TextNotNil applies the NotNil predicate on the "text" field.
 func TextNotNil() predicate.FieldType {
 	return predicate.FieldType(sql.FieldNotNull(FieldText))
-}
-
-// TextEqualFold applies the EqualFold predicate on the "text" field.
-func TextEqualFold(v string) predicate.FieldType {
-	return predicate.FieldType(sql.FieldEqualFold(FieldText, v))
-}
-
-// TextContainsFold applies the ContainsFold predicate on the "text" field.
-func TextContainsFold(v string) predicate.FieldType {
-	return predicate.FieldType(sql.FieldContainsFold(FieldText, v))
 }
 
 // DatetimeEQ applies the EQ predicate on the "datetime" field.
@@ -1824,10 +1824,22 @@ func MACLTE(v schema.MAC) predicate.FieldType {
 	return predicate.FieldType(sql.FieldLTE(FieldMAC, v))
 }
 
+// MACEqualFold applies the EqualFold predicate on the "mac" field.
+func MACEqualFold(v schema.MAC) predicate.FieldType {
+	vc := v.String()
+	return predicate.FieldType(sql.FieldEqualFold(FieldMAC, vc))
+}
+
 // MACContains applies the Contains predicate on the "mac" field.
 func MACContains(v schema.MAC) predicate.FieldType {
 	vc := v.String()
 	return predicate.FieldType(sql.FieldContains(FieldMAC, vc))
+}
+
+// MACContainsFold applies the ContainsFold predicate on the "mac" field.
+func MACContainsFold(v schema.MAC) predicate.FieldType {
+	vc := v.String()
+	return predicate.FieldType(sql.FieldContainsFold(FieldMAC, vc))
 }
 
 // MACHasPrefix applies the HasPrefix predicate on the "mac" field.
@@ -1850,18 +1862,6 @@ func MACIsNil() predicate.FieldType {
 // MACNotNil applies the NotNil predicate on the "mac" field.
 func MACNotNil() predicate.FieldType {
 	return predicate.FieldType(sql.FieldNotNull(FieldMAC))
-}
-
-// MACEqualFold applies the EqualFold predicate on the "mac" field.
-func MACEqualFold(v schema.MAC) predicate.FieldType {
-	vc := v.String()
-	return predicate.FieldType(sql.FieldEqualFold(FieldMAC, vc))
-}
-
-// MACContainsFold applies the ContainsFold predicate on the "mac" field.
-func MACContainsFold(v schema.MAC) predicate.FieldType {
-	vc := v.String()
-	return predicate.FieldType(sql.FieldContainsFold(FieldMAC, vc))
 }
 
 // StringArrayEQ applies the EQ predicate on the "string_array" field.
@@ -1954,9 +1954,19 @@ func PasswordLTE(v string) predicate.FieldType {
 	return predicate.FieldType(sql.FieldLTE(FieldPassword, v))
 }
 
+// PasswordEqualFold applies the EqualFold predicate on the "password" field.
+func PasswordEqualFold(v string) predicate.FieldType {
+	return predicate.FieldType(sql.FieldEqualFold(FieldPassword, v))
+}
+
 // PasswordContains applies the Contains predicate on the "password" field.
 func PasswordContains(v string) predicate.FieldType {
 	return predicate.FieldType(sql.FieldContains(FieldPassword, v))
+}
+
+// PasswordContainsFold applies the ContainsFold predicate on the "password" field.
+func PasswordContainsFold(v string) predicate.FieldType {
+	return predicate.FieldType(sql.FieldContainsFold(FieldPassword, v))
 }
 
 // PasswordHasPrefix applies the HasPrefix predicate on the "password" field.
@@ -1977,16 +1987,6 @@ func PasswordIsNil() predicate.FieldType {
 // PasswordNotNil applies the NotNil predicate on the "password" field.
 func PasswordNotNil() predicate.FieldType {
 	return predicate.FieldType(sql.FieldNotNull(FieldPassword))
-}
-
-// PasswordEqualFold applies the EqualFold predicate on the "password" field.
-func PasswordEqualFold(v string) predicate.FieldType {
-	return predicate.FieldType(sql.FieldEqualFold(FieldPassword, v))
-}
-
-// PasswordContainsFold applies the ContainsFold predicate on the "password" field.
-func PasswordContainsFold(v string) predicate.FieldType {
-	return predicate.FieldType(sql.FieldContainsFold(FieldPassword, v))
 }
 
 // StringScannerEQ applies the EQ predicate on the "string_scanner" field.
@@ -2029,10 +2029,22 @@ func StringScannerLTE(v schema.StringScanner) predicate.FieldType {
 	return predicate.FieldType(sql.FieldLTE(FieldStringScanner, v))
 }
 
+// StringScannerEqualFold applies the EqualFold predicate on the "string_scanner" field.
+func StringScannerEqualFold(v schema.StringScanner) predicate.FieldType {
+	vc := string(v)
+	return predicate.FieldType(sql.FieldEqualFold(FieldStringScanner, vc))
+}
+
 // StringScannerContains applies the Contains predicate on the "string_scanner" field.
 func StringScannerContains(v schema.StringScanner) predicate.FieldType {
 	vc := string(v)
 	return predicate.FieldType(sql.FieldContains(FieldStringScanner, vc))
+}
+
+// StringScannerContainsFold applies the ContainsFold predicate on the "string_scanner" field.
+func StringScannerContainsFold(v schema.StringScanner) predicate.FieldType {
+	vc := string(v)
+	return predicate.FieldType(sql.FieldContainsFold(FieldStringScanner, vc))
 }
 
 // StringScannerHasPrefix applies the HasPrefix predicate on the "string_scanner" field.
@@ -2055,18 +2067,6 @@ func StringScannerIsNil() predicate.FieldType {
 // StringScannerNotNil applies the NotNil predicate on the "string_scanner" field.
 func StringScannerNotNil() predicate.FieldType {
 	return predicate.FieldType(sql.FieldNotNull(FieldStringScanner))
-}
-
-// StringScannerEqualFold applies the EqualFold predicate on the "string_scanner" field.
-func StringScannerEqualFold(v schema.StringScanner) predicate.FieldType {
-	vc := string(v)
-	return predicate.FieldType(sql.FieldEqualFold(FieldStringScanner, vc))
-}
-
-// StringScannerContainsFold applies the ContainsFold predicate on the "string_scanner" field.
-func StringScannerContainsFold(v schema.StringScanner) predicate.FieldType {
-	vc := string(v)
-	return predicate.FieldType(sql.FieldContainsFold(FieldStringScanner, vc))
 }
 
 // DurationEQ applies the EQ predicate on the "duration" field.
@@ -2187,10 +2187,22 @@ func DirLTE(v http.Dir) predicate.FieldType {
 	return predicate.FieldType(sql.FieldLTE(FieldDir, vc))
 }
 
+// DirEqualFold applies the EqualFold predicate on the "dir" field.
+func DirEqualFold(v http.Dir) predicate.FieldType {
+	vc := string(v)
+	return predicate.FieldType(sql.FieldEqualFold(FieldDir, vc))
+}
+
 // DirContains applies the Contains predicate on the "dir" field.
 func DirContains(v http.Dir) predicate.FieldType {
 	vc := string(v)
 	return predicate.FieldType(sql.FieldContains(FieldDir, vc))
+}
+
+// DirContainsFold applies the ContainsFold predicate on the "dir" field.
+func DirContainsFold(v http.Dir) predicate.FieldType {
+	vc := string(v)
+	return predicate.FieldType(sql.FieldContainsFold(FieldDir, vc))
 }
 
 // DirHasPrefix applies the HasPrefix predicate on the "dir" field.
@@ -2203,18 +2215,6 @@ func DirHasPrefix(v http.Dir) predicate.FieldType {
 func DirHasSuffix(v http.Dir) predicate.FieldType {
 	vc := string(v)
 	return predicate.FieldType(sql.FieldHasSuffix(FieldDir, vc))
-}
-
-// DirEqualFold applies the EqualFold predicate on the "dir" field.
-func DirEqualFold(v http.Dir) predicate.FieldType {
-	vc := string(v)
-	return predicate.FieldType(sql.FieldEqualFold(FieldDir, vc))
-}
-
-// DirContainsFold applies the ContainsFold predicate on the "dir" field.
-func DirContainsFold(v http.Dir) predicate.FieldType {
-	vc := string(v)
-	return predicate.FieldType(sql.FieldContainsFold(FieldDir, vc))
 }
 
 // NdirEQ applies the EQ predicate on the "ndir" field.
@@ -2271,10 +2271,22 @@ func NdirLTE(v http.Dir) predicate.FieldType {
 	return predicate.FieldType(sql.FieldLTE(FieldNdir, vc))
 }
 
+// NdirEqualFold applies the EqualFold predicate on the "ndir" field.
+func NdirEqualFold(v http.Dir) predicate.FieldType {
+	vc := string(v)
+	return predicate.FieldType(sql.FieldEqualFold(FieldNdir, vc))
+}
+
 // NdirContains applies the Contains predicate on the "ndir" field.
 func NdirContains(v http.Dir) predicate.FieldType {
 	vc := string(v)
 	return predicate.FieldType(sql.FieldContains(FieldNdir, vc))
+}
+
+// NdirContainsFold applies the ContainsFold predicate on the "ndir" field.
+func NdirContainsFold(v http.Dir) predicate.FieldType {
+	vc := string(v)
+	return predicate.FieldType(sql.FieldContainsFold(FieldNdir, vc))
 }
 
 // NdirHasPrefix applies the HasPrefix predicate on the "ndir" field.
@@ -2297,18 +2309,6 @@ func NdirIsNil() predicate.FieldType {
 // NdirNotNil applies the NotNil predicate on the "ndir" field.
 func NdirNotNil() predicate.FieldType {
 	return predicate.FieldType(sql.FieldNotNull(FieldNdir))
-}
-
-// NdirEqualFold applies the EqualFold predicate on the "ndir" field.
-func NdirEqualFold(v http.Dir) predicate.FieldType {
-	vc := string(v)
-	return predicate.FieldType(sql.FieldEqualFold(FieldNdir, vc))
-}
-
-// NdirContainsFold applies the ContainsFold predicate on the "ndir" field.
-func NdirContainsFold(v http.Dir) predicate.FieldType {
-	vc := string(v)
-	return predicate.FieldType(sql.FieldContainsFold(FieldNdir, vc))
 }
 
 // StrEQ applies the EQ predicate on the "str" field.
@@ -2351,10 +2351,22 @@ func StrLTE(v sql.NullString) predicate.FieldType {
 	return predicate.FieldType(sql.FieldLTE(FieldStr, v))
 }
 
+// StrEqualFold applies the EqualFold predicate on the "str" field.
+func StrEqualFold(v sql.NullString) predicate.FieldType {
+	vc := v.String
+	return predicate.FieldType(sql.FieldEqualFold(FieldStr, vc))
+}
+
 // StrContains applies the Contains predicate on the "str" field.
 func StrContains(v sql.NullString) predicate.FieldType {
 	vc := v.String
 	return predicate.FieldType(sql.FieldContains(FieldStr, vc))
+}
+
+// StrContainsFold applies the ContainsFold predicate on the "str" field.
+func StrContainsFold(v sql.NullString) predicate.FieldType {
+	vc := v.String
+	return predicate.FieldType(sql.FieldContainsFold(FieldStr, vc))
 }
 
 // StrHasPrefix applies the HasPrefix predicate on the "str" field.
@@ -2377,18 +2389,6 @@ func StrIsNil() predicate.FieldType {
 // StrNotNil applies the NotNil predicate on the "str" field.
 func StrNotNil() predicate.FieldType {
 	return predicate.FieldType(sql.FieldNotNull(FieldStr))
-}
-
-// StrEqualFold applies the EqualFold predicate on the "str" field.
-func StrEqualFold(v sql.NullString) predicate.FieldType {
-	vc := v.String
-	return predicate.FieldType(sql.FieldEqualFold(FieldStr, vc))
-}
-
-// StrContainsFold applies the ContainsFold predicate on the "str" field.
-func StrContainsFold(v sql.NullString) predicate.FieldType {
-	vc := v.String
-	return predicate.FieldType(sql.FieldContainsFold(FieldStr, vc))
 }
 
 // NullStrEQ applies the EQ predicate on the "null_str" field.
@@ -2431,10 +2431,22 @@ func NullStrLTE(v *sql.NullString) predicate.FieldType {
 	return predicate.FieldType(sql.FieldLTE(FieldNullStr, v))
 }
 
+// NullStrEqualFold applies the EqualFold predicate on the "null_str" field.
+func NullStrEqualFold(v *sql.NullString) predicate.FieldType {
+	vc := v.String
+	return predicate.FieldType(sql.FieldEqualFold(FieldNullStr, vc))
+}
+
 // NullStrContains applies the Contains predicate on the "null_str" field.
 func NullStrContains(v *sql.NullString) predicate.FieldType {
 	vc := v.String
 	return predicate.FieldType(sql.FieldContains(FieldNullStr, vc))
+}
+
+// NullStrContainsFold applies the ContainsFold predicate on the "null_str" field.
+func NullStrContainsFold(v *sql.NullString) predicate.FieldType {
+	vc := v.String
+	return predicate.FieldType(sql.FieldContainsFold(FieldNullStr, vc))
 }
 
 // NullStrHasPrefix applies the HasPrefix predicate on the "null_str" field.
@@ -2457,18 +2469,6 @@ func NullStrIsNil() predicate.FieldType {
 // NullStrNotNil applies the NotNil predicate on the "null_str" field.
 func NullStrNotNil() predicate.FieldType {
 	return predicate.FieldType(sql.FieldNotNull(FieldNullStr))
-}
-
-// NullStrEqualFold applies the EqualFold predicate on the "null_str" field.
-func NullStrEqualFold(v *sql.NullString) predicate.FieldType {
-	vc := v.String
-	return predicate.FieldType(sql.FieldEqualFold(FieldNullStr, vc))
-}
-
-// NullStrContainsFold applies the ContainsFold predicate on the "null_str" field.
-func NullStrContainsFold(v *sql.NullString) predicate.FieldType {
-	vc := v.String
-	return predicate.FieldType(sql.FieldContainsFold(FieldNullStr, vc))
 }
 
 // LinkEQ applies the EQ predicate on the "link" field.
@@ -2511,10 +2511,22 @@ func LinkLTE(v schema.Link) predicate.FieldType {
 	return predicate.FieldType(sql.FieldLTE(FieldLink, v))
 }
 
+// LinkEqualFold applies the EqualFold predicate on the "link" field.
+func LinkEqualFold(v schema.Link) predicate.FieldType {
+	vc := v.String()
+	return predicate.FieldType(sql.FieldEqualFold(FieldLink, vc))
+}
+
 // LinkContains applies the Contains predicate on the "link" field.
 func LinkContains(v schema.Link) predicate.FieldType {
 	vc := v.String()
 	return predicate.FieldType(sql.FieldContains(FieldLink, vc))
+}
+
+// LinkContainsFold applies the ContainsFold predicate on the "link" field.
+func LinkContainsFold(v schema.Link) predicate.FieldType {
+	vc := v.String()
+	return predicate.FieldType(sql.FieldContainsFold(FieldLink, vc))
 }
 
 // LinkHasPrefix applies the HasPrefix predicate on the "link" field.
@@ -2537,18 +2549,6 @@ func LinkIsNil() predicate.FieldType {
 // LinkNotNil applies the NotNil predicate on the "link" field.
 func LinkNotNil() predicate.FieldType {
 	return predicate.FieldType(sql.FieldNotNull(FieldLink))
-}
-
-// LinkEqualFold applies the EqualFold predicate on the "link" field.
-func LinkEqualFold(v schema.Link) predicate.FieldType {
-	vc := v.String()
-	return predicate.FieldType(sql.FieldEqualFold(FieldLink, vc))
-}
-
-// LinkContainsFold applies the ContainsFold predicate on the "link" field.
-func LinkContainsFold(v schema.Link) predicate.FieldType {
-	vc := v.String()
-	return predicate.FieldType(sql.FieldContainsFold(FieldLink, vc))
 }
 
 // NullLinkEQ applies the EQ predicate on the "null_link" field.
@@ -2591,10 +2591,22 @@ func NullLinkLTE(v *schema.Link) predicate.FieldType {
 	return predicate.FieldType(sql.FieldLTE(FieldNullLink, v))
 }
 
+// NullLinkEqualFold applies the EqualFold predicate on the "null_link" field.
+func NullLinkEqualFold(v *schema.Link) predicate.FieldType {
+	vc := v.String()
+	return predicate.FieldType(sql.FieldEqualFold(FieldNullLink, vc))
+}
+
 // NullLinkContains applies the Contains predicate on the "null_link" field.
 func NullLinkContains(v *schema.Link) predicate.FieldType {
 	vc := v.String()
 	return predicate.FieldType(sql.FieldContains(FieldNullLink, vc))
+}
+
+// NullLinkContainsFold applies the ContainsFold predicate on the "null_link" field.
+func NullLinkContainsFold(v *schema.Link) predicate.FieldType {
+	vc := v.String()
+	return predicate.FieldType(sql.FieldContainsFold(FieldNullLink, vc))
 }
 
 // NullLinkHasPrefix applies the HasPrefix predicate on the "null_link" field.
@@ -2617,18 +2629,6 @@ func NullLinkIsNil() predicate.FieldType {
 // NullLinkNotNil applies the NotNil predicate on the "null_link" field.
 func NullLinkNotNil() predicate.FieldType {
 	return predicate.FieldType(sql.FieldNotNull(FieldNullLink))
-}
-
-// NullLinkEqualFold applies the EqualFold predicate on the "null_link" field.
-func NullLinkEqualFold(v *schema.Link) predicate.FieldType {
-	vc := v.String()
-	return predicate.FieldType(sql.FieldEqualFold(FieldNullLink, vc))
-}
-
-// NullLinkContainsFold applies the ContainsFold predicate on the "null_link" field.
-func NullLinkContainsFold(v *schema.Link) predicate.FieldType {
-	vc := v.String()
-	return predicate.FieldType(sql.FieldContainsFold(FieldNullLink, vc))
 }
 
 // ActiveEQ applies the EQ predicate on the "active" field.
@@ -3629,10 +3629,22 @@ func VstringLTE(v schema.VString) predicate.FieldType {
 	return predicate.FieldType(sql.FieldLTE(FieldVstring, v))
 }
 
+// VstringEqualFold applies the EqualFold predicate on the "vstring" field.
+func VstringEqualFold(v schema.VString) predicate.FieldType {
+	vc := string(v)
+	return predicate.FieldType(sql.FieldEqualFold(FieldVstring, vc))
+}
+
 // VstringContains applies the Contains predicate on the "vstring" field.
 func VstringContains(v schema.VString) predicate.FieldType {
 	vc := string(v)
 	return predicate.FieldType(sql.FieldContains(FieldVstring, vc))
+}
+
+// VstringContainsFold applies the ContainsFold predicate on the "vstring" field.
+func VstringContainsFold(v schema.VString) predicate.FieldType {
+	vc := string(v)
+	return predicate.FieldType(sql.FieldContainsFold(FieldVstring, vc))
 }
 
 // VstringHasPrefix applies the HasPrefix predicate on the "vstring" field.
@@ -3645,18 +3657,6 @@ func VstringHasPrefix(v schema.VString) predicate.FieldType {
 func VstringHasSuffix(v schema.VString) predicate.FieldType {
 	vc := string(v)
 	return predicate.FieldType(sql.FieldHasSuffix(FieldVstring, vc))
-}
-
-// VstringEqualFold applies the EqualFold predicate on the "vstring" field.
-func VstringEqualFold(v schema.VString) predicate.FieldType {
-	vc := string(v)
-	return predicate.FieldType(sql.FieldEqualFold(FieldVstring, vc))
-}
-
-// VstringContainsFold applies the ContainsFold predicate on the "vstring" field.
-func VstringContainsFold(v schema.VString) predicate.FieldType {
-	vc := string(v)
-	return predicate.FieldType(sql.FieldContainsFold(FieldVstring, vc))
 }
 
 // TripleEQ applies the EQ predicate on the "triple" field.

--- a/entc/integration/ent/file/where.go
+++ b/entc/integration/ent/file/where.go
@@ -162,9 +162,19 @@ func NameLTE(v string) predicate.File {
 	return predicate.File(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.File {
+	return predicate.File(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.File {
 	return predicate.File(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.File {
+	return predicate.File(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -175,16 +185,6 @@ func NameHasPrefix(v string) predicate.File {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.File {
 	return predicate.File(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.File {
-	return predicate.File(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.File {
-	return predicate.File(sql.FieldContainsFold(FieldName, v))
 }
 
 // UserEQ applies the EQ predicate on the "user" field.
@@ -227,9 +227,19 @@ func UserLTE(v string) predicate.File {
 	return predicate.File(sql.FieldLTE(FieldUser, v))
 }
 
+// UserEqualFold applies the EqualFold predicate on the "user" field.
+func UserEqualFold(v string) predicate.File {
+	return predicate.File(sql.FieldEqualFold(FieldUser, v))
+}
+
 // UserContains applies the Contains predicate on the "user" field.
 func UserContains(v string) predicate.File {
 	return predicate.File(sql.FieldContains(FieldUser, v))
+}
+
+// UserContainsFold applies the ContainsFold predicate on the "user" field.
+func UserContainsFold(v string) predicate.File {
+	return predicate.File(sql.FieldContainsFold(FieldUser, v))
 }
 
 // UserHasPrefix applies the HasPrefix predicate on the "user" field.
@@ -250,16 +260,6 @@ func UserIsNil() predicate.File {
 // UserNotNil applies the NotNil predicate on the "user" field.
 func UserNotNil() predicate.File {
 	return predicate.File(sql.FieldNotNull(FieldUser))
-}
-
-// UserEqualFold applies the EqualFold predicate on the "user" field.
-func UserEqualFold(v string) predicate.File {
-	return predicate.File(sql.FieldEqualFold(FieldUser, v))
-}
-
-// UserContainsFold applies the ContainsFold predicate on the "user" field.
-func UserContainsFold(v string) predicate.File {
-	return predicate.File(sql.FieldContainsFold(FieldUser, v))
 }
 
 // GroupEQ applies the EQ predicate on the "group" field.
@@ -302,9 +302,19 @@ func GroupLTE(v string) predicate.File {
 	return predicate.File(sql.FieldLTE(FieldGroup, v))
 }
 
+// GroupEqualFold applies the EqualFold predicate on the "group" field.
+func GroupEqualFold(v string) predicate.File {
+	return predicate.File(sql.FieldEqualFold(FieldGroup, v))
+}
+
 // GroupContains applies the Contains predicate on the "group" field.
 func GroupContains(v string) predicate.File {
 	return predicate.File(sql.FieldContains(FieldGroup, v))
+}
+
+// GroupContainsFold applies the ContainsFold predicate on the "group" field.
+func GroupContainsFold(v string) predicate.File {
+	return predicate.File(sql.FieldContainsFold(FieldGroup, v))
 }
 
 // GroupHasPrefix applies the HasPrefix predicate on the "group" field.
@@ -325,16 +335,6 @@ func GroupIsNil() predicate.File {
 // GroupNotNil applies the NotNil predicate on the "group" field.
 func GroupNotNil() predicate.File {
 	return predicate.File(sql.FieldNotNull(FieldGroup))
-}
-
-// GroupEqualFold applies the EqualFold predicate on the "group" field.
-func GroupEqualFold(v string) predicate.File {
-	return predicate.File(sql.FieldEqualFold(FieldGroup, v))
-}
-
-// GroupContainsFold applies the ContainsFold predicate on the "group" field.
-func GroupContainsFold(v string) predicate.File {
-	return predicate.File(sql.FieldContainsFold(FieldGroup, v))
 }
 
 // OpEQ applies the EQ predicate on the "op" field.

--- a/entc/integration/ent/filetype/where.go
+++ b/entc/integration/ent/filetype/where.go
@@ -102,9 +102,19 @@ func NameLTE(v string) predicate.FileType {
 	return predicate.FileType(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.FileType {
+	return predicate.FileType(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.FileType {
 	return predicate.FileType(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.FileType {
+	return predicate.FileType(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -115,16 +125,6 @@ func NameHasPrefix(v string) predicate.FileType {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.FileType {
 	return predicate.FileType(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.FileType {
-	return predicate.FileType(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.FileType {
-	return predicate.FileType(sql.FieldContainsFold(FieldName, v))
 }
 
 // TypeEQ applies the EQ predicate on the "type" field.

--- a/entc/integration/ent/group/where.go
+++ b/entc/integration/ent/group/where.go
@@ -174,9 +174,19 @@ func TypeLTE(v string) predicate.Group {
 	return predicate.Group(sql.FieldLTE(FieldType, v))
 }
 
+// TypeEqualFold applies the EqualFold predicate on the "type" field.
+func TypeEqualFold(v string) predicate.Group {
+	return predicate.Group(sql.FieldEqualFold(FieldType, v))
+}
+
 // TypeContains applies the Contains predicate on the "type" field.
 func TypeContains(v string) predicate.Group {
 	return predicate.Group(sql.FieldContains(FieldType, v))
+}
+
+// TypeContainsFold applies the ContainsFold predicate on the "type" field.
+func TypeContainsFold(v string) predicate.Group {
+	return predicate.Group(sql.FieldContainsFold(FieldType, v))
 }
 
 // TypeHasPrefix applies the HasPrefix predicate on the "type" field.
@@ -197,16 +207,6 @@ func TypeIsNil() predicate.Group {
 // TypeNotNil applies the NotNil predicate on the "type" field.
 func TypeNotNil() predicate.Group {
 	return predicate.Group(sql.FieldNotNull(FieldType))
-}
-
-// TypeEqualFold applies the EqualFold predicate on the "type" field.
-func TypeEqualFold(v string) predicate.Group {
-	return predicate.Group(sql.FieldEqualFold(FieldType, v))
-}
-
-// TypeContainsFold applies the ContainsFold predicate on the "type" field.
-func TypeContainsFold(v string) predicate.Group {
-	return predicate.Group(sql.FieldContainsFold(FieldType, v))
 }
 
 // MaxUsersEQ applies the EQ predicate on the "max_users" field.
@@ -299,9 +299,19 @@ func NameLTE(v string) predicate.Group {
 	return predicate.Group(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.Group {
+	return predicate.Group(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.Group {
 	return predicate.Group(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.Group {
+	return predicate.Group(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -312,16 +322,6 @@ func NameHasPrefix(v string) predicate.Group {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.Group {
 	return predicate.Group(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.Group {
-	return predicate.Group(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.Group {
-	return predicate.Group(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasFiles applies the HasEdge predicate on the "files" edge.

--- a/entc/integration/ent/groupinfo/where.go
+++ b/entc/integration/ent/groupinfo/where.go
@@ -107,9 +107,19 @@ func DescLTE(v string) predicate.GroupInfo {
 	return predicate.GroupInfo(sql.FieldLTE(FieldDesc, v))
 }
 
+// DescEqualFold applies the EqualFold predicate on the "desc" field.
+func DescEqualFold(v string) predicate.GroupInfo {
+	return predicate.GroupInfo(sql.FieldEqualFold(FieldDesc, v))
+}
+
 // DescContains applies the Contains predicate on the "desc" field.
 func DescContains(v string) predicate.GroupInfo {
 	return predicate.GroupInfo(sql.FieldContains(FieldDesc, v))
+}
+
+// DescContainsFold applies the ContainsFold predicate on the "desc" field.
+func DescContainsFold(v string) predicate.GroupInfo {
+	return predicate.GroupInfo(sql.FieldContainsFold(FieldDesc, v))
 }
 
 // DescHasPrefix applies the HasPrefix predicate on the "desc" field.
@@ -120,16 +130,6 @@ func DescHasPrefix(v string) predicate.GroupInfo {
 // DescHasSuffix applies the HasSuffix predicate on the "desc" field.
 func DescHasSuffix(v string) predicate.GroupInfo {
 	return predicate.GroupInfo(sql.FieldHasSuffix(FieldDesc, v))
-}
-
-// DescEqualFold applies the EqualFold predicate on the "desc" field.
-func DescEqualFold(v string) predicate.GroupInfo {
-	return predicate.GroupInfo(sql.FieldEqualFold(FieldDesc, v))
-}
-
-// DescContainsFold applies the ContainsFold predicate on the "desc" field.
-func DescContainsFold(v string) predicate.GroupInfo {
-	return predicate.GroupInfo(sql.FieldContainsFold(FieldDesc, v))
 }
 
 // MaxUsersEQ applies the EQ predicate on the "max_users" field.

--- a/entc/integration/ent/item/where.go
+++ b/entc/integration/ent/item/where.go
@@ -111,9 +111,19 @@ func TextLTE(v string) predicate.Item {
 	return predicate.Item(sql.FieldLTE(FieldText, v))
 }
 
+// TextEqualFold applies the EqualFold predicate on the "text" field.
+func TextEqualFold(v string) predicate.Item {
+	return predicate.Item(sql.FieldEqualFold(FieldText, v))
+}
+
 // TextContains applies the Contains predicate on the "text" field.
 func TextContains(v string) predicate.Item {
 	return predicate.Item(sql.FieldContains(FieldText, v))
+}
+
+// TextContainsFold applies the ContainsFold predicate on the "text" field.
+func TextContainsFold(v string) predicate.Item {
+	return predicate.Item(sql.FieldContainsFold(FieldText, v))
 }
 
 // TextHasPrefix applies the HasPrefix predicate on the "text" field.
@@ -134,16 +144,6 @@ func TextIsNil() predicate.Item {
 // TextNotNil applies the NotNil predicate on the "text" field.
 func TextNotNil() predicate.Item {
 	return predicate.Item(sql.FieldNotNull(FieldText))
-}
-
-// TextEqualFold applies the EqualFold predicate on the "text" field.
-func TextEqualFold(v string) predicate.Item {
-	return predicate.Item(sql.FieldEqualFold(FieldText, v))
-}
-
-// TextContainsFold applies the ContainsFold predicate on the "text" field.
-func TextContainsFold(v string) predicate.Item {
-	return predicate.Item(sql.FieldContainsFold(FieldText, v))
 }
 
 // And groups predicates with the AND operator between them.

--- a/entc/integration/ent/pet/where.go
+++ b/entc/integration/ent/pet/where.go
@@ -163,9 +163,19 @@ func NameLTE(v string) predicate.Pet {
 	return predicate.Pet(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.Pet {
+	return predicate.Pet(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.Pet {
 	return predicate.Pet(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.Pet {
+	return predicate.Pet(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -176,16 +186,6 @@ func NameHasPrefix(v string) predicate.Pet {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.Pet {
 	return predicate.Pet(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.Pet {
-	return predicate.Pet(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.Pet {
-	return predicate.Pet(sql.FieldContainsFold(FieldName, v))
 }
 
 // UUIDEQ applies the EQ predicate on the "uuid" field.
@@ -278,9 +278,19 @@ func NicknameLTE(v string) predicate.Pet {
 	return predicate.Pet(sql.FieldLTE(FieldNickname, v))
 }
 
+// NicknameEqualFold applies the EqualFold predicate on the "nickname" field.
+func NicknameEqualFold(v string) predicate.Pet {
+	return predicate.Pet(sql.FieldEqualFold(FieldNickname, v))
+}
+
 // NicknameContains applies the Contains predicate on the "nickname" field.
 func NicknameContains(v string) predicate.Pet {
 	return predicate.Pet(sql.FieldContains(FieldNickname, v))
+}
+
+// NicknameContainsFold applies the ContainsFold predicate on the "nickname" field.
+func NicknameContainsFold(v string) predicate.Pet {
+	return predicate.Pet(sql.FieldContainsFold(FieldNickname, v))
 }
 
 // NicknameHasPrefix applies the HasPrefix predicate on the "nickname" field.
@@ -301,16 +311,6 @@ func NicknameIsNil() predicate.Pet {
 // NicknameNotNil applies the NotNil predicate on the "nickname" field.
 func NicknameNotNil() predicate.Pet {
 	return predicate.Pet(sql.FieldNotNull(FieldNickname))
-}
-
-// NicknameEqualFold applies the EqualFold predicate on the "nickname" field.
-func NicknameEqualFold(v string) predicate.Pet {
-	return predicate.Pet(sql.FieldEqualFold(FieldNickname, v))
-}
-
-// NicknameContainsFold applies the ContainsFold predicate on the "nickname" field.
-func NicknameContainsFold(v string) predicate.Pet {
-	return predicate.Pet(sql.FieldContainsFold(FieldNickname, v))
 }
 
 // TrainedEQ applies the EQ predicate on the "trained" field.

--- a/entc/integration/ent/task/where.go
+++ b/entc/integration/ent/task/where.go
@@ -234,9 +234,19 @@ func NameLTE(v string) predicate.Task {
 	return predicate.Task(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.Task {
+	return predicate.Task(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.Task {
 	return predicate.Task(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.Task {
+	return predicate.Task(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -257,16 +267,6 @@ func NameIsNil() predicate.Task {
 // NameNotNil applies the NotNil predicate on the "name" field.
 func NameNotNil() predicate.Task {
 	return predicate.Task(sql.FieldNotNull(FieldName))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.Task {
-	return predicate.Task(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.Task {
-	return predicate.Task(sql.FieldContainsFold(FieldName, v))
 }
 
 // OwnerEQ applies the EQ predicate on the "owner" field.
@@ -309,9 +309,19 @@ func OwnerLTE(v string) predicate.Task {
 	return predicate.Task(sql.FieldLTE(FieldOwner, v))
 }
 
+// OwnerEqualFold applies the EqualFold predicate on the "owner" field.
+func OwnerEqualFold(v string) predicate.Task {
+	return predicate.Task(sql.FieldEqualFold(FieldOwner, v))
+}
+
 // OwnerContains applies the Contains predicate on the "owner" field.
 func OwnerContains(v string) predicate.Task {
 	return predicate.Task(sql.FieldContains(FieldOwner, v))
+}
+
+// OwnerContainsFold applies the ContainsFold predicate on the "owner" field.
+func OwnerContainsFold(v string) predicate.Task {
+	return predicate.Task(sql.FieldContainsFold(FieldOwner, v))
 }
 
 // OwnerHasPrefix applies the HasPrefix predicate on the "owner" field.
@@ -332,16 +342,6 @@ func OwnerIsNil() predicate.Task {
 // OwnerNotNil applies the NotNil predicate on the "owner" field.
 func OwnerNotNil() predicate.Task {
 	return predicate.Task(sql.FieldNotNull(FieldOwner))
-}
-
-// OwnerEqualFold applies the EqualFold predicate on the "owner" field.
-func OwnerEqualFold(v string) predicate.Task {
-	return predicate.Task(sql.FieldEqualFold(FieldOwner, v))
-}
-
-// OwnerContainsFold applies the ContainsFold predicate on the "owner" field.
-func OwnerContainsFold(v string) predicate.Task {
-	return predicate.Task(sql.FieldContainsFold(FieldOwner, v))
 }
 
 // OrderEQ applies the EQ predicate on the "order" field.
@@ -484,9 +484,19 @@ func OpLTE(v string) predicate.Task {
 	return predicate.Task(sql.FieldLTE(FieldOp, v))
 }
 
+// OpEqualFold applies the EqualFold predicate on the "op" field.
+func OpEqualFold(v string) predicate.Task {
+	return predicate.Task(sql.FieldEqualFold(FieldOp, v))
+}
+
 // OpContains applies the Contains predicate on the "op" field.
 func OpContains(v string) predicate.Task {
 	return predicate.Task(sql.FieldContains(FieldOp, v))
+}
+
+// OpContainsFold applies the ContainsFold predicate on the "op" field.
+func OpContainsFold(v string) predicate.Task {
+	return predicate.Task(sql.FieldContainsFold(FieldOp, v))
 }
 
 // OpHasPrefix applies the HasPrefix predicate on the "op" field.
@@ -497,16 +507,6 @@ func OpHasPrefix(v string) predicate.Task {
 // OpHasSuffix applies the HasSuffix predicate on the "op" field.
 func OpHasSuffix(v string) predicate.Task {
 	return predicate.Task(sql.FieldHasSuffix(FieldOp, v))
-}
-
-// OpEqualFold applies the EqualFold predicate on the "op" field.
-func OpEqualFold(v string) predicate.Task {
-	return predicate.Task(sql.FieldEqualFold(FieldOp, v))
-}
-
-// OpContainsFold applies the ContainsFold predicate on the "op" field.
-func OpContainsFold(v string) predicate.Task {
-	return predicate.Task(sql.FieldContainsFold(FieldOp, v))
 }
 
 // And groups predicates with the AND operator between them.

--- a/entc/integration/ent/user/where.go
+++ b/entc/integration/ent/user/where.go
@@ -237,9 +237,19 @@ func NameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -250,16 +260,6 @@ func NameHasPrefix(v string) predicate.User {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // LastEQ applies the EQ predicate on the "last" field.
@@ -302,9 +302,19 @@ func LastLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldLast, v))
 }
 
+// LastEqualFold applies the EqualFold predicate on the "last" field.
+func LastEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldLast, v))
+}
+
 // LastContains applies the Contains predicate on the "last" field.
 func LastContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldLast, v))
+}
+
+// LastContainsFold applies the ContainsFold predicate on the "last" field.
+func LastContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldLast, v))
 }
 
 // LastHasPrefix applies the HasPrefix predicate on the "last" field.
@@ -315,16 +325,6 @@ func LastHasPrefix(v string) predicate.User {
 // LastHasSuffix applies the HasSuffix predicate on the "last" field.
 func LastHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldLast, v))
-}
-
-// LastEqualFold applies the EqualFold predicate on the "last" field.
-func LastEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldLast, v))
-}
-
-// LastContainsFold applies the ContainsFold predicate on the "last" field.
-func LastContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldLast, v))
 }
 
 // NicknameEQ applies the EQ predicate on the "nickname" field.
@@ -367,9 +367,19 @@ func NicknameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldNickname, v))
 }
 
+// NicknameEqualFold applies the EqualFold predicate on the "nickname" field.
+func NicknameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldNickname, v))
+}
+
 // NicknameContains applies the Contains predicate on the "nickname" field.
 func NicknameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldNickname, v))
+}
+
+// NicknameContainsFold applies the ContainsFold predicate on the "nickname" field.
+func NicknameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldNickname, v))
 }
 
 // NicknameHasPrefix applies the HasPrefix predicate on the "nickname" field.
@@ -390,16 +400,6 @@ func NicknameIsNil() predicate.User {
 // NicknameNotNil applies the NotNil predicate on the "nickname" field.
 func NicknameNotNil() predicate.User {
 	return predicate.User(sql.FieldNotNull(FieldNickname))
-}
-
-// NicknameEqualFold applies the EqualFold predicate on the "nickname" field.
-func NicknameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldNickname, v))
-}
-
-// NicknameContainsFold applies the ContainsFold predicate on the "nickname" field.
-func NicknameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldNickname, v))
 }
 
 // AddressEQ applies the EQ predicate on the "address" field.
@@ -442,9 +442,19 @@ func AddressLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldAddress, v))
 }
 
+// AddressEqualFold applies the EqualFold predicate on the "address" field.
+func AddressEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldAddress, v))
+}
+
 // AddressContains applies the Contains predicate on the "address" field.
 func AddressContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldAddress, v))
+}
+
+// AddressContainsFold applies the ContainsFold predicate on the "address" field.
+func AddressContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldAddress, v))
 }
 
 // AddressHasPrefix applies the HasPrefix predicate on the "address" field.
@@ -465,16 +475,6 @@ func AddressIsNil() predicate.User {
 // AddressNotNil applies the NotNil predicate on the "address" field.
 func AddressNotNil() predicate.User {
 	return predicate.User(sql.FieldNotNull(FieldAddress))
-}
-
-// AddressEqualFold applies the EqualFold predicate on the "address" field.
-func AddressEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldAddress, v))
-}
-
-// AddressContainsFold applies the ContainsFold predicate on the "address" field.
-func AddressContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldAddress, v))
 }
 
 // PhoneEQ applies the EQ predicate on the "phone" field.
@@ -517,9 +517,19 @@ func PhoneLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldPhone, v))
 }
 
+// PhoneEqualFold applies the EqualFold predicate on the "phone" field.
+func PhoneEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldPhone, v))
+}
+
 // PhoneContains applies the Contains predicate on the "phone" field.
 func PhoneContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldPhone, v))
+}
+
+// PhoneContainsFold applies the ContainsFold predicate on the "phone" field.
+func PhoneContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldPhone, v))
 }
 
 // PhoneHasPrefix applies the HasPrefix predicate on the "phone" field.
@@ -540,16 +550,6 @@ func PhoneIsNil() predicate.User {
 // PhoneNotNil applies the NotNil predicate on the "phone" field.
 func PhoneNotNil() predicate.User {
 	return predicate.User(sql.FieldNotNull(FieldPhone))
-}
-
-// PhoneEqualFold applies the EqualFold predicate on the "phone" field.
-func PhoneEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldPhone, v))
-}
-
-// PhoneContainsFold applies the ContainsFold predicate on the "phone" field.
-func PhoneContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldPhone, v))
 }
 
 // PasswordEQ applies the EQ predicate on the "password" field.
@@ -592,9 +592,19 @@ func PasswordLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldPassword, v))
 }
 
+// PasswordEqualFold applies the EqualFold predicate on the "password" field.
+func PasswordEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldPassword, v))
+}
+
 // PasswordContains applies the Contains predicate on the "password" field.
 func PasswordContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldPassword, v))
+}
+
+// PasswordContainsFold applies the ContainsFold predicate on the "password" field.
+func PasswordContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldPassword, v))
 }
 
 // PasswordHasPrefix applies the HasPrefix predicate on the "password" field.
@@ -615,16 +625,6 @@ func PasswordIsNil() predicate.User {
 // PasswordNotNil applies the NotNil predicate on the "password" field.
 func PasswordNotNil() predicate.User {
 	return predicate.User(sql.FieldNotNull(FieldPassword))
-}
-
-// PasswordEqualFold applies the EqualFold predicate on the "password" field.
-func PasswordEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldPassword, v))
-}
-
-// PasswordContainsFold applies the ContainsFold predicate on the "password" field.
-func PasswordContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldPassword, v))
 }
 
 // RoleEQ applies the EQ predicate on the "role" field.
@@ -707,9 +707,19 @@ func SSOCertLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldSSOCert, v))
 }
 
+// SSOCertEqualFold applies the EqualFold predicate on the "SSOCert" field.
+func SSOCertEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldSSOCert, v))
+}
+
 // SSOCertContains applies the Contains predicate on the "SSOCert" field.
 func SSOCertContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldSSOCert, v))
+}
+
+// SSOCertContainsFold applies the ContainsFold predicate on the "SSOCert" field.
+func SSOCertContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldSSOCert, v))
 }
 
 // SSOCertHasPrefix applies the HasPrefix predicate on the "SSOCert" field.
@@ -730,16 +740,6 @@ func SSOCertIsNil() predicate.User {
 // SSOCertNotNil applies the NotNil predicate on the "SSOCert" field.
 func SSOCertNotNil() predicate.User {
 	return predicate.User(sql.FieldNotNull(FieldSSOCert))
-}
-
-// SSOCertEqualFold applies the EqualFold predicate on the "SSOCert" field.
-func SSOCertEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldSSOCert, v))
-}
-
-// SSOCertContainsFold applies the ContainsFold predicate on the "SSOCert" field.
-func SSOCertContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldSSOCert, v))
 }
 
 // FilesCountEQ applies the EQ predicate on the "files_count" field.

--- a/entc/integration/gremlin/ent/card/where.go
+++ b/entc/integration/gremlin/ent/card/where.go
@@ -345,10 +345,24 @@ func NumberLTE(v string) predicate.Card {
 	})
 }
 
+// NumberEqualFold applies the EqualFold predicate on the "number" field.
+func NumberEqualFold(v string) predicate.Card {
+	return predicate.Card(func(t *dsl.Traversal) {
+		t.Has(Label, FieldNumber, p.EqualFold(v))
+	})
+}
+
 // NumberContains applies the Contains predicate on the "number" field.
 func NumberContains(v string) predicate.Card {
 	return predicate.Card(func(t *dsl.Traversal) {
 		t.Has(Label, FieldNumber, p.Containing(v))
+	})
+}
+
+// NumberContainsFold applies the ContainsFold predicate on the "number" field.
+func NumberContainsFold(v string) predicate.Card {
+	return predicate.Card(func(t *dsl.Traversal) {
+		t.Has(Label, FieldNumber, p.ContainsFold(v))
 	})
 }
 
@@ -422,10 +436,24 @@ func NameLTE(v string) predicate.Card {
 	})
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.Card {
+	return predicate.Card(func(t *dsl.Traversal) {
+		t.Has(Label, FieldName, p.EqualFold(v))
+	})
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.Card {
 	return predicate.Card(func(t *dsl.Traversal) {
 		t.Has(Label, FieldName, p.Containing(v))
+	})
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.Card {
+	return predicate.Card(func(t *dsl.Traversal) {
+		t.Has(Label, FieldName, p.ContainsFold(v))
 	})
 }
 

--- a/entc/integration/gremlin/ent/comment/where.go
+++ b/entc/integration/gremlin/ent/comment/where.go
@@ -350,10 +350,24 @@ func TableLTE(v string) predicate.Comment {
 	})
 }
 
+// TableEqualFold applies the EqualFold predicate on the "table" field.
+func TableEqualFold(v string) predicate.Comment {
+	return predicate.Comment(func(t *dsl.Traversal) {
+		t.Has(Label, FieldTable, p.EqualFold(v))
+	})
+}
+
 // TableContains applies the Contains predicate on the "table" field.
 func TableContains(v string) predicate.Comment {
 	return predicate.Comment(func(t *dsl.Traversal) {
 		t.Has(Label, FieldTable, p.Containing(v))
+	})
+}
+
+// TableContainsFold applies the ContainsFold predicate on the "table" field.
+func TableContainsFold(v string) predicate.Comment {
+	return predicate.Comment(func(t *dsl.Traversal) {
+		t.Has(Label, FieldTable, p.ContainsFold(v))
 	})
 }
 
@@ -455,10 +469,24 @@ func ClientLTE(v string) predicate.Comment {
 	})
 }
 
+// ClientEqualFold applies the EqualFold predicate on the "client" field.
+func ClientEqualFold(v string) predicate.Comment {
+	return predicate.Comment(func(t *dsl.Traversal) {
+		t.Has(Label, FieldClient, p.EqualFold(v))
+	})
+}
+
 // ClientContains applies the Contains predicate on the "client" field.
 func ClientContains(v string) predicate.Comment {
 	return predicate.Comment(func(t *dsl.Traversal) {
 		t.Has(Label, FieldClient, p.Containing(v))
+	})
+}
+
+// ClientContainsFold applies the ContainsFold predicate on the "client" field.
+func ClientContainsFold(v string) predicate.Comment {
+	return predicate.Comment(func(t *dsl.Traversal) {
+		t.Has(Label, FieldClient, p.ContainsFold(v))
 	})
 }
 

--- a/entc/integration/gremlin/ent/exvaluescan/where.go
+++ b/entc/integration/gremlin/ent/exvaluescan/where.go
@@ -224,6 +224,18 @@ func BinaryLTE(v *url.URL) predicate.ExValueScan {
 	}, err)
 }
 
+// BinaryEqualFold applies the EqualFold predicate on the "binary" field.
+func BinaryEqualFold(v *url.URL) predicate.ExValueScan {
+	vc, err := ValueScanner.Binary.Value(v)
+	vcs, ok := vc.(string)
+	if err == nil && !ok {
+		err = fmt.Errorf("binary value is not a string: %T", vc)
+	}
+	return predicate.ExValueScanOrErr(func(t *dsl.Traversal) {
+		t.Has(Label, FieldBinary, p.EqualFold(vcs))
+	}, err)
+}
+
 // BinaryContains applies the Contains predicate on the "binary" field.
 func BinaryContains(v *url.URL) predicate.ExValueScan {
 	vc, err := ValueScanner.Binary.Value(v)
@@ -233,6 +245,18 @@ func BinaryContains(v *url.URL) predicate.ExValueScan {
 	}
 	return predicate.ExValueScanOrErr(func(t *dsl.Traversal) {
 		t.Has(Label, FieldBinary, p.Containing(vcs))
+	}, err)
+}
+
+// BinaryContainsFold applies the ContainsFold predicate on the "binary" field.
+func BinaryContainsFold(v *url.URL) predicate.ExValueScan {
+	vc, err := ValueScanner.Binary.Value(v)
+	vcs, ok := vc.(string)
+	if err == nil && !ok {
+		err = fmt.Errorf("binary value is not a string: %T", vc)
+	}
+	return predicate.ExValueScanOrErr(func(t *dsl.Traversal) {
+		t.Has(Label, FieldBinary, p.ContainsFold(vcs))
 	}, err)
 }
 
@@ -340,6 +364,18 @@ func BinaryOptionalLTE(v *url.URL) predicate.ExValueScan {
 	}, err)
 }
 
+// BinaryOptionalEqualFold applies the EqualFold predicate on the "binary_optional" field.
+func BinaryOptionalEqualFold(v *url.URL) predicate.ExValueScan {
+	vc, err := ValueScanner.BinaryOptional.Value(v)
+	vcs, ok := vc.(string)
+	if err == nil && !ok {
+		err = fmt.Errorf("binary_optional value is not a string: %T", vc)
+	}
+	return predicate.ExValueScanOrErr(func(t *dsl.Traversal) {
+		t.Has(Label, FieldBinaryOptional, p.EqualFold(vcs))
+	}, err)
+}
+
 // BinaryOptionalContains applies the Contains predicate on the "binary_optional" field.
 func BinaryOptionalContains(v *url.URL) predicate.ExValueScan {
 	vc, err := ValueScanner.BinaryOptional.Value(v)
@@ -349,6 +385,18 @@ func BinaryOptionalContains(v *url.URL) predicate.ExValueScan {
 	}
 	return predicate.ExValueScanOrErr(func(t *dsl.Traversal) {
 		t.Has(Label, FieldBinaryOptional, p.Containing(vcs))
+	}, err)
+}
+
+// BinaryOptionalContainsFold applies the ContainsFold predicate on the "binary_optional" field.
+func BinaryOptionalContainsFold(v *url.URL) predicate.ExValueScan {
+	vc, err := ValueScanner.BinaryOptional.Value(v)
+	vcs, ok := vc.(string)
+	if err == nil && !ok {
+		err = fmt.Errorf("binary_optional value is not a string: %T", vc)
+	}
+	return predicate.ExValueScanOrErr(func(t *dsl.Traversal) {
+		t.Has(Label, FieldBinaryOptional, p.ContainsFold(vcs))
 	}, err)
 }
 
@@ -470,6 +518,18 @@ func TextLTE(v *big.Int) predicate.ExValueScan {
 	}, err)
 }
 
+// TextEqualFold applies the EqualFold predicate on the "text" field.
+func TextEqualFold(v *big.Int) predicate.ExValueScan {
+	vc, err := ValueScanner.Text.Value(v)
+	vcs, ok := vc.(string)
+	if err == nil && !ok {
+		err = fmt.Errorf("text value is not a string: %T", vc)
+	}
+	return predicate.ExValueScanOrErr(func(t *dsl.Traversal) {
+		t.Has(Label, FieldText, p.EqualFold(vcs))
+	}, err)
+}
+
 // TextContains applies the Contains predicate on the "text" field.
 func TextContains(v *big.Int) predicate.ExValueScan {
 	vc, err := ValueScanner.Text.Value(v)
@@ -479,6 +539,18 @@ func TextContains(v *big.Int) predicate.ExValueScan {
 	}
 	return predicate.ExValueScanOrErr(func(t *dsl.Traversal) {
 		t.Has(Label, FieldText, p.Containing(vcs))
+	}, err)
+}
+
+// TextContainsFold applies the ContainsFold predicate on the "text" field.
+func TextContainsFold(v *big.Int) predicate.ExValueScan {
+	vc, err := ValueScanner.Text.Value(v)
+	vcs, ok := vc.(string)
+	if err == nil && !ok {
+		err = fmt.Errorf("text value is not a string: %T", vc)
+	}
+	return predicate.ExValueScanOrErr(func(t *dsl.Traversal) {
+		t.Has(Label, FieldText, p.ContainsFold(vcs))
 	}, err)
 }
 
@@ -586,6 +658,18 @@ func TextOptionalLTE(v *big.Int) predicate.ExValueScan {
 	}, err)
 }
 
+// TextOptionalEqualFold applies the EqualFold predicate on the "text_optional" field.
+func TextOptionalEqualFold(v *big.Int) predicate.ExValueScan {
+	vc, err := ValueScanner.TextOptional.Value(v)
+	vcs, ok := vc.(string)
+	if err == nil && !ok {
+		err = fmt.Errorf("text_optional value is not a string: %T", vc)
+	}
+	return predicate.ExValueScanOrErr(func(t *dsl.Traversal) {
+		t.Has(Label, FieldTextOptional, p.EqualFold(vcs))
+	}, err)
+}
+
 // TextOptionalContains applies the Contains predicate on the "text_optional" field.
 func TextOptionalContains(v *big.Int) predicate.ExValueScan {
 	vc, err := ValueScanner.TextOptional.Value(v)
@@ -595,6 +679,18 @@ func TextOptionalContains(v *big.Int) predicate.ExValueScan {
 	}
 	return predicate.ExValueScanOrErr(func(t *dsl.Traversal) {
 		t.Has(Label, FieldTextOptional, p.Containing(vcs))
+	}, err)
+}
+
+// TextOptionalContainsFold applies the ContainsFold predicate on the "text_optional" field.
+func TextOptionalContainsFold(v *big.Int) predicate.ExValueScan {
+	vc, err := ValueScanner.TextOptional.Value(v)
+	vcs, ok := vc.(string)
+	if err == nil && !ok {
+		err = fmt.Errorf("text_optional value is not a string: %T", vc)
+	}
+	return predicate.ExValueScanOrErr(func(t *dsl.Traversal) {
+		t.Has(Label, FieldTextOptional, p.ContainsFold(vcs))
 	}, err)
 }
 
@@ -716,6 +812,18 @@ func Base64LTE(v string) predicate.ExValueScan {
 	}, err)
 }
 
+// Base64EqualFold applies the EqualFold predicate on the "base64" field.
+func Base64EqualFold(v string) predicate.ExValueScan {
+	vc, err := ValueScanner.Base64.Value(v)
+	vcs, ok := vc.(string)
+	if err == nil && !ok {
+		err = fmt.Errorf("base64 value is not a string: %T", vc)
+	}
+	return predicate.ExValueScanOrErr(func(t *dsl.Traversal) {
+		t.Has(Label, FieldBase64, p.EqualFold(vcs))
+	}, err)
+}
+
 // Base64Contains applies the Contains predicate on the "base64" field.
 func Base64Contains(v string) predicate.ExValueScan {
 	vc, err := ValueScanner.Base64.Value(v)
@@ -725,6 +833,18 @@ func Base64Contains(v string) predicate.ExValueScan {
 	}
 	return predicate.ExValueScanOrErr(func(t *dsl.Traversal) {
 		t.Has(Label, FieldBase64, p.Containing(vcs))
+	}, err)
+}
+
+// Base64ContainsFold applies the ContainsFold predicate on the "base64" field.
+func Base64ContainsFold(v string) predicate.ExValueScan {
+	vc, err := ValueScanner.Base64.Value(v)
+	vcs, ok := vc.(string)
+	if err == nil && !ok {
+		err = fmt.Errorf("base64 value is not a string: %T", vc)
+	}
+	return predicate.ExValueScanOrErr(func(t *dsl.Traversal) {
+		t.Has(Label, FieldBase64, p.ContainsFold(vcs))
 	}, err)
 }
 
@@ -832,6 +952,18 @@ func CustomLTE(v string) predicate.ExValueScan {
 	}, err)
 }
 
+// CustomEqualFold applies the EqualFold predicate on the "custom" field.
+func CustomEqualFold(v string) predicate.ExValueScan {
+	vc, err := ValueScanner.Custom.Value(v)
+	vcs, ok := vc.(string)
+	if err == nil && !ok {
+		err = fmt.Errorf("custom value is not a string: %T", vc)
+	}
+	return predicate.ExValueScanOrErr(func(t *dsl.Traversal) {
+		t.Has(Label, FieldCustom, p.EqualFold(vcs))
+	}, err)
+}
+
 // CustomContains applies the Contains predicate on the "custom" field.
 func CustomContains(v string) predicate.ExValueScan {
 	vc, err := ValueScanner.Custom.Value(v)
@@ -841,6 +973,18 @@ func CustomContains(v string) predicate.ExValueScan {
 	}
 	return predicate.ExValueScanOrErr(func(t *dsl.Traversal) {
 		t.Has(Label, FieldCustom, p.Containing(vcs))
+	}, err)
+}
+
+// CustomContainsFold applies the ContainsFold predicate on the "custom" field.
+func CustomContainsFold(v string) predicate.ExValueScan {
+	vc, err := ValueScanner.Custom.Value(v)
+	vcs, ok := vc.(string)
+	if err == nil && !ok {
+		err = fmt.Errorf("custom value is not a string: %T", vc)
+	}
+	return predicate.ExValueScanOrErr(func(t *dsl.Traversal) {
+		t.Has(Label, FieldCustom, p.ContainsFold(vcs))
 	}, err)
 }
 
@@ -948,6 +1092,18 @@ func CustomOptionalLTE(v string) predicate.ExValueScan {
 	}, err)
 }
 
+// CustomOptionalEqualFold applies the EqualFold predicate on the "custom_optional" field.
+func CustomOptionalEqualFold(v string) predicate.ExValueScan {
+	vc, err := ValueScanner.CustomOptional.Value(v)
+	vcs, ok := vc.(string)
+	if err == nil && !ok {
+		err = fmt.Errorf("custom_optional value is not a string: %T", vc)
+	}
+	return predicate.ExValueScanOrErr(func(t *dsl.Traversal) {
+		t.Has(Label, FieldCustomOptional, p.EqualFold(vcs))
+	}, err)
+}
+
 // CustomOptionalContains applies the Contains predicate on the "custom_optional" field.
 func CustomOptionalContains(v string) predicate.ExValueScan {
 	vc, err := ValueScanner.CustomOptional.Value(v)
@@ -957,6 +1113,18 @@ func CustomOptionalContains(v string) predicate.ExValueScan {
 	}
 	return predicate.ExValueScanOrErr(func(t *dsl.Traversal) {
 		t.Has(Label, FieldCustomOptional, p.Containing(vcs))
+	}, err)
+}
+
+// CustomOptionalContainsFold applies the ContainsFold predicate on the "custom_optional" field.
+func CustomOptionalContainsFold(v string) predicate.ExValueScan {
+	vc, err := ValueScanner.CustomOptional.Value(v)
+	vcs, ok := vc.(string)
+	if err == nil && !ok {
+		err = fmt.Errorf("custom_optional value is not a string: %T", vc)
+	}
+	return predicate.ExValueScanOrErr(func(t *dsl.Traversal) {
+		t.Has(Label, FieldCustomOptional, p.ContainsFold(vcs))
 	}, err)
 }
 

--- a/entc/integration/gremlin/ent/fieldtype/where.go
+++ b/entc/integration/gremlin/ent/fieldtype/where.go
@@ -2168,10 +2168,24 @@ func TextLTE(v string) predicate.FieldType {
 	})
 }
 
+// TextEqualFold applies the EqualFold predicate on the "text" field.
+func TextEqualFold(v string) predicate.FieldType {
+	return predicate.FieldType(func(t *dsl.Traversal) {
+		t.Has(Label, FieldText, p.EqualFold(v))
+	})
+}
+
 // TextContains applies the Contains predicate on the "text" field.
 func TextContains(v string) predicate.FieldType {
 	return predicate.FieldType(func(t *dsl.Traversal) {
 		t.Has(Label, FieldText, p.Containing(v))
+	})
+}
+
+// TextContainsFold applies the ContainsFold predicate on the "text" field.
+func TextContainsFold(v string) predicate.FieldType {
+	return predicate.FieldType(func(t *dsl.Traversal) {
+		t.Has(Label, FieldText, p.ContainsFold(v))
 	})
 }
 
@@ -2539,11 +2553,27 @@ func MACLTE(v schema.MAC) predicate.FieldType {
 	})
 }
 
+// MACEqualFold applies the EqualFold predicate on the "mac" field.
+func MACEqualFold(v schema.MAC) predicate.FieldType {
+	vc := v.String()
+	return predicate.FieldType(func(t *dsl.Traversal) {
+		t.Has(Label, FieldMAC, p.EqualFold(vc))
+	})
+}
+
 // MACContains applies the Contains predicate on the "mac" field.
 func MACContains(v schema.MAC) predicate.FieldType {
 	vc := v.String()
 	return predicate.FieldType(func(t *dsl.Traversal) {
 		t.Has(Label, FieldMAC, p.Containing(vc))
+	})
+}
+
+// MACContainsFold applies the ContainsFold predicate on the "mac" field.
+func MACContainsFold(v schema.MAC) predicate.FieldType {
+	vc := v.String()
+	return predicate.FieldType(func(t *dsl.Traversal) {
+		t.Has(Label, FieldMAC, p.ContainsFold(vc))
 	})
 }
 
@@ -2703,10 +2733,24 @@ func PasswordLTE(v string) predicate.FieldType {
 	})
 }
 
+// PasswordEqualFold applies the EqualFold predicate on the "password" field.
+func PasswordEqualFold(v string) predicate.FieldType {
+	return predicate.FieldType(func(t *dsl.Traversal) {
+		t.Has(Label, FieldPassword, p.EqualFold(v))
+	})
+}
+
 // PasswordContains applies the Contains predicate on the "password" field.
 func PasswordContains(v string) predicate.FieldType {
 	return predicate.FieldType(func(t *dsl.Traversal) {
 		t.Has(Label, FieldPassword, p.Containing(v))
+	})
+}
+
+// PasswordContainsFold applies the ContainsFold predicate on the "password" field.
+func PasswordContainsFold(v string) predicate.FieldType {
+	return predicate.FieldType(func(t *dsl.Traversal) {
+		t.Has(Label, FieldPassword, p.ContainsFold(v))
 	})
 }
 
@@ -2794,11 +2838,27 @@ func StringScannerLTE(v schema.StringScanner) predicate.FieldType {
 	})
 }
 
+// StringScannerEqualFold applies the EqualFold predicate on the "string_scanner" field.
+func StringScannerEqualFold(v schema.StringScanner) predicate.FieldType {
+	vc := string(v)
+	return predicate.FieldType(func(t *dsl.Traversal) {
+		t.Has(Label, FieldStringScanner, p.EqualFold(vc))
+	})
+}
+
 // StringScannerContains applies the Contains predicate on the "string_scanner" field.
 func StringScannerContains(v schema.StringScanner) predicate.FieldType {
 	vc := string(v)
 	return predicate.FieldType(func(t *dsl.Traversal) {
 		t.Has(Label, FieldStringScanner, p.Containing(vc))
+	})
+}
+
+// StringScannerContainsFold applies the ContainsFold predicate on the "string_scanner" field.
+func StringScannerContainsFold(v schema.StringScanner) predicate.FieldType {
+	vc := string(v)
+	return predicate.FieldType(func(t *dsl.Traversal) {
+		t.Has(Label, FieldStringScanner, p.ContainsFold(vc))
 	})
 }
 
@@ -2986,11 +3046,27 @@ func DirLTE(v http.Dir) predicate.FieldType {
 	})
 }
 
+// DirEqualFold applies the EqualFold predicate on the "dir" field.
+func DirEqualFold(v http.Dir) predicate.FieldType {
+	vc := string(v)
+	return predicate.FieldType(func(t *dsl.Traversal) {
+		t.Has(Label, FieldDir, p.EqualFold(vc))
+	})
+}
+
 // DirContains applies the Contains predicate on the "dir" field.
 func DirContains(v http.Dir) predicate.FieldType {
 	vc := string(v)
 	return predicate.FieldType(func(t *dsl.Traversal) {
 		t.Has(Label, FieldDir, p.Containing(vc))
+	})
+}
+
+// DirContainsFold applies the ContainsFold predicate on the "dir" field.
+func DirContainsFold(v http.Dir) predicate.FieldType {
+	vc := string(v)
+	return predicate.FieldType(func(t *dsl.Traversal) {
+		t.Has(Label, FieldDir, p.ContainsFold(vc))
 	})
 }
 
@@ -3080,11 +3156,27 @@ func NdirLTE(v http.Dir) predicate.FieldType {
 	})
 }
 
+// NdirEqualFold applies the EqualFold predicate on the "ndir" field.
+func NdirEqualFold(v http.Dir) predicate.FieldType {
+	vc := string(v)
+	return predicate.FieldType(func(t *dsl.Traversal) {
+		t.Has(Label, FieldNdir, p.EqualFold(vc))
+	})
+}
+
 // NdirContains applies the Contains predicate on the "ndir" field.
 func NdirContains(v http.Dir) predicate.FieldType {
 	vc := string(v)
 	return predicate.FieldType(func(t *dsl.Traversal) {
 		t.Has(Label, FieldNdir, p.Containing(vc))
+	})
+}
+
+// NdirContainsFold applies the ContainsFold predicate on the "ndir" field.
+func NdirContainsFold(v http.Dir) predicate.FieldType {
+	vc := string(v)
+	return predicate.FieldType(func(t *dsl.Traversal) {
+		t.Has(Label, FieldNdir, p.ContainsFold(vc))
 	})
 }
 
@@ -3174,11 +3266,27 @@ func StrLTE(v sql.NullString) predicate.FieldType {
 	})
 }
 
+// StrEqualFold applies the EqualFold predicate on the "str" field.
+func StrEqualFold(v sql.NullString) predicate.FieldType {
+	vc := v.String
+	return predicate.FieldType(func(t *dsl.Traversal) {
+		t.Has(Label, FieldStr, p.EqualFold(vc))
+	})
+}
+
 // StrContains applies the Contains predicate on the "str" field.
 func StrContains(v sql.NullString) predicate.FieldType {
 	vc := v.String
 	return predicate.FieldType(func(t *dsl.Traversal) {
 		t.Has(Label, FieldStr, p.Containing(vc))
+	})
+}
+
+// StrContainsFold applies the ContainsFold predicate on the "str" field.
+func StrContainsFold(v sql.NullString) predicate.FieldType {
+	vc := v.String
+	return predicate.FieldType(func(t *dsl.Traversal) {
+		t.Has(Label, FieldStr, p.ContainsFold(vc))
 	})
 }
 
@@ -3268,11 +3376,27 @@ func NullStrLTE(v *sql.NullString) predicate.FieldType {
 	})
 }
 
+// NullStrEqualFold applies the EqualFold predicate on the "null_str" field.
+func NullStrEqualFold(v *sql.NullString) predicate.FieldType {
+	vc := v.String
+	return predicate.FieldType(func(t *dsl.Traversal) {
+		t.Has(Label, FieldNullStr, p.EqualFold(vc))
+	})
+}
+
 // NullStrContains applies the Contains predicate on the "null_str" field.
 func NullStrContains(v *sql.NullString) predicate.FieldType {
 	vc := v.String
 	return predicate.FieldType(func(t *dsl.Traversal) {
 		t.Has(Label, FieldNullStr, p.Containing(vc))
+	})
+}
+
+// NullStrContainsFold applies the ContainsFold predicate on the "null_str" field.
+func NullStrContainsFold(v *sql.NullString) predicate.FieldType {
+	vc := v.String
+	return predicate.FieldType(func(t *dsl.Traversal) {
+		t.Has(Label, FieldNullStr, p.ContainsFold(vc))
 	})
 }
 
@@ -3362,11 +3486,27 @@ func LinkLTE(v schema.Link) predicate.FieldType {
 	})
 }
 
+// LinkEqualFold applies the EqualFold predicate on the "link" field.
+func LinkEqualFold(v schema.Link) predicate.FieldType {
+	vc := v.String()
+	return predicate.FieldType(func(t *dsl.Traversal) {
+		t.Has(Label, FieldLink, p.EqualFold(vc))
+	})
+}
+
 // LinkContains applies the Contains predicate on the "link" field.
 func LinkContains(v schema.Link) predicate.FieldType {
 	vc := v.String()
 	return predicate.FieldType(func(t *dsl.Traversal) {
 		t.Has(Label, FieldLink, p.Containing(vc))
+	})
+}
+
+// LinkContainsFold applies the ContainsFold predicate on the "link" field.
+func LinkContainsFold(v schema.Link) predicate.FieldType {
+	vc := v.String()
+	return predicate.FieldType(func(t *dsl.Traversal) {
+		t.Has(Label, FieldLink, p.ContainsFold(vc))
 	})
 }
 
@@ -3456,11 +3596,27 @@ func NullLinkLTE(v *schema.Link) predicate.FieldType {
 	})
 }
 
+// NullLinkEqualFold applies the EqualFold predicate on the "null_link" field.
+func NullLinkEqualFold(v *schema.Link) predicate.FieldType {
+	vc := v.String()
+	return predicate.FieldType(func(t *dsl.Traversal) {
+		t.Has(Label, FieldNullLink, p.EqualFold(vc))
+	})
+}
+
 // NullLinkContains applies the Contains predicate on the "null_link" field.
 func NullLinkContains(v *schema.Link) predicate.FieldType {
 	vc := v.String()
 	return predicate.FieldType(func(t *dsl.Traversal) {
 		t.Has(Label, FieldNullLink, p.Containing(vc))
+	})
+}
+
+// NullLinkContainsFold applies the ContainsFold predicate on the "null_link" field.
+func NullLinkContainsFold(v *schema.Link) predicate.FieldType {
+	vc := v.String()
+	return predicate.FieldType(func(t *dsl.Traversal) {
+		t.Has(Label, FieldNullLink, p.ContainsFold(vc))
 	})
 }
 
@@ -4852,11 +5008,27 @@ func VstringLTE(v schema.VString) predicate.FieldType {
 	})
 }
 
+// VstringEqualFold applies the EqualFold predicate on the "vstring" field.
+func VstringEqualFold(v schema.VString) predicate.FieldType {
+	vc := string(v)
+	return predicate.FieldType(func(t *dsl.Traversal) {
+		t.Has(Label, FieldVstring, p.EqualFold(vc))
+	})
+}
+
 // VstringContains applies the Contains predicate on the "vstring" field.
 func VstringContains(v schema.VString) predicate.FieldType {
 	vc := string(v)
 	return predicate.FieldType(func(t *dsl.Traversal) {
 		t.Has(Label, FieldVstring, p.Containing(vc))
+	})
+}
+
+// VstringContainsFold applies the ContainsFold predicate on the "vstring" field.
+func VstringContainsFold(v schema.VString) predicate.FieldType {
+	vc := string(v)
+	return predicate.FieldType(func(t *dsl.Traversal) {
+		t.Has(Label, FieldVstring, p.ContainsFold(vc))
 	})
 }
 

--- a/entc/integration/gremlin/ent/file/where.go
+++ b/entc/integration/gremlin/ent/file/where.go
@@ -231,10 +231,24 @@ func NameLTE(v string) predicate.File {
 	})
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.File {
+	return predicate.File(func(t *dsl.Traversal) {
+		t.Has(Label, FieldName, p.EqualFold(v))
+	})
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.File {
 	return predicate.File(func(t *dsl.Traversal) {
 		t.Has(Label, FieldName, p.Containing(v))
+	})
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.File {
+	return predicate.File(func(t *dsl.Traversal) {
+		t.Has(Label, FieldName, p.ContainsFold(v))
 	})
 }
 
@@ -308,10 +322,24 @@ func UserLTE(v string) predicate.File {
 	})
 }
 
+// UserEqualFold applies the EqualFold predicate on the "user" field.
+func UserEqualFold(v string) predicate.File {
+	return predicate.File(func(t *dsl.Traversal) {
+		t.Has(Label, FieldUser, p.EqualFold(v))
+	})
+}
+
 // UserContains applies the Contains predicate on the "user" field.
 func UserContains(v string) predicate.File {
 	return predicate.File(func(t *dsl.Traversal) {
 		t.Has(Label, FieldUser, p.Containing(v))
+	})
+}
+
+// UserContainsFold applies the ContainsFold predicate on the "user" field.
+func UserContainsFold(v string) predicate.File {
+	return predicate.File(func(t *dsl.Traversal) {
+		t.Has(Label, FieldUser, p.ContainsFold(v))
 	})
 }
 
@@ -399,10 +427,24 @@ func GroupLTE(v string) predicate.File {
 	})
 }
 
+// GroupEqualFold applies the EqualFold predicate on the "group" field.
+func GroupEqualFold(v string) predicate.File {
+	return predicate.File(func(t *dsl.Traversal) {
+		t.Has(Label, FieldGroup, p.EqualFold(v))
+	})
+}
+
 // GroupContains applies the Contains predicate on the "group" field.
 func GroupContains(v string) predicate.File {
 	return predicate.File(func(t *dsl.Traversal) {
 		t.Has(Label, FieldGroup, p.Containing(v))
+	})
+}
+
+// GroupContainsFold applies the ContainsFold predicate on the "group" field.
+func GroupContainsFold(v string) predicate.File {
+	return predicate.File(func(t *dsl.Traversal) {
+		t.Has(Label, FieldGroup, p.ContainsFold(v))
 	})
 }
 

--- a/entc/integration/gremlin/ent/filetype/where.go
+++ b/entc/integration/gremlin/ent/filetype/where.go
@@ -147,10 +147,24 @@ func NameLTE(v string) predicate.FileType {
 	})
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.FileType {
+	return predicate.FileType(func(t *dsl.Traversal) {
+		t.Has(Label, FieldName, p.EqualFold(v))
+	})
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.FileType {
 	return predicate.FileType(func(t *dsl.Traversal) {
 		t.Has(Label, FieldName, p.Containing(v))
+	})
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.FileType {
+	return predicate.FileType(func(t *dsl.Traversal) {
+		t.Has(Label, FieldName, p.ContainsFold(v))
 	})
 }
 

--- a/entc/integration/gremlin/ent/group/where.go
+++ b/entc/integration/gremlin/ent/group/where.go
@@ -247,10 +247,24 @@ func TypeLTE(v string) predicate.Group {
 	})
 }
 
+// TypeEqualFold applies the EqualFold predicate on the "type" field.
+func TypeEqualFold(v string) predicate.Group {
+	return predicate.Group(func(t *dsl.Traversal) {
+		t.Has(Label, FieldType, p.EqualFold(v))
+	})
+}
+
 // TypeContains applies the Contains predicate on the "type" field.
 func TypeContains(v string) predicate.Group {
 	return predicate.Group(func(t *dsl.Traversal) {
 		t.Has(Label, FieldType, p.Containing(v))
+	})
+}
+
+// TypeContainsFold applies the ContainsFold predicate on the "type" field.
+func TypeContainsFold(v string) predicate.Group {
+	return predicate.Group(func(t *dsl.Traversal) {
+		t.Has(Label, FieldType, p.ContainsFold(v))
 	})
 }
 
@@ -408,10 +422,24 @@ func NameLTE(v string) predicate.Group {
 	})
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.Group {
+	return predicate.Group(func(t *dsl.Traversal) {
+		t.Has(Label, FieldName, p.EqualFold(v))
+	})
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.Group {
 	return predicate.Group(func(t *dsl.Traversal) {
 		t.Has(Label, FieldName, p.Containing(v))
+	})
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.Group {
+	return predicate.Group(func(t *dsl.Traversal) {
+		t.Has(Label, FieldName, p.ContainsFold(v))
 	})
 }
 

--- a/entc/integration/gremlin/ent/groupinfo/where.go
+++ b/entc/integration/gremlin/ent/groupinfo/where.go
@@ -154,10 +154,24 @@ func DescLTE(v string) predicate.GroupInfo {
 	})
 }
 
+// DescEqualFold applies the EqualFold predicate on the "desc" field.
+func DescEqualFold(v string) predicate.GroupInfo {
+	return predicate.GroupInfo(func(t *dsl.Traversal) {
+		t.Has(Label, FieldDesc, p.EqualFold(v))
+	})
+}
+
 // DescContains applies the Contains predicate on the "desc" field.
 func DescContains(v string) predicate.GroupInfo {
 	return predicate.GroupInfo(func(t *dsl.Traversal) {
 		t.Has(Label, FieldDesc, p.Containing(v))
+	})
+}
+
+// DescContainsFold applies the ContainsFold predicate on the "desc" field.
+func DescContainsFold(v string) predicate.GroupInfo {
+	return predicate.GroupInfo(func(t *dsl.Traversal) {
+		t.Has(Label, FieldDesc, p.ContainsFold(v))
 	})
 }
 

--- a/entc/integration/gremlin/ent/item/where.go
+++ b/entc/integration/gremlin/ent/item/where.go
@@ -147,10 +147,24 @@ func TextLTE(v string) predicate.Item {
 	})
 }
 
+// TextEqualFold applies the EqualFold predicate on the "text" field.
+func TextEqualFold(v string) predicate.Item {
+	return predicate.Item(func(t *dsl.Traversal) {
+		t.Has(Label, FieldText, p.EqualFold(v))
+	})
+}
+
 // TextContains applies the Contains predicate on the "text" field.
 func TextContains(v string) predicate.Item {
 	return predicate.Item(func(t *dsl.Traversal) {
 		t.Has(Label, FieldText, p.Containing(v))
+	})
+}
+
+// TextContainsFold applies the ContainsFold predicate on the "text" field.
+func TextContainsFold(v string) predicate.Item {
+	return predicate.Item(func(t *dsl.Traversal) {
+		t.Has(Label, FieldText, p.ContainsFold(v))
 	})
 }
 

--- a/entc/integration/gremlin/ent/pet/where.go
+++ b/entc/integration/gremlin/ent/pet/where.go
@@ -232,10 +232,24 @@ func NameLTE(v string) predicate.Pet {
 	})
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.Pet {
+	return predicate.Pet(func(t *dsl.Traversal) {
+		t.Has(Label, FieldName, p.EqualFold(v))
+	})
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.Pet {
 	return predicate.Pet(func(t *dsl.Traversal) {
 		t.Has(Label, FieldName, p.Containing(v))
+	})
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.Pet {
+	return predicate.Pet(func(t *dsl.Traversal) {
+		t.Has(Label, FieldName, p.ContainsFold(v))
 	})
 }
 
@@ -379,10 +393,24 @@ func NicknameLTE(v string) predicate.Pet {
 	})
 }
 
+// NicknameEqualFold applies the EqualFold predicate on the "nickname" field.
+func NicknameEqualFold(v string) predicate.Pet {
+	return predicate.Pet(func(t *dsl.Traversal) {
+		t.Has(Label, FieldNickname, p.EqualFold(v))
+	})
+}
+
 // NicknameContains applies the Contains predicate on the "nickname" field.
 func NicknameContains(v string) predicate.Pet {
 	return predicate.Pet(func(t *dsl.Traversal) {
 		t.Has(Label, FieldNickname, p.Containing(v))
+	})
+}
+
+// NicknameContainsFold applies the ContainsFold predicate on the "nickname" field.
+func NicknameContainsFold(v string) predicate.Pet {
+	return predicate.Pet(func(t *dsl.Traversal) {
+		t.Has(Label, FieldNickname, p.ContainsFold(v))
 	})
 }
 

--- a/entc/integration/gremlin/ent/task/where.go
+++ b/entc/integration/gremlin/ent/task/where.go
@@ -326,10 +326,24 @@ func NameLTE(v string) predicate.Task {
 	})
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.Task {
+	return predicate.Task(func(t *dsl.Traversal) {
+		t.Has(Label, FieldName, p.EqualFold(v))
+	})
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.Task {
 	return predicate.Task(func(t *dsl.Traversal) {
 		t.Has(Label, FieldName, p.Containing(v))
+	})
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.Task {
+	return predicate.Task(func(t *dsl.Traversal) {
+		t.Has(Label, FieldName, p.ContainsFold(v))
 	})
 }
 
@@ -417,10 +431,24 @@ func OwnerLTE(v string) predicate.Task {
 	})
 }
 
+// OwnerEqualFold applies the EqualFold predicate on the "owner" field.
+func OwnerEqualFold(v string) predicate.Task {
+	return predicate.Task(func(t *dsl.Traversal) {
+		t.Has(Label, FieldOwner, p.EqualFold(v))
+	})
+}
+
 // OwnerContains applies the Contains predicate on the "owner" field.
 func OwnerContains(v string) predicate.Task {
 	return predicate.Task(func(t *dsl.Traversal) {
 		t.Has(Label, FieldOwner, p.Containing(v))
+	})
+}
+
+// OwnerContainsFold applies the ContainsFold predicate on the "owner" field.
+func OwnerContainsFold(v string) predicate.Task {
+	return predicate.Task(func(t *dsl.Traversal) {
+		t.Has(Label, FieldOwner, p.ContainsFold(v))
 	})
 }
 
@@ -648,10 +676,24 @@ func OpLTE(v string) predicate.Task {
 	})
 }
 
+// OpEqualFold applies the EqualFold predicate on the "op" field.
+func OpEqualFold(v string) predicate.Task {
+	return predicate.Task(func(t *dsl.Traversal) {
+		t.Has(Label, FieldOp, p.EqualFold(v))
+	})
+}
+
 // OpContains applies the Contains predicate on the "op" field.
 func OpContains(v string) predicate.Task {
 	return predicate.Task(func(t *dsl.Traversal) {
 		t.Has(Label, FieldOp, p.Containing(v))
+	})
+}
+
+// OpContainsFold applies the ContainsFold predicate on the "op" field.
+func OpContainsFold(v string) predicate.Task {
+	return predicate.Task(func(t *dsl.Traversal) {
+		t.Has(Label, FieldOp, p.ContainsFold(v))
 	})
 }
 

--- a/entc/integration/gremlin/ent/user/where.go
+++ b/entc/integration/gremlin/ent/user/where.go
@@ -336,10 +336,24 @@ func NameLTE(v string) predicate.User {
 	})
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.User {
+	return predicate.User(func(t *dsl.Traversal) {
+		t.Has(Label, FieldName, p.EqualFold(v))
+	})
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.User {
 	return predicate.User(func(t *dsl.Traversal) {
 		t.Has(Label, FieldName, p.Containing(v))
+	})
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.User {
+	return predicate.User(func(t *dsl.Traversal) {
+		t.Has(Label, FieldName, p.ContainsFold(v))
 	})
 }
 
@@ -413,10 +427,24 @@ func LastLTE(v string) predicate.User {
 	})
 }
 
+// LastEqualFold applies the EqualFold predicate on the "last" field.
+func LastEqualFold(v string) predicate.User {
+	return predicate.User(func(t *dsl.Traversal) {
+		t.Has(Label, FieldLast, p.EqualFold(v))
+	})
+}
+
 // LastContains applies the Contains predicate on the "last" field.
 func LastContains(v string) predicate.User {
 	return predicate.User(func(t *dsl.Traversal) {
 		t.Has(Label, FieldLast, p.Containing(v))
+	})
+}
+
+// LastContainsFold applies the ContainsFold predicate on the "last" field.
+func LastContainsFold(v string) predicate.User {
+	return predicate.User(func(t *dsl.Traversal) {
+		t.Has(Label, FieldLast, p.ContainsFold(v))
 	})
 }
 
@@ -490,10 +518,24 @@ func NicknameLTE(v string) predicate.User {
 	})
 }
 
+// NicknameEqualFold applies the EqualFold predicate on the "nickname" field.
+func NicknameEqualFold(v string) predicate.User {
+	return predicate.User(func(t *dsl.Traversal) {
+		t.Has(Label, FieldNickname, p.EqualFold(v))
+	})
+}
+
 // NicknameContains applies the Contains predicate on the "nickname" field.
 func NicknameContains(v string) predicate.User {
 	return predicate.User(func(t *dsl.Traversal) {
 		t.Has(Label, FieldNickname, p.Containing(v))
+	})
+}
+
+// NicknameContainsFold applies the ContainsFold predicate on the "nickname" field.
+func NicknameContainsFold(v string) predicate.User {
+	return predicate.User(func(t *dsl.Traversal) {
+		t.Has(Label, FieldNickname, p.ContainsFold(v))
 	})
 }
 
@@ -581,10 +623,24 @@ func AddressLTE(v string) predicate.User {
 	})
 }
 
+// AddressEqualFold applies the EqualFold predicate on the "address" field.
+func AddressEqualFold(v string) predicate.User {
+	return predicate.User(func(t *dsl.Traversal) {
+		t.Has(Label, FieldAddress, p.EqualFold(v))
+	})
+}
+
 // AddressContains applies the Contains predicate on the "address" field.
 func AddressContains(v string) predicate.User {
 	return predicate.User(func(t *dsl.Traversal) {
 		t.Has(Label, FieldAddress, p.Containing(v))
+	})
+}
+
+// AddressContainsFold applies the ContainsFold predicate on the "address" field.
+func AddressContainsFold(v string) predicate.User {
+	return predicate.User(func(t *dsl.Traversal) {
+		t.Has(Label, FieldAddress, p.ContainsFold(v))
 	})
 }
 
@@ -672,10 +728,24 @@ func PhoneLTE(v string) predicate.User {
 	})
 }
 
+// PhoneEqualFold applies the EqualFold predicate on the "phone" field.
+func PhoneEqualFold(v string) predicate.User {
+	return predicate.User(func(t *dsl.Traversal) {
+		t.Has(Label, FieldPhone, p.EqualFold(v))
+	})
+}
+
 // PhoneContains applies the Contains predicate on the "phone" field.
 func PhoneContains(v string) predicate.User {
 	return predicate.User(func(t *dsl.Traversal) {
 		t.Has(Label, FieldPhone, p.Containing(v))
+	})
+}
+
+// PhoneContainsFold applies the ContainsFold predicate on the "phone" field.
+func PhoneContainsFold(v string) predicate.User {
+	return predicate.User(func(t *dsl.Traversal) {
+		t.Has(Label, FieldPhone, p.ContainsFold(v))
 	})
 }
 
@@ -763,10 +833,24 @@ func PasswordLTE(v string) predicate.User {
 	})
 }
 
+// PasswordEqualFold applies the EqualFold predicate on the "password" field.
+func PasswordEqualFold(v string) predicate.User {
+	return predicate.User(func(t *dsl.Traversal) {
+		t.Has(Label, FieldPassword, p.EqualFold(v))
+	})
+}
+
 // PasswordContains applies the Contains predicate on the "password" field.
 func PasswordContains(v string) predicate.User {
 	return predicate.User(func(t *dsl.Traversal) {
 		t.Has(Label, FieldPassword, p.Containing(v))
+	})
+}
+
+// PasswordContainsFold applies the ContainsFold predicate on the "password" field.
+func PasswordContainsFold(v string) predicate.User {
+	return predicate.User(func(t *dsl.Traversal) {
+		t.Has(Label, FieldPassword, p.ContainsFold(v))
 	})
 }
 
@@ -910,10 +994,24 @@ func SSOCertLTE(v string) predicate.User {
 	})
 }
 
+// SSOCertEqualFold applies the EqualFold predicate on the "SSOCert" field.
+func SSOCertEqualFold(v string) predicate.User {
+	return predicate.User(func(t *dsl.Traversal) {
+		t.Has(Label, FieldSSOCert, p.EqualFold(v))
+	})
+}
+
 // SSOCertContains applies the Contains predicate on the "SSOCert" field.
 func SSOCertContains(v string) predicate.User {
 	return predicate.User(func(t *dsl.Traversal) {
 		t.Has(Label, FieldSSOCert, p.Containing(v))
+	})
+}
+
+// SSOCertContainsFold applies the ContainsFold predicate on the "SSOCert" field.
+func SSOCertContainsFold(v string) predicate.User {
+	return predicate.User(func(t *dsl.Traversal) {
+		t.Has(Label, FieldSSOCert, p.ContainsFold(v))
 	})
 }
 

--- a/entc/integration/hooks/ent/card/where.go
+++ b/entc/integration/hooks/ent/card/where.go
@@ -124,9 +124,19 @@ func NumberLTE(v string) predicate.Card {
 	return predicate.Card(sql.FieldLTE(FieldNumber, v))
 }
 
+// NumberEqualFold applies the EqualFold predicate on the "number" field.
+func NumberEqualFold(v string) predicate.Card {
+	return predicate.Card(sql.FieldEqualFold(FieldNumber, v))
+}
+
 // NumberContains applies the Contains predicate on the "number" field.
 func NumberContains(v string) predicate.Card {
 	return predicate.Card(sql.FieldContains(FieldNumber, v))
+}
+
+// NumberContainsFold applies the ContainsFold predicate on the "number" field.
+func NumberContainsFold(v string) predicate.Card {
+	return predicate.Card(sql.FieldContainsFold(FieldNumber, v))
 }
 
 // NumberHasPrefix applies the HasPrefix predicate on the "number" field.
@@ -137,16 +147,6 @@ func NumberHasPrefix(v string) predicate.Card {
 // NumberHasSuffix applies the HasSuffix predicate on the "number" field.
 func NumberHasSuffix(v string) predicate.Card {
 	return predicate.Card(sql.FieldHasSuffix(FieldNumber, v))
-}
-
-// NumberEqualFold applies the EqualFold predicate on the "number" field.
-func NumberEqualFold(v string) predicate.Card {
-	return predicate.Card(sql.FieldEqualFold(FieldNumber, v))
-}
-
-// NumberContainsFold applies the ContainsFold predicate on the "number" field.
-func NumberContainsFold(v string) predicate.Card {
-	return predicate.Card(sql.FieldContainsFold(FieldNumber, v))
 }
 
 // NameEQ applies the EQ predicate on the "name" field.
@@ -189,9 +189,19 @@ func NameLTE(v string) predicate.Card {
 	return predicate.Card(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.Card {
+	return predicate.Card(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.Card {
 	return predicate.Card(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.Card {
+	return predicate.Card(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -212,16 +222,6 @@ func NameIsNil() predicate.Card {
 // NameNotNil applies the NotNil predicate on the "name" field.
 func NameNotNil() predicate.Card {
 	return predicate.Card(sql.FieldNotNull(FieldName))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.Card {
-	return predicate.Card(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.Card {
-	return predicate.Card(sql.FieldContainsFold(FieldName, v))
 }
 
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.
@@ -304,9 +304,19 @@ func InHookLTE(v string) predicate.Card {
 	return predicate.Card(sql.FieldLTE(FieldInHook, v))
 }
 
+// InHookEqualFold applies the EqualFold predicate on the "in_hook" field.
+func InHookEqualFold(v string) predicate.Card {
+	return predicate.Card(sql.FieldEqualFold(FieldInHook, v))
+}
+
 // InHookContains applies the Contains predicate on the "in_hook" field.
 func InHookContains(v string) predicate.Card {
 	return predicate.Card(sql.FieldContains(FieldInHook, v))
+}
+
+// InHookContainsFold applies the ContainsFold predicate on the "in_hook" field.
+func InHookContainsFold(v string) predicate.Card {
+	return predicate.Card(sql.FieldContainsFold(FieldInHook, v))
 }
 
 // InHookHasPrefix applies the HasPrefix predicate on the "in_hook" field.
@@ -317,16 +327,6 @@ func InHookHasPrefix(v string) predicate.Card {
 // InHookHasSuffix applies the HasSuffix predicate on the "in_hook" field.
 func InHookHasSuffix(v string) predicate.Card {
 	return predicate.Card(sql.FieldHasSuffix(FieldInHook, v))
-}
-
-// InHookEqualFold applies the EqualFold predicate on the "in_hook" field.
-func InHookEqualFold(v string) predicate.Card {
-	return predicate.Card(sql.FieldEqualFold(FieldInHook, v))
-}
-
-// InHookContainsFold applies the ContainsFold predicate on the "in_hook" field.
-func InHookContainsFold(v string) predicate.Card {
-	return predicate.Card(sql.FieldContainsFold(FieldInHook, v))
 }
 
 // ExpiredAtEQ applies the EQ predicate on the "expired_at" field.

--- a/entc/integration/hooks/ent/pet/where.go
+++ b/entc/integration/hooks/ent/pet/where.go
@@ -159,9 +159,19 @@ func NameLTE(v string) predicate.Pet {
 	return predicate.Pet(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.Pet {
+	return predicate.Pet(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.Pet {
 	return predicate.Pet(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.Pet {
+	return predicate.Pet(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -182,16 +192,6 @@ func NameIsNil() predicate.Pet {
 // NameNotNil applies the NotNil predicate on the "name" field.
 func NameNotNil() predicate.Pet {
 	return predicate.Pet(sql.FieldNotNull(FieldName))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.Pet {
-	return predicate.Pet(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.Pet {
-	return predicate.Pet(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasOwner applies the HasEdge predicate on the "owner" edge.

--- a/entc/integration/hooks/ent/user/where.go
+++ b/entc/integration/hooks/ent/user/where.go
@@ -162,9 +162,19 @@ func NameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -175,16 +185,6 @@ func NameHasPrefix(v string) predicate.User {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // WorthEQ applies the EQ predicate on the "worth" field.
@@ -277,9 +277,19 @@ func PasswordLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldPassword, v))
 }
 
+// PasswordEqualFold applies the EqualFold predicate on the "password" field.
+func PasswordEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldPassword, v))
+}
+
 // PasswordContains applies the Contains predicate on the "password" field.
 func PasswordContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldPassword, v))
+}
+
+// PasswordContainsFold applies the ContainsFold predicate on the "password" field.
+func PasswordContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldPassword, v))
 }
 
 // PasswordHasPrefix applies the HasPrefix predicate on the "password" field.
@@ -300,16 +310,6 @@ func PasswordIsNil() predicate.User {
 // PasswordNotNil applies the NotNil predicate on the "password" field.
 func PasswordNotNil() predicate.User {
 	return predicate.User(sql.FieldNotNull(FieldPassword))
-}
-
-// PasswordEqualFold applies the EqualFold predicate on the "password" field.
-func PasswordEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldPassword, v))
-}
-
-// PasswordContainsFold applies the ContainsFold predicate on the "password" field.
-func PasswordContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldPassword, v))
 }
 
 // ActiveEQ applies the EQ predicate on the "active" field.

--- a/entc/integration/idtype/ent/user/where.go
+++ b/entc/integration/idtype/ent/user/where.go
@@ -102,9 +102,19 @@ func NameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -115,16 +125,6 @@ func NameHasPrefix(v string) predicate.User {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasSpouse applies the HasEdge predicate on the "spouse" edge.

--- a/entc/integration/migrate/entv1/conversion/where.go
+++ b/entc/integration/migrate/entv1/conversion/where.go
@@ -141,9 +141,19 @@ func NameLTE(v string) predicate.Conversion {
 	return predicate.Conversion(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.Conversion {
+	return predicate.Conversion(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.Conversion {
 	return predicate.Conversion(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.Conversion {
+	return predicate.Conversion(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -164,16 +174,6 @@ func NameIsNil() predicate.Conversion {
 // NameNotNil applies the NotNil predicate on the "name" field.
 func NameNotNil() predicate.Conversion {
 	return predicate.Conversion(sql.FieldNotNull(FieldName))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.Conversion {
-	return predicate.Conversion(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.Conversion {
-	return predicate.Conversion(sql.FieldContainsFold(FieldName, v))
 }
 
 // Int8ToStringEQ applies the EQ predicate on the "int8_to_string" field.

--- a/entc/integration/migrate/entv1/customtype/where.go
+++ b/entc/integration/migrate/entv1/customtype/where.go
@@ -101,9 +101,19 @@ func CustomLTE(v string) predicate.CustomType {
 	return predicate.CustomType(sql.FieldLTE(FieldCustom, v))
 }
 
+// CustomEqualFold applies the EqualFold predicate on the "custom" field.
+func CustomEqualFold(v string) predicate.CustomType {
+	return predicate.CustomType(sql.FieldEqualFold(FieldCustom, v))
+}
+
 // CustomContains applies the Contains predicate on the "custom" field.
 func CustomContains(v string) predicate.CustomType {
 	return predicate.CustomType(sql.FieldContains(FieldCustom, v))
+}
+
+// CustomContainsFold applies the ContainsFold predicate on the "custom" field.
+func CustomContainsFold(v string) predicate.CustomType {
+	return predicate.CustomType(sql.FieldContainsFold(FieldCustom, v))
 }
 
 // CustomHasPrefix applies the HasPrefix predicate on the "custom" field.
@@ -124,16 +134,6 @@ func CustomIsNil() predicate.CustomType {
 // CustomNotNil applies the NotNil predicate on the "custom" field.
 func CustomNotNil() predicate.CustomType {
 	return predicate.CustomType(sql.FieldNotNull(FieldCustom))
-}
-
-// CustomEqualFold applies the EqualFold predicate on the "custom" field.
-func CustomEqualFold(v string) predicate.CustomType {
-	return predicate.CustomType(sql.FieldEqualFold(FieldCustom, v))
-}
-
-// CustomContainsFold applies the ContainsFold predicate on the "custom" field.
-func CustomContainsFold(v string) predicate.CustomType {
-	return predicate.CustomType(sql.FieldContainsFold(FieldCustom, v))
 }
 
 // And groups predicates with the AND operator between them.

--- a/entc/integration/migrate/entv1/user/where.go
+++ b/entc/integration/migrate/entv1/user/where.go
@@ -192,9 +192,19 @@ func NameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -205,16 +215,6 @@ func NameHasPrefix(v string) predicate.User {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // DescriptionEQ applies the EQ predicate on the "description" field.
@@ -257,9 +257,19 @@ func DescriptionLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldDescription, v))
 }
 
+// DescriptionEqualFold applies the EqualFold predicate on the "description" field.
+func DescriptionEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldDescription, v))
+}
+
 // DescriptionContains applies the Contains predicate on the "description" field.
 func DescriptionContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldDescription, v))
+}
+
+// DescriptionContainsFold applies the ContainsFold predicate on the "description" field.
+func DescriptionContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldDescription, v))
 }
 
 // DescriptionHasPrefix applies the HasPrefix predicate on the "description" field.
@@ -280,16 +290,6 @@ func DescriptionIsNil() predicate.User {
 // DescriptionNotNil applies the NotNil predicate on the "description" field.
 func DescriptionNotNil() predicate.User {
 	return predicate.User(sql.FieldNotNull(FieldDescription))
-}
-
-// DescriptionEqualFold applies the EqualFold predicate on the "description" field.
-func DescriptionEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldDescription, v))
-}
-
-// DescriptionContainsFold applies the ContainsFold predicate on the "description" field.
-func DescriptionContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldDescription, v))
 }
 
 // NicknameEQ applies the EQ predicate on the "nickname" field.
@@ -332,9 +332,19 @@ func NicknameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldNickname, v))
 }
 
+// NicknameEqualFold applies the EqualFold predicate on the "nickname" field.
+func NicknameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldNickname, v))
+}
+
 // NicknameContains applies the Contains predicate on the "nickname" field.
 func NicknameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldNickname, v))
+}
+
+// NicknameContainsFold applies the ContainsFold predicate on the "nickname" field.
+func NicknameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldNickname, v))
 }
 
 // NicknameHasPrefix applies the HasPrefix predicate on the "nickname" field.
@@ -345,16 +355,6 @@ func NicknameHasPrefix(v string) predicate.User {
 // NicknameHasSuffix applies the HasSuffix predicate on the "nickname" field.
 func NicknameHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldNickname, v))
-}
-
-// NicknameEqualFold applies the EqualFold predicate on the "nickname" field.
-func NicknameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldNickname, v))
-}
-
-// NicknameContainsFold applies the ContainsFold predicate on the "nickname" field.
-func NicknameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldNickname, v))
 }
 
 // AddressEQ applies the EQ predicate on the "address" field.
@@ -397,9 +397,19 @@ func AddressLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldAddress, v))
 }
 
+// AddressEqualFold applies the EqualFold predicate on the "address" field.
+func AddressEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldAddress, v))
+}
+
 // AddressContains applies the Contains predicate on the "address" field.
 func AddressContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldAddress, v))
+}
+
+// AddressContainsFold applies the ContainsFold predicate on the "address" field.
+func AddressContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldAddress, v))
 }
 
 // AddressHasPrefix applies the HasPrefix predicate on the "address" field.
@@ -420,16 +430,6 @@ func AddressIsNil() predicate.User {
 // AddressNotNil applies the NotNil predicate on the "address" field.
 func AddressNotNil() predicate.User {
 	return predicate.User(sql.FieldNotNull(FieldAddress))
-}
-
-// AddressEqualFold applies the EqualFold predicate on the "address" field.
-func AddressEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldAddress, v))
-}
-
-// AddressContainsFold applies the ContainsFold predicate on the "address" field.
-func AddressContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldAddress, v))
 }
 
 // RenamedEQ applies the EQ predicate on the "renamed" field.
@@ -472,9 +472,19 @@ func RenamedLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldRenamed, v))
 }
 
+// RenamedEqualFold applies the EqualFold predicate on the "renamed" field.
+func RenamedEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldRenamed, v))
+}
+
 // RenamedContains applies the Contains predicate on the "renamed" field.
 func RenamedContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldRenamed, v))
+}
+
+// RenamedContainsFold applies the ContainsFold predicate on the "renamed" field.
+func RenamedContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldRenamed, v))
 }
 
 // RenamedHasPrefix applies the HasPrefix predicate on the "renamed" field.
@@ -495,16 +505,6 @@ func RenamedIsNil() predicate.User {
 // RenamedNotNil applies the NotNil predicate on the "renamed" field.
 func RenamedNotNil() predicate.User {
 	return predicate.User(sql.FieldNotNull(FieldRenamed))
-}
-
-// RenamedEqualFold applies the EqualFold predicate on the "renamed" field.
-func RenamedEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldRenamed, v))
-}
-
-// RenamedContainsFold applies the ContainsFold predicate on the "renamed" field.
-func RenamedContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldRenamed, v))
 }
 
 // OldTokenEQ applies the EQ predicate on the "old_token" field.
@@ -547,9 +547,19 @@ func OldTokenLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldOldToken, v))
 }
 
+// OldTokenEqualFold applies the EqualFold predicate on the "old_token" field.
+func OldTokenEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldOldToken, v))
+}
+
 // OldTokenContains applies the Contains predicate on the "old_token" field.
 func OldTokenContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldOldToken, v))
+}
+
+// OldTokenContainsFold applies the ContainsFold predicate on the "old_token" field.
+func OldTokenContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldOldToken, v))
 }
 
 // OldTokenHasPrefix applies the HasPrefix predicate on the "old_token" field.
@@ -560,16 +570,6 @@ func OldTokenHasPrefix(v string) predicate.User {
 // OldTokenHasSuffix applies the HasSuffix predicate on the "old_token" field.
 func OldTokenHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldOldToken, v))
-}
-
-// OldTokenEqualFold applies the EqualFold predicate on the "old_token" field.
-func OldTokenEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldOldToken, v))
-}
-
-// OldTokenContainsFold applies the ContainsFold predicate on the "old_token" field.
-func OldTokenContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldOldToken, v))
 }
 
 // BlobEQ applies the EQ predicate on the "blob" field.
@@ -692,9 +692,19 @@ func StatusLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldStatus, v))
 }
 
+// StatusEqualFold applies the EqualFold predicate on the "status" field.
+func StatusEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldStatus, v))
+}
+
 // StatusContains applies the Contains predicate on the "status" field.
 func StatusContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldStatus, v))
+}
+
+// StatusContainsFold applies the ContainsFold predicate on the "status" field.
+func StatusContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldStatus, v))
 }
 
 // StatusHasPrefix applies the HasPrefix predicate on the "status" field.
@@ -715,16 +725,6 @@ func StatusIsNil() predicate.User {
 // StatusNotNil applies the NotNil predicate on the "status" field.
 func StatusNotNil() predicate.User {
 	return predicate.User(sql.FieldNotNull(FieldStatus))
-}
-
-// StatusEqualFold applies the EqualFold predicate on the "status" field.
-func StatusEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldStatus, v))
-}
-
-// StatusContainsFold applies the ContainsFold predicate on the "status" field.
-func StatusContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldStatus, v))
 }
 
 // WorkplaceEQ applies the EQ predicate on the "workplace" field.
@@ -767,9 +767,19 @@ func WorkplaceLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldWorkplace, v))
 }
 
+// WorkplaceEqualFold applies the EqualFold predicate on the "workplace" field.
+func WorkplaceEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldWorkplace, v))
+}
+
 // WorkplaceContains applies the Contains predicate on the "workplace" field.
 func WorkplaceContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldWorkplace, v))
+}
+
+// WorkplaceContainsFold applies the ContainsFold predicate on the "workplace" field.
+func WorkplaceContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldWorkplace, v))
 }
 
 // WorkplaceHasPrefix applies the HasPrefix predicate on the "workplace" field.
@@ -790,16 +800,6 @@ func WorkplaceIsNil() predicate.User {
 // WorkplaceNotNil applies the NotNil predicate on the "workplace" field.
 func WorkplaceNotNil() predicate.User {
 	return predicate.User(sql.FieldNotNull(FieldWorkplace))
-}
-
-// WorkplaceEqualFold applies the EqualFold predicate on the "workplace" field.
-func WorkplaceEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldWorkplace, v))
-}
-
-// WorkplaceContainsFold applies the ContainsFold predicate on the "workplace" field.
-func WorkplaceContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldWorkplace, v))
 }
 
 // DropOptionalEQ applies the EQ predicate on the "drop_optional" field.
@@ -842,9 +842,19 @@ func DropOptionalLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldDropOptional, v))
 }
 
+// DropOptionalEqualFold applies the EqualFold predicate on the "drop_optional" field.
+func DropOptionalEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldDropOptional, v))
+}
+
 // DropOptionalContains applies the Contains predicate on the "drop_optional" field.
 func DropOptionalContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldDropOptional, v))
+}
+
+// DropOptionalContainsFold applies the ContainsFold predicate on the "drop_optional" field.
+func DropOptionalContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldDropOptional, v))
 }
 
 // DropOptionalHasPrefix applies the HasPrefix predicate on the "drop_optional" field.
@@ -865,16 +875,6 @@ func DropOptionalIsNil() predicate.User {
 // DropOptionalNotNil applies the NotNil predicate on the "drop_optional" field.
 func DropOptionalNotNil() predicate.User {
 	return predicate.User(sql.FieldNotNull(FieldDropOptional))
-}
-
-// DropOptionalEqualFold applies the EqualFold predicate on the "drop_optional" field.
-func DropOptionalEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldDropOptional, v))
-}
-
-// DropOptionalContainsFold applies the ContainsFold predicate on the "drop_optional" field.
-func DropOptionalContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldDropOptional, v))
 }
 
 // HasParent applies the HasEdge predicate on the "parent" edge.

--- a/entc/integration/migrate/entv2/car/where.go
+++ b/entc/integration/migrate/entv2/car/where.go
@@ -102,9 +102,19 @@ func NameLTE(v string) predicate.Car {
 	return predicate.Car(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.Car {
+	return predicate.Car(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.Car {
 	return predicate.Car(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.Car {
+	return predicate.Car(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -125,16 +135,6 @@ func NameIsNil() predicate.Car {
 // NameNotNil applies the NotNil predicate on the "name" field.
 func NameNotNil() predicate.Car {
 	return predicate.Car(sql.FieldNotNull(FieldName))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.Car {
-	return predicate.Car(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.Car {
-	return predicate.Car(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasOwner applies the HasEdge predicate on the "owner" edge.

--- a/entc/integration/migrate/entv2/conversion/where.go
+++ b/entc/integration/migrate/entv2/conversion/where.go
@@ -141,9 +141,19 @@ func NameLTE(v string) predicate.Conversion {
 	return predicate.Conversion(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.Conversion {
+	return predicate.Conversion(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.Conversion {
 	return predicate.Conversion(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.Conversion {
+	return predicate.Conversion(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -164,16 +174,6 @@ func NameIsNil() predicate.Conversion {
 // NameNotNil applies the NotNil predicate on the "name" field.
 func NameNotNil() predicate.Conversion {
 	return predicate.Conversion(sql.FieldNotNull(FieldName))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.Conversion {
-	return predicate.Conversion(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.Conversion {
-	return predicate.Conversion(sql.FieldContainsFold(FieldName, v))
 }
 
 // Int8ToStringEQ applies the EQ predicate on the "int8_to_string" field.
@@ -216,9 +216,19 @@ func Int8ToStringLTE(v string) predicate.Conversion {
 	return predicate.Conversion(sql.FieldLTE(FieldInt8ToString, v))
 }
 
+// Int8ToStringEqualFold applies the EqualFold predicate on the "int8_to_string" field.
+func Int8ToStringEqualFold(v string) predicate.Conversion {
+	return predicate.Conversion(sql.FieldEqualFold(FieldInt8ToString, v))
+}
+
 // Int8ToStringContains applies the Contains predicate on the "int8_to_string" field.
 func Int8ToStringContains(v string) predicate.Conversion {
 	return predicate.Conversion(sql.FieldContains(FieldInt8ToString, v))
+}
+
+// Int8ToStringContainsFold applies the ContainsFold predicate on the "int8_to_string" field.
+func Int8ToStringContainsFold(v string) predicate.Conversion {
+	return predicate.Conversion(sql.FieldContainsFold(FieldInt8ToString, v))
 }
 
 // Int8ToStringHasPrefix applies the HasPrefix predicate on the "int8_to_string" field.
@@ -239,16 +249,6 @@ func Int8ToStringIsNil() predicate.Conversion {
 // Int8ToStringNotNil applies the NotNil predicate on the "int8_to_string" field.
 func Int8ToStringNotNil() predicate.Conversion {
 	return predicate.Conversion(sql.FieldNotNull(FieldInt8ToString))
-}
-
-// Int8ToStringEqualFold applies the EqualFold predicate on the "int8_to_string" field.
-func Int8ToStringEqualFold(v string) predicate.Conversion {
-	return predicate.Conversion(sql.FieldEqualFold(FieldInt8ToString, v))
-}
-
-// Int8ToStringContainsFold applies the ContainsFold predicate on the "int8_to_string" field.
-func Int8ToStringContainsFold(v string) predicate.Conversion {
-	return predicate.Conversion(sql.FieldContainsFold(FieldInt8ToString, v))
 }
 
 // Uint8ToStringEQ applies the EQ predicate on the "uint8_to_string" field.
@@ -291,9 +291,19 @@ func Uint8ToStringLTE(v string) predicate.Conversion {
 	return predicate.Conversion(sql.FieldLTE(FieldUint8ToString, v))
 }
 
+// Uint8ToStringEqualFold applies the EqualFold predicate on the "uint8_to_string" field.
+func Uint8ToStringEqualFold(v string) predicate.Conversion {
+	return predicate.Conversion(sql.FieldEqualFold(FieldUint8ToString, v))
+}
+
 // Uint8ToStringContains applies the Contains predicate on the "uint8_to_string" field.
 func Uint8ToStringContains(v string) predicate.Conversion {
 	return predicate.Conversion(sql.FieldContains(FieldUint8ToString, v))
+}
+
+// Uint8ToStringContainsFold applies the ContainsFold predicate on the "uint8_to_string" field.
+func Uint8ToStringContainsFold(v string) predicate.Conversion {
+	return predicate.Conversion(sql.FieldContainsFold(FieldUint8ToString, v))
 }
 
 // Uint8ToStringHasPrefix applies the HasPrefix predicate on the "uint8_to_string" field.
@@ -314,16 +324,6 @@ func Uint8ToStringIsNil() predicate.Conversion {
 // Uint8ToStringNotNil applies the NotNil predicate on the "uint8_to_string" field.
 func Uint8ToStringNotNil() predicate.Conversion {
 	return predicate.Conversion(sql.FieldNotNull(FieldUint8ToString))
-}
-
-// Uint8ToStringEqualFold applies the EqualFold predicate on the "uint8_to_string" field.
-func Uint8ToStringEqualFold(v string) predicate.Conversion {
-	return predicate.Conversion(sql.FieldEqualFold(FieldUint8ToString, v))
-}
-
-// Uint8ToStringContainsFold applies the ContainsFold predicate on the "uint8_to_string" field.
-func Uint8ToStringContainsFold(v string) predicate.Conversion {
-	return predicate.Conversion(sql.FieldContainsFold(FieldUint8ToString, v))
 }
 
 // Int16ToStringEQ applies the EQ predicate on the "int16_to_string" field.
@@ -366,9 +366,19 @@ func Int16ToStringLTE(v string) predicate.Conversion {
 	return predicate.Conversion(sql.FieldLTE(FieldInt16ToString, v))
 }
 
+// Int16ToStringEqualFold applies the EqualFold predicate on the "int16_to_string" field.
+func Int16ToStringEqualFold(v string) predicate.Conversion {
+	return predicate.Conversion(sql.FieldEqualFold(FieldInt16ToString, v))
+}
+
 // Int16ToStringContains applies the Contains predicate on the "int16_to_string" field.
 func Int16ToStringContains(v string) predicate.Conversion {
 	return predicate.Conversion(sql.FieldContains(FieldInt16ToString, v))
+}
+
+// Int16ToStringContainsFold applies the ContainsFold predicate on the "int16_to_string" field.
+func Int16ToStringContainsFold(v string) predicate.Conversion {
+	return predicate.Conversion(sql.FieldContainsFold(FieldInt16ToString, v))
 }
 
 // Int16ToStringHasPrefix applies the HasPrefix predicate on the "int16_to_string" field.
@@ -389,16 +399,6 @@ func Int16ToStringIsNil() predicate.Conversion {
 // Int16ToStringNotNil applies the NotNil predicate on the "int16_to_string" field.
 func Int16ToStringNotNil() predicate.Conversion {
 	return predicate.Conversion(sql.FieldNotNull(FieldInt16ToString))
-}
-
-// Int16ToStringEqualFold applies the EqualFold predicate on the "int16_to_string" field.
-func Int16ToStringEqualFold(v string) predicate.Conversion {
-	return predicate.Conversion(sql.FieldEqualFold(FieldInt16ToString, v))
-}
-
-// Int16ToStringContainsFold applies the ContainsFold predicate on the "int16_to_string" field.
-func Int16ToStringContainsFold(v string) predicate.Conversion {
-	return predicate.Conversion(sql.FieldContainsFold(FieldInt16ToString, v))
 }
 
 // Uint16ToStringEQ applies the EQ predicate on the "uint16_to_string" field.
@@ -441,9 +441,19 @@ func Uint16ToStringLTE(v string) predicate.Conversion {
 	return predicate.Conversion(sql.FieldLTE(FieldUint16ToString, v))
 }
 
+// Uint16ToStringEqualFold applies the EqualFold predicate on the "uint16_to_string" field.
+func Uint16ToStringEqualFold(v string) predicate.Conversion {
+	return predicate.Conversion(sql.FieldEqualFold(FieldUint16ToString, v))
+}
+
 // Uint16ToStringContains applies the Contains predicate on the "uint16_to_string" field.
 func Uint16ToStringContains(v string) predicate.Conversion {
 	return predicate.Conversion(sql.FieldContains(FieldUint16ToString, v))
+}
+
+// Uint16ToStringContainsFold applies the ContainsFold predicate on the "uint16_to_string" field.
+func Uint16ToStringContainsFold(v string) predicate.Conversion {
+	return predicate.Conversion(sql.FieldContainsFold(FieldUint16ToString, v))
 }
 
 // Uint16ToStringHasPrefix applies the HasPrefix predicate on the "uint16_to_string" field.
@@ -464,16 +474,6 @@ func Uint16ToStringIsNil() predicate.Conversion {
 // Uint16ToStringNotNil applies the NotNil predicate on the "uint16_to_string" field.
 func Uint16ToStringNotNil() predicate.Conversion {
 	return predicate.Conversion(sql.FieldNotNull(FieldUint16ToString))
-}
-
-// Uint16ToStringEqualFold applies the EqualFold predicate on the "uint16_to_string" field.
-func Uint16ToStringEqualFold(v string) predicate.Conversion {
-	return predicate.Conversion(sql.FieldEqualFold(FieldUint16ToString, v))
-}
-
-// Uint16ToStringContainsFold applies the ContainsFold predicate on the "uint16_to_string" field.
-func Uint16ToStringContainsFold(v string) predicate.Conversion {
-	return predicate.Conversion(sql.FieldContainsFold(FieldUint16ToString, v))
 }
 
 // Int32ToStringEQ applies the EQ predicate on the "int32_to_string" field.
@@ -516,9 +516,19 @@ func Int32ToStringLTE(v string) predicate.Conversion {
 	return predicate.Conversion(sql.FieldLTE(FieldInt32ToString, v))
 }
 
+// Int32ToStringEqualFold applies the EqualFold predicate on the "int32_to_string" field.
+func Int32ToStringEqualFold(v string) predicate.Conversion {
+	return predicate.Conversion(sql.FieldEqualFold(FieldInt32ToString, v))
+}
+
 // Int32ToStringContains applies the Contains predicate on the "int32_to_string" field.
 func Int32ToStringContains(v string) predicate.Conversion {
 	return predicate.Conversion(sql.FieldContains(FieldInt32ToString, v))
+}
+
+// Int32ToStringContainsFold applies the ContainsFold predicate on the "int32_to_string" field.
+func Int32ToStringContainsFold(v string) predicate.Conversion {
+	return predicate.Conversion(sql.FieldContainsFold(FieldInt32ToString, v))
 }
 
 // Int32ToStringHasPrefix applies the HasPrefix predicate on the "int32_to_string" field.
@@ -539,16 +549,6 @@ func Int32ToStringIsNil() predicate.Conversion {
 // Int32ToStringNotNil applies the NotNil predicate on the "int32_to_string" field.
 func Int32ToStringNotNil() predicate.Conversion {
 	return predicate.Conversion(sql.FieldNotNull(FieldInt32ToString))
-}
-
-// Int32ToStringEqualFold applies the EqualFold predicate on the "int32_to_string" field.
-func Int32ToStringEqualFold(v string) predicate.Conversion {
-	return predicate.Conversion(sql.FieldEqualFold(FieldInt32ToString, v))
-}
-
-// Int32ToStringContainsFold applies the ContainsFold predicate on the "int32_to_string" field.
-func Int32ToStringContainsFold(v string) predicate.Conversion {
-	return predicate.Conversion(sql.FieldContainsFold(FieldInt32ToString, v))
 }
 
 // Uint32ToStringEQ applies the EQ predicate on the "uint32_to_string" field.
@@ -591,9 +591,19 @@ func Uint32ToStringLTE(v string) predicate.Conversion {
 	return predicate.Conversion(sql.FieldLTE(FieldUint32ToString, v))
 }
 
+// Uint32ToStringEqualFold applies the EqualFold predicate on the "uint32_to_string" field.
+func Uint32ToStringEqualFold(v string) predicate.Conversion {
+	return predicate.Conversion(sql.FieldEqualFold(FieldUint32ToString, v))
+}
+
 // Uint32ToStringContains applies the Contains predicate on the "uint32_to_string" field.
 func Uint32ToStringContains(v string) predicate.Conversion {
 	return predicate.Conversion(sql.FieldContains(FieldUint32ToString, v))
+}
+
+// Uint32ToStringContainsFold applies the ContainsFold predicate on the "uint32_to_string" field.
+func Uint32ToStringContainsFold(v string) predicate.Conversion {
+	return predicate.Conversion(sql.FieldContainsFold(FieldUint32ToString, v))
 }
 
 // Uint32ToStringHasPrefix applies the HasPrefix predicate on the "uint32_to_string" field.
@@ -614,16 +624,6 @@ func Uint32ToStringIsNil() predicate.Conversion {
 // Uint32ToStringNotNil applies the NotNil predicate on the "uint32_to_string" field.
 func Uint32ToStringNotNil() predicate.Conversion {
 	return predicate.Conversion(sql.FieldNotNull(FieldUint32ToString))
-}
-
-// Uint32ToStringEqualFold applies the EqualFold predicate on the "uint32_to_string" field.
-func Uint32ToStringEqualFold(v string) predicate.Conversion {
-	return predicate.Conversion(sql.FieldEqualFold(FieldUint32ToString, v))
-}
-
-// Uint32ToStringContainsFold applies the ContainsFold predicate on the "uint32_to_string" field.
-func Uint32ToStringContainsFold(v string) predicate.Conversion {
-	return predicate.Conversion(sql.FieldContainsFold(FieldUint32ToString, v))
 }
 
 // Int64ToStringEQ applies the EQ predicate on the "int64_to_string" field.
@@ -666,9 +666,19 @@ func Int64ToStringLTE(v string) predicate.Conversion {
 	return predicate.Conversion(sql.FieldLTE(FieldInt64ToString, v))
 }
 
+// Int64ToStringEqualFold applies the EqualFold predicate on the "int64_to_string" field.
+func Int64ToStringEqualFold(v string) predicate.Conversion {
+	return predicate.Conversion(sql.FieldEqualFold(FieldInt64ToString, v))
+}
+
 // Int64ToStringContains applies the Contains predicate on the "int64_to_string" field.
 func Int64ToStringContains(v string) predicate.Conversion {
 	return predicate.Conversion(sql.FieldContains(FieldInt64ToString, v))
+}
+
+// Int64ToStringContainsFold applies the ContainsFold predicate on the "int64_to_string" field.
+func Int64ToStringContainsFold(v string) predicate.Conversion {
+	return predicate.Conversion(sql.FieldContainsFold(FieldInt64ToString, v))
 }
 
 // Int64ToStringHasPrefix applies the HasPrefix predicate on the "int64_to_string" field.
@@ -689,16 +699,6 @@ func Int64ToStringIsNil() predicate.Conversion {
 // Int64ToStringNotNil applies the NotNil predicate on the "int64_to_string" field.
 func Int64ToStringNotNil() predicate.Conversion {
 	return predicate.Conversion(sql.FieldNotNull(FieldInt64ToString))
-}
-
-// Int64ToStringEqualFold applies the EqualFold predicate on the "int64_to_string" field.
-func Int64ToStringEqualFold(v string) predicate.Conversion {
-	return predicate.Conversion(sql.FieldEqualFold(FieldInt64ToString, v))
-}
-
-// Int64ToStringContainsFold applies the ContainsFold predicate on the "int64_to_string" field.
-func Int64ToStringContainsFold(v string) predicate.Conversion {
-	return predicate.Conversion(sql.FieldContainsFold(FieldInt64ToString, v))
 }
 
 // Uint64ToStringEQ applies the EQ predicate on the "uint64_to_string" field.
@@ -741,9 +741,19 @@ func Uint64ToStringLTE(v string) predicate.Conversion {
 	return predicate.Conversion(sql.FieldLTE(FieldUint64ToString, v))
 }
 
+// Uint64ToStringEqualFold applies the EqualFold predicate on the "uint64_to_string" field.
+func Uint64ToStringEqualFold(v string) predicate.Conversion {
+	return predicate.Conversion(sql.FieldEqualFold(FieldUint64ToString, v))
+}
+
 // Uint64ToStringContains applies the Contains predicate on the "uint64_to_string" field.
 func Uint64ToStringContains(v string) predicate.Conversion {
 	return predicate.Conversion(sql.FieldContains(FieldUint64ToString, v))
+}
+
+// Uint64ToStringContainsFold applies the ContainsFold predicate on the "uint64_to_string" field.
+func Uint64ToStringContainsFold(v string) predicate.Conversion {
+	return predicate.Conversion(sql.FieldContainsFold(FieldUint64ToString, v))
 }
 
 // Uint64ToStringHasPrefix applies the HasPrefix predicate on the "uint64_to_string" field.
@@ -764,16 +774,6 @@ func Uint64ToStringIsNil() predicate.Conversion {
 // Uint64ToStringNotNil applies the NotNil predicate on the "uint64_to_string" field.
 func Uint64ToStringNotNil() predicate.Conversion {
 	return predicate.Conversion(sql.FieldNotNull(FieldUint64ToString))
-}
-
-// Uint64ToStringEqualFold applies the EqualFold predicate on the "uint64_to_string" field.
-func Uint64ToStringEqualFold(v string) predicate.Conversion {
-	return predicate.Conversion(sql.FieldEqualFold(FieldUint64ToString, v))
-}
-
-// Uint64ToStringContainsFold applies the ContainsFold predicate on the "uint64_to_string" field.
-func Uint64ToStringContainsFold(v string) predicate.Conversion {
-	return predicate.Conversion(sql.FieldContainsFold(FieldUint64ToString, v))
 }
 
 // And groups predicates with the AND operator between them.

--- a/entc/integration/migrate/entv2/customtype/where.go
+++ b/entc/integration/migrate/entv2/customtype/where.go
@@ -113,9 +113,19 @@ func CustomLTE(v string) predicate.CustomType {
 	return predicate.CustomType(sql.FieldLTE(FieldCustom, v))
 }
 
+// CustomEqualFold applies the EqualFold predicate on the "custom" field.
+func CustomEqualFold(v string) predicate.CustomType {
+	return predicate.CustomType(sql.FieldEqualFold(FieldCustom, v))
+}
+
 // CustomContains applies the Contains predicate on the "custom" field.
 func CustomContains(v string) predicate.CustomType {
 	return predicate.CustomType(sql.FieldContains(FieldCustom, v))
+}
+
+// CustomContainsFold applies the ContainsFold predicate on the "custom" field.
+func CustomContainsFold(v string) predicate.CustomType {
+	return predicate.CustomType(sql.FieldContainsFold(FieldCustom, v))
 }
 
 // CustomHasPrefix applies the HasPrefix predicate on the "custom" field.
@@ -136,16 +146,6 @@ func CustomIsNil() predicate.CustomType {
 // CustomNotNil applies the NotNil predicate on the "custom" field.
 func CustomNotNil() predicate.CustomType {
 	return predicate.CustomType(sql.FieldNotNull(FieldCustom))
-}
-
-// CustomEqualFold applies the EqualFold predicate on the "custom" field.
-func CustomEqualFold(v string) predicate.CustomType {
-	return predicate.CustomType(sql.FieldEqualFold(FieldCustom, v))
-}
-
-// CustomContainsFold applies the ContainsFold predicate on the "custom" field.
-func CustomContainsFold(v string) predicate.CustomType {
-	return predicate.CustomType(sql.FieldContainsFold(FieldCustom, v))
 }
 
 // Tz0EQ applies the EQ predicate on the "tz0" field.

--- a/entc/integration/migrate/entv2/media/where.go
+++ b/entc/integration/migrate/entv2/media/where.go
@@ -111,9 +111,19 @@ func SourceLTE(v string) predicate.Media {
 	return predicate.Media(sql.FieldLTE(FieldSource, v))
 }
 
+// SourceEqualFold applies the EqualFold predicate on the "source" field.
+func SourceEqualFold(v string) predicate.Media {
+	return predicate.Media(sql.FieldEqualFold(FieldSource, v))
+}
+
 // SourceContains applies the Contains predicate on the "source" field.
 func SourceContains(v string) predicate.Media {
 	return predicate.Media(sql.FieldContains(FieldSource, v))
+}
+
+// SourceContainsFold applies the ContainsFold predicate on the "source" field.
+func SourceContainsFold(v string) predicate.Media {
+	return predicate.Media(sql.FieldContainsFold(FieldSource, v))
 }
 
 // SourceHasPrefix applies the HasPrefix predicate on the "source" field.
@@ -134,16 +144,6 @@ func SourceIsNil() predicate.Media {
 // SourceNotNil applies the NotNil predicate on the "source" field.
 func SourceNotNil() predicate.Media {
 	return predicate.Media(sql.FieldNotNull(FieldSource))
-}
-
-// SourceEqualFold applies the EqualFold predicate on the "source" field.
-func SourceEqualFold(v string) predicate.Media {
-	return predicate.Media(sql.FieldEqualFold(FieldSource, v))
-}
-
-// SourceContainsFold applies the ContainsFold predicate on the "source" field.
-func SourceContainsFold(v string) predicate.Media {
-	return predicate.Media(sql.FieldContainsFold(FieldSource, v))
 }
 
 // SourceURIEQ applies the EQ predicate on the "source_uri" field.
@@ -186,9 +186,19 @@ func SourceURILTE(v string) predicate.Media {
 	return predicate.Media(sql.FieldLTE(FieldSourceURI, v))
 }
 
+// SourceURIEqualFold applies the EqualFold predicate on the "source_uri" field.
+func SourceURIEqualFold(v string) predicate.Media {
+	return predicate.Media(sql.FieldEqualFold(FieldSourceURI, v))
+}
+
 // SourceURIContains applies the Contains predicate on the "source_uri" field.
 func SourceURIContains(v string) predicate.Media {
 	return predicate.Media(sql.FieldContains(FieldSourceURI, v))
+}
+
+// SourceURIContainsFold applies the ContainsFold predicate on the "source_uri" field.
+func SourceURIContainsFold(v string) predicate.Media {
+	return predicate.Media(sql.FieldContainsFold(FieldSourceURI, v))
 }
 
 // SourceURIHasPrefix applies the HasPrefix predicate on the "source_uri" field.
@@ -209,16 +219,6 @@ func SourceURIIsNil() predicate.Media {
 // SourceURINotNil applies the NotNil predicate on the "source_uri" field.
 func SourceURINotNil() predicate.Media {
 	return predicate.Media(sql.FieldNotNull(FieldSourceURI))
-}
-
-// SourceURIEqualFold applies the EqualFold predicate on the "source_uri" field.
-func SourceURIEqualFold(v string) predicate.Media {
-	return predicate.Media(sql.FieldEqualFold(FieldSourceURI, v))
-}
-
-// SourceURIContainsFold applies the ContainsFold predicate on the "source_uri" field.
-func SourceURIContainsFold(v string) predicate.Media {
-	return predicate.Media(sql.FieldContainsFold(FieldSourceURI, v))
 }
 
 // TextEQ applies the EQ predicate on the "text" field.
@@ -261,9 +261,19 @@ func TextLTE(v string) predicate.Media {
 	return predicate.Media(sql.FieldLTE(FieldText, v))
 }
 
+// TextEqualFold applies the EqualFold predicate on the "text" field.
+func TextEqualFold(v string) predicate.Media {
+	return predicate.Media(sql.FieldEqualFold(FieldText, v))
+}
+
 // TextContains applies the Contains predicate on the "text" field.
 func TextContains(v string) predicate.Media {
 	return predicate.Media(sql.FieldContains(FieldText, v))
+}
+
+// TextContainsFold applies the ContainsFold predicate on the "text" field.
+func TextContainsFold(v string) predicate.Media {
+	return predicate.Media(sql.FieldContainsFold(FieldText, v))
 }
 
 // TextHasPrefix applies the HasPrefix predicate on the "text" field.
@@ -284,16 +294,6 @@ func TextIsNil() predicate.Media {
 // TextNotNil applies the NotNil predicate on the "text" field.
 func TextNotNil() predicate.Media {
 	return predicate.Media(sql.FieldNotNull(FieldText))
-}
-
-// TextEqualFold applies the EqualFold predicate on the "text" field.
-func TextEqualFold(v string) predicate.Media {
-	return predicate.Media(sql.FieldEqualFold(FieldText, v))
-}
-
-// TextContainsFold applies the ContainsFold predicate on the "text" field.
-func TextContainsFold(v string) predicate.Media {
-	return predicate.Media(sql.FieldContainsFold(FieldText, v))
 }
 
 // And groups predicates with the AND operator between them.

--- a/entc/integration/migrate/entv2/pet/where.go
+++ b/entc/integration/migrate/entv2/pet/where.go
@@ -102,9 +102,19 @@ func NameLTE(v string) predicate.Pet {
 	return predicate.Pet(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.Pet {
+	return predicate.Pet(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.Pet {
 	return predicate.Pet(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.Pet {
+	return predicate.Pet(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -125,16 +135,6 @@ func NameIsNil() predicate.Pet {
 // NameNotNil applies the NotNil predicate on the "name" field.
 func NameNotNil() predicate.Pet {
 	return predicate.Pet(sql.FieldNotNull(FieldName))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.Pet {
-	return predicate.Pet(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.Pet {
-	return predicate.Pet(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasOwner applies the HasEdge predicate on the "owner" edge.

--- a/entc/integration/migrate/entv2/user/where.go
+++ b/entc/integration/migrate/entv2/user/where.go
@@ -184,9 +184,19 @@ func MixedStringLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldMixedString, v))
 }
 
+// MixedStringEqualFold applies the EqualFold predicate on the "mixed_string" field.
+func MixedStringEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldMixedString, v))
+}
+
 // MixedStringContains applies the Contains predicate on the "mixed_string" field.
 func MixedStringContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldMixedString, v))
+}
+
+// MixedStringContainsFold applies the ContainsFold predicate on the "mixed_string" field.
+func MixedStringContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldMixedString, v))
 }
 
 // MixedStringHasPrefix applies the HasPrefix predicate on the "mixed_string" field.
@@ -197,16 +207,6 @@ func MixedStringHasPrefix(v string) predicate.User {
 // MixedStringHasSuffix applies the HasSuffix predicate on the "mixed_string" field.
 func MixedStringHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldMixedString, v))
-}
-
-// MixedStringEqualFold applies the EqualFold predicate on the "mixed_string" field.
-func MixedStringEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldMixedString, v))
-}
-
-// MixedStringContainsFold applies the ContainsFold predicate on the "mixed_string" field.
-func MixedStringContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldMixedString, v))
 }
 
 // MixedEnumEQ applies the EQ predicate on the "mixed_enum" field.
@@ -319,9 +319,19 @@ func NameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -332,16 +342,6 @@ func NameHasPrefix(v string) predicate.User {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // DescriptionEQ applies the EQ predicate on the "description" field.
@@ -384,9 +384,19 @@ func DescriptionLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldDescription, v))
 }
 
+// DescriptionEqualFold applies the EqualFold predicate on the "description" field.
+func DescriptionEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldDescription, v))
+}
+
 // DescriptionContains applies the Contains predicate on the "description" field.
 func DescriptionContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldDescription, v))
+}
+
+// DescriptionContainsFold applies the ContainsFold predicate on the "description" field.
+func DescriptionContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldDescription, v))
 }
 
 // DescriptionHasPrefix applies the HasPrefix predicate on the "description" field.
@@ -407,16 +417,6 @@ func DescriptionIsNil() predicate.User {
 // DescriptionNotNil applies the NotNil predicate on the "description" field.
 func DescriptionNotNil() predicate.User {
 	return predicate.User(sql.FieldNotNull(FieldDescription))
-}
-
-// DescriptionEqualFold applies the EqualFold predicate on the "description" field.
-func DescriptionEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldDescription, v))
-}
-
-// DescriptionContainsFold applies the ContainsFold predicate on the "description" field.
-func DescriptionContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldDescription, v))
 }
 
 // NicknameEQ applies the EQ predicate on the "nickname" field.
@@ -459,9 +459,19 @@ func NicknameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldNickname, v))
 }
 
+// NicknameEqualFold applies the EqualFold predicate on the "nickname" field.
+func NicknameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldNickname, v))
+}
+
 // NicknameContains applies the Contains predicate on the "nickname" field.
 func NicknameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldNickname, v))
+}
+
+// NicknameContainsFold applies the ContainsFold predicate on the "nickname" field.
+func NicknameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldNickname, v))
 }
 
 // NicknameHasPrefix applies the HasPrefix predicate on the "nickname" field.
@@ -472,16 +482,6 @@ func NicknameHasPrefix(v string) predicate.User {
 // NicknameHasSuffix applies the HasSuffix predicate on the "nickname" field.
 func NicknameHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldNickname, v))
-}
-
-// NicknameEqualFold applies the EqualFold predicate on the "nickname" field.
-func NicknameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldNickname, v))
-}
-
-// NicknameContainsFold applies the ContainsFold predicate on the "nickname" field.
-func NicknameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldNickname, v))
 }
 
 // PhoneEQ applies the EQ predicate on the "phone" field.
@@ -524,9 +524,19 @@ func PhoneLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldPhone, v))
 }
 
+// PhoneEqualFold applies the EqualFold predicate on the "phone" field.
+func PhoneEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldPhone, v))
+}
+
 // PhoneContains applies the Contains predicate on the "phone" field.
 func PhoneContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldPhone, v))
+}
+
+// PhoneContainsFold applies the ContainsFold predicate on the "phone" field.
+func PhoneContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldPhone, v))
 }
 
 // PhoneHasPrefix applies the HasPrefix predicate on the "phone" field.
@@ -537,16 +547,6 @@ func PhoneHasPrefix(v string) predicate.User {
 // PhoneHasSuffix applies the HasSuffix predicate on the "phone" field.
 func PhoneHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldPhone, v))
-}
-
-// PhoneEqualFold applies the EqualFold predicate on the "phone" field.
-func PhoneEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldPhone, v))
-}
-
-// PhoneContainsFold applies the ContainsFold predicate on the "phone" field.
-func PhoneContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldPhone, v))
 }
 
 // BufferEQ applies the EQ predicate on the "buffer" field.
@@ -639,9 +639,19 @@ func TitleLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldTitle, v))
 }
 
+// TitleEqualFold applies the EqualFold predicate on the "title" field.
+func TitleEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldTitle, v))
+}
+
 // TitleContains applies the Contains predicate on the "title" field.
 func TitleContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldTitle, v))
+}
+
+// TitleContainsFold applies the ContainsFold predicate on the "title" field.
+func TitleContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldTitle, v))
 }
 
 // TitleHasPrefix applies the HasPrefix predicate on the "title" field.
@@ -652,16 +662,6 @@ func TitleHasPrefix(v string) predicate.User {
 // TitleHasSuffix applies the HasSuffix predicate on the "title" field.
 func TitleHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldTitle, v))
-}
-
-// TitleEqualFold applies the EqualFold predicate on the "title" field.
-func TitleEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldTitle, v))
-}
-
-// TitleContainsFold applies the ContainsFold predicate on the "title" field.
-func TitleContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldTitle, v))
 }
 
 // NewNameEQ applies the EQ predicate on the "new_name" field.
@@ -704,9 +704,19 @@ func NewNameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldNewName, v))
 }
 
+// NewNameEqualFold applies the EqualFold predicate on the "new_name" field.
+func NewNameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldNewName, v))
+}
+
 // NewNameContains applies the Contains predicate on the "new_name" field.
 func NewNameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldNewName, v))
+}
+
+// NewNameContainsFold applies the ContainsFold predicate on the "new_name" field.
+func NewNameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldNewName, v))
 }
 
 // NewNameHasPrefix applies the HasPrefix predicate on the "new_name" field.
@@ -727,16 +737,6 @@ func NewNameIsNil() predicate.User {
 // NewNameNotNil applies the NotNil predicate on the "new_name" field.
 func NewNameNotNil() predicate.User {
 	return predicate.User(sql.FieldNotNull(FieldNewName))
-}
-
-// NewNameEqualFold applies the EqualFold predicate on the "new_name" field.
-func NewNameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldNewName, v))
-}
-
-// NewNameContainsFold applies the ContainsFold predicate on the "new_name" field.
-func NewNameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldNewName, v))
 }
 
 // NewTokenEQ applies the EQ predicate on the "new_token" field.
@@ -779,9 +779,19 @@ func NewTokenLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldNewToken, v))
 }
 
+// NewTokenEqualFold applies the EqualFold predicate on the "new_token" field.
+func NewTokenEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldNewToken, v))
+}
+
 // NewTokenContains applies the Contains predicate on the "new_token" field.
 func NewTokenContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldNewToken, v))
+}
+
+// NewTokenContainsFold applies the ContainsFold predicate on the "new_token" field.
+func NewTokenContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldNewToken, v))
 }
 
 // NewTokenHasPrefix applies the HasPrefix predicate on the "new_token" field.
@@ -792,16 +802,6 @@ func NewTokenHasPrefix(v string) predicate.User {
 // NewTokenHasSuffix applies the HasSuffix predicate on the "new_token" field.
 func NewTokenHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldNewToken, v))
-}
-
-// NewTokenEqualFold applies the EqualFold predicate on the "new_token" field.
-func NewTokenEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldNewToken, v))
-}
-
-// NewTokenContainsFold applies the ContainsFold predicate on the "new_token" field.
-func NewTokenContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldNewToken, v))
 }
 
 // BlobEQ applies the EQ predicate on the "blob" field.
@@ -954,9 +954,19 @@ func WorkplaceLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldWorkplace, v))
 }
 
+// WorkplaceEqualFold applies the EqualFold predicate on the "workplace" field.
+func WorkplaceEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldWorkplace, v))
+}
+
 // WorkplaceContains applies the Contains predicate on the "workplace" field.
 func WorkplaceContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldWorkplace, v))
+}
+
+// WorkplaceContainsFold applies the ContainsFold predicate on the "workplace" field.
+func WorkplaceContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldWorkplace, v))
 }
 
 // WorkplaceHasPrefix applies the HasPrefix predicate on the "workplace" field.
@@ -977,16 +987,6 @@ func WorkplaceIsNil() predicate.User {
 // WorkplaceNotNil applies the NotNil predicate on the "workplace" field.
 func WorkplaceNotNil() predicate.User {
 	return predicate.User(sql.FieldNotNull(FieldWorkplace))
-}
-
-// WorkplaceEqualFold applies the EqualFold predicate on the "workplace" field.
-func WorkplaceEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldWorkplace, v))
-}
-
-// WorkplaceContainsFold applies the ContainsFold predicate on the "workplace" field.
-func WorkplaceContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldWorkplace, v))
 }
 
 // RolesIsNil applies the IsNil predicate on the "roles" field.
@@ -1039,9 +1039,19 @@ func DefaultExprLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldDefaultExpr, v))
 }
 
+// DefaultExprEqualFold applies the EqualFold predicate on the "default_expr" field.
+func DefaultExprEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldDefaultExpr, v))
+}
+
 // DefaultExprContains applies the Contains predicate on the "default_expr" field.
 func DefaultExprContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldDefaultExpr, v))
+}
+
+// DefaultExprContainsFold applies the ContainsFold predicate on the "default_expr" field.
+func DefaultExprContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldDefaultExpr, v))
 }
 
 // DefaultExprHasPrefix applies the HasPrefix predicate on the "default_expr" field.
@@ -1062,16 +1072,6 @@ func DefaultExprIsNil() predicate.User {
 // DefaultExprNotNil applies the NotNil predicate on the "default_expr" field.
 func DefaultExprNotNil() predicate.User {
 	return predicate.User(sql.FieldNotNull(FieldDefaultExpr))
-}
-
-// DefaultExprEqualFold applies the EqualFold predicate on the "default_expr" field.
-func DefaultExprEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldDefaultExpr, v))
-}
-
-// DefaultExprContainsFold applies the ContainsFold predicate on the "default_expr" field.
-func DefaultExprContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldDefaultExpr, v))
 }
 
 // DefaultExprsEQ applies the EQ predicate on the "default_exprs" field.
@@ -1114,9 +1114,19 @@ func DefaultExprsLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldDefaultExprs, v))
 }
 
+// DefaultExprsEqualFold applies the EqualFold predicate on the "default_exprs" field.
+func DefaultExprsEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldDefaultExprs, v))
+}
+
 // DefaultExprsContains applies the Contains predicate on the "default_exprs" field.
 func DefaultExprsContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldDefaultExprs, v))
+}
+
+// DefaultExprsContainsFold applies the ContainsFold predicate on the "default_exprs" field.
+func DefaultExprsContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldDefaultExprs, v))
 }
 
 // DefaultExprsHasPrefix applies the HasPrefix predicate on the "default_exprs" field.
@@ -1137,16 +1147,6 @@ func DefaultExprsIsNil() predicate.User {
 // DefaultExprsNotNil applies the NotNil predicate on the "default_exprs" field.
 func DefaultExprsNotNil() predicate.User {
 	return predicate.User(sql.FieldNotNull(FieldDefaultExprs))
-}
-
-// DefaultExprsEqualFold applies the EqualFold predicate on the "default_exprs" field.
-func DefaultExprsEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldDefaultExprs, v))
-}
-
-// DefaultExprsContainsFold applies the ContainsFold predicate on the "default_exprs" field.
-func DefaultExprsContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldDefaultExprs, v))
 }
 
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.
@@ -1229,9 +1229,19 @@ func DropOptionalLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldDropOptional, v))
 }
 
+// DropOptionalEqualFold applies the EqualFold predicate on the "drop_optional" field.
+func DropOptionalEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldDropOptional, v))
+}
+
 // DropOptionalContains applies the Contains predicate on the "drop_optional" field.
 func DropOptionalContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldDropOptional, v))
+}
+
+// DropOptionalContainsFold applies the ContainsFold predicate on the "drop_optional" field.
+func DropOptionalContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldDropOptional, v))
 }
 
 // DropOptionalHasPrefix applies the HasPrefix predicate on the "drop_optional" field.
@@ -1242,16 +1252,6 @@ func DropOptionalHasPrefix(v string) predicate.User {
 // DropOptionalHasSuffix applies the HasSuffix predicate on the "drop_optional" field.
 func DropOptionalHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldDropOptional, v))
-}
-
-// DropOptionalEqualFold applies the EqualFold predicate on the "drop_optional" field.
-func DropOptionalEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldDropOptional, v))
-}
-
-// DropOptionalContainsFold applies the ContainsFold predicate on the "drop_optional" field.
-func DropOptionalContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldDropOptional, v))
 }
 
 // HasCar applies the HasEdge predicate on the "car" edge.

--- a/entc/integration/migrate/versioned/group/where.go
+++ b/entc/integration/migrate/versioned/group/where.go
@@ -101,9 +101,19 @@ func NameLTE(v string) predicate.Group {
 	return predicate.Group(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.Group {
+	return predicate.Group(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.Group {
 	return predicate.Group(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.Group {
+	return predicate.Group(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -114,16 +124,6 @@ func NameHasPrefix(v string) predicate.Group {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.Group {
 	return predicate.Group(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.Group {
-	return predicate.Group(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.Group {
-	return predicate.Group(sql.FieldContainsFold(FieldName, v))
 }
 
 // And groups predicates with the AND operator between them.

--- a/entc/integration/migrate/versioned/user/where.go
+++ b/entc/integration/migrate/versioned/user/where.go
@@ -151,9 +151,19 @@ func NameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -164,16 +174,6 @@ func NameHasPrefix(v string) predicate.User {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // AddressEQ applies the EQ predicate on the "address" field.
@@ -216,9 +216,19 @@ func AddressLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldAddress, v))
 }
 
+// AddressEqualFold applies the EqualFold predicate on the "address" field.
+func AddressEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldAddress, v))
+}
+
 // AddressContains applies the Contains predicate on the "address" field.
 func AddressContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldAddress, v))
+}
+
+// AddressContainsFold applies the ContainsFold predicate on the "address" field.
+func AddressContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldAddress, v))
 }
 
 // AddressHasPrefix applies the HasPrefix predicate on the "address" field.
@@ -239,16 +249,6 @@ func AddressIsNil() predicate.User {
 // AddressNotNil applies the NotNil predicate on the "address" field.
 func AddressNotNil() predicate.User {
 	return predicate.User(sql.FieldNotNull(FieldAddress))
-}
-
-// AddressEqualFold applies the EqualFold predicate on the "address" field.
-func AddressEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldAddress, v))
-}
-
-// AddressContainsFold applies the ContainsFold predicate on the "address" field.
-func AddressContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldAddress, v))
 }
 
 // And groups predicates with the AND operator between them.

--- a/entc/integration/multischema/ent/group/where.go
+++ b/entc/integration/multischema/ent/group/where.go
@@ -103,9 +103,19 @@ func NameLTE(v string) predicate.Group {
 	return predicate.Group(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.Group {
+	return predicate.Group(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.Group {
 	return predicate.Group(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.Group {
+	return predicate.Group(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -116,16 +126,6 @@ func NameHasPrefix(v string) predicate.Group {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.Group {
 	return predicate.Group(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.Group {
-	return predicate.Group(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.Group {
-	return predicate.Group(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasUsers applies the HasEdge predicate on the "users" edge.

--- a/entc/integration/multischema/ent/pet/where.go
+++ b/entc/integration/multischema/ent/pet/where.go
@@ -108,9 +108,19 @@ func NameLTE(v string) predicate.Pet {
 	return predicate.Pet(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.Pet {
+	return predicate.Pet(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.Pet {
 	return predicate.Pet(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.Pet {
+	return predicate.Pet(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -121,16 +131,6 @@ func NameHasPrefix(v string) predicate.Pet {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.Pet {
 	return predicate.Pet(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.Pet {
-	return predicate.Pet(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.Pet {
-	return predicate.Pet(sql.FieldContainsFold(FieldName, v))
 }
 
 // OwnerIDEQ applies the EQ predicate on the "owner_id" field.

--- a/entc/integration/multischema/ent/user/where.go
+++ b/entc/integration/multischema/ent/user/where.go
@@ -103,9 +103,19 @@ func NameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -116,16 +126,6 @@ func NameHasPrefix(v string) predicate.User {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasPets applies the HasEdge predicate on the "pets" edge.

--- a/entc/integration/multischema/versioned/group/where.go
+++ b/entc/integration/multischema/versioned/group/where.go
@@ -103,9 +103,19 @@ func NameLTE(v string) predicate.Group {
 	return predicate.Group(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.Group {
+	return predicate.Group(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.Group {
 	return predicate.Group(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.Group {
+	return predicate.Group(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -116,16 +126,6 @@ func NameHasPrefix(v string) predicate.Group {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.Group {
 	return predicate.Group(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.Group {
-	return predicate.Group(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.Group {
-	return predicate.Group(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasUsers applies the HasEdge predicate on the "users" edge.

--- a/entc/integration/multischema/versioned/pet/where.go
+++ b/entc/integration/multischema/versioned/pet/where.go
@@ -108,9 +108,19 @@ func NameLTE(v string) predicate.Pet {
 	return predicate.Pet(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.Pet {
+	return predicate.Pet(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.Pet {
 	return predicate.Pet(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.Pet {
+	return predicate.Pet(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -121,16 +131,6 @@ func NameHasPrefix(v string) predicate.Pet {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.Pet {
 	return predicate.Pet(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.Pet {
-	return predicate.Pet(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.Pet {
-	return predicate.Pet(sql.FieldContainsFold(FieldName, v))
 }
 
 // OwnerIDEQ applies the EQ predicate on the "owner_id" field.

--- a/entc/integration/multischema/versioned/user/where.go
+++ b/entc/integration/multischema/versioned/user/where.go
@@ -103,9 +103,19 @@ func NameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -116,16 +126,6 @@ func NameHasPrefix(v string) predicate.User {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasPets applies the HasEdge predicate on the "pets" edge.

--- a/entc/integration/privacy/ent/task/where.go
+++ b/entc/integration/privacy/ent/task/where.go
@@ -113,9 +113,19 @@ func TitleLTE(v string) predicate.Task {
 	return predicate.Task(sql.FieldLTE(FieldTitle, v))
 }
 
+// TitleEqualFold applies the EqualFold predicate on the "title" field.
+func TitleEqualFold(v string) predicate.Task {
+	return predicate.Task(sql.FieldEqualFold(FieldTitle, v))
+}
+
 // TitleContains applies the Contains predicate on the "title" field.
 func TitleContains(v string) predicate.Task {
 	return predicate.Task(sql.FieldContains(FieldTitle, v))
+}
+
+// TitleContainsFold applies the ContainsFold predicate on the "title" field.
+func TitleContainsFold(v string) predicate.Task {
+	return predicate.Task(sql.FieldContainsFold(FieldTitle, v))
 }
 
 // TitleHasPrefix applies the HasPrefix predicate on the "title" field.
@@ -126,16 +136,6 @@ func TitleHasPrefix(v string) predicate.Task {
 // TitleHasSuffix applies the HasSuffix predicate on the "title" field.
 func TitleHasSuffix(v string) predicate.Task {
 	return predicate.Task(sql.FieldHasSuffix(FieldTitle, v))
-}
-
-// TitleEqualFold applies the EqualFold predicate on the "title" field.
-func TitleEqualFold(v string) predicate.Task {
-	return predicate.Task(sql.FieldEqualFold(FieldTitle, v))
-}
-
-// TitleContainsFold applies the ContainsFold predicate on the "title" field.
-func TitleContainsFold(v string) predicate.Task {
-	return predicate.Task(sql.FieldContainsFold(FieldTitle, v))
 }
 
 // DescriptionEQ applies the EQ predicate on the "description" field.
@@ -178,9 +178,19 @@ func DescriptionLTE(v string) predicate.Task {
 	return predicate.Task(sql.FieldLTE(FieldDescription, v))
 }
 
+// DescriptionEqualFold applies the EqualFold predicate on the "description" field.
+func DescriptionEqualFold(v string) predicate.Task {
+	return predicate.Task(sql.FieldEqualFold(FieldDescription, v))
+}
+
 // DescriptionContains applies the Contains predicate on the "description" field.
 func DescriptionContains(v string) predicate.Task {
 	return predicate.Task(sql.FieldContains(FieldDescription, v))
+}
+
+// DescriptionContainsFold applies the ContainsFold predicate on the "description" field.
+func DescriptionContainsFold(v string) predicate.Task {
+	return predicate.Task(sql.FieldContainsFold(FieldDescription, v))
 }
 
 // DescriptionHasPrefix applies the HasPrefix predicate on the "description" field.
@@ -201,16 +211,6 @@ func DescriptionIsNil() predicate.Task {
 // DescriptionNotNil applies the NotNil predicate on the "description" field.
 func DescriptionNotNil() predicate.Task {
 	return predicate.Task(sql.FieldNotNull(FieldDescription))
-}
-
-// DescriptionEqualFold applies the EqualFold predicate on the "description" field.
-func DescriptionEqualFold(v string) predicate.Task {
-	return predicate.Task(sql.FieldEqualFold(FieldDescription, v))
-}
-
-// DescriptionContainsFold applies the ContainsFold predicate on the "description" field.
-func DescriptionContainsFold(v string) predicate.Task {
-	return predicate.Task(sql.FieldContainsFold(FieldDescription, v))
 }
 
 // StatusEQ applies the EQ predicate on the "status" field.

--- a/entc/integration/privacy/ent/team/where.go
+++ b/entc/integration/privacy/ent/team/where.go
@@ -102,9 +102,19 @@ func NameLTE(v string) predicate.Team {
 	return predicate.Team(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.Team {
+	return predicate.Team(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.Team {
 	return predicate.Team(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.Team {
+	return predicate.Team(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -115,16 +125,6 @@ func NameHasPrefix(v string) predicate.Team {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.Team {
 	return predicate.Team(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.Team {
-	return predicate.Team(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.Team {
-	return predicate.Team(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasTasks applies the HasEdge predicate on the "tasks" edge.

--- a/entc/integration/privacy/ent/user/where.go
+++ b/entc/integration/privacy/ent/user/where.go
@@ -107,9 +107,19 @@ func NameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -120,16 +130,6 @@ func NameHasPrefix(v string) predicate.User {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // AgeEQ applies the EQ predicate on the "age" field.

--- a/entc/integration/template/ent/user/where.go
+++ b/entc/integration/template/ent/user/where.go
@@ -102,9 +102,19 @@ func NameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -115,16 +125,6 @@ func NameHasPrefix(v string) predicate.User {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasPets applies the HasEdge predicate on the "pets" edge.

--- a/examples/edgeindex/ent/city/where.go
+++ b/examples/edgeindex/ent/city/where.go
@@ -102,9 +102,19 @@ func NameLTE(v string) predicate.City {
 	return predicate.City(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.City {
+	return predicate.City(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.City {
 	return predicate.City(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.City {
+	return predicate.City(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -115,16 +125,6 @@ func NameHasPrefix(v string) predicate.City {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.City {
 	return predicate.City(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.City {
-	return predicate.City(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.City {
-	return predicate.City(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasStreets applies the HasEdge predicate on the "streets" edge.

--- a/examples/edgeindex/ent/street/where.go
+++ b/examples/edgeindex/ent/street/where.go
@@ -102,9 +102,19 @@ func NameLTE(v string) predicate.Street {
 	return predicate.Street(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.Street {
+	return predicate.Street(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.Street {
 	return predicate.Street(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.Street {
+	return predicate.Street(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -115,16 +125,6 @@ func NameHasPrefix(v string) predicate.Street {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.Street {
 	return predicate.Street(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.Street {
-	return predicate.Street(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.Street {
-	return predicate.Street(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasCity applies the HasEdge predicate on the "city" edge.

--- a/examples/encryptfield/ent/generate.go
+++ b/examples/encryptfield/ent/generate.go
@@ -4,4 +4,4 @@
 
 package ent
 
-//go:generate go run entc.go
+//go:generate go run -mod=mod entc.go

--- a/examples/encryptfield/ent/user/where.go
+++ b/examples/encryptfield/ent/user/where.go
@@ -106,9 +106,19 @@ func NameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -129,16 +139,6 @@ func NameIsNil() predicate.User {
 // NameNotNil applies the NotNil predicate on the "name" field.
 func NameNotNil() predicate.User {
 	return predicate.User(sql.FieldNotNull(FieldName))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // NicknameEQ applies the EQ predicate on the "nickname" field.
@@ -181,9 +181,19 @@ func NicknameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldNickname, v))
 }
 
+// NicknameEqualFold applies the EqualFold predicate on the "nickname" field.
+func NicknameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldNickname, v))
+}
+
 // NicknameContains applies the Contains predicate on the "nickname" field.
 func NicknameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldNickname, v))
+}
+
+// NicknameContainsFold applies the ContainsFold predicate on the "nickname" field.
+func NicknameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldNickname, v))
 }
 
 // NicknameHasPrefix applies the HasPrefix predicate on the "nickname" field.
@@ -194,16 +204,6 @@ func NicknameHasPrefix(v string) predicate.User {
 // NicknameHasSuffix applies the HasSuffix predicate on the "nickname" field.
 func NicknameHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldNickname, v))
-}
-
-// NicknameEqualFold applies the EqualFold predicate on the "nickname" field.
-func NicknameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldNickname, v))
-}
-
-// NicknameContainsFold applies the ContainsFold predicate on the "nickname" field.
-func NicknameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldNickname, v))
 }
 
 // And groups predicates with the AND operator between them.

--- a/examples/entcpkg/README.md
+++ b/examples/entcpkg/README.md
@@ -57,7 +57,7 @@ or run `go generate ./ent`. The `generate.go` file holds the `go run command`:
 ```go
 package ent
 
-//go:generate go run entc.go
+//go:generate go run -mod=mod entc.go
 ```
 
 The `generate.go` file is preferred if you have many `generate` pragmas in your project.

--- a/examples/entcpkg/ent/user/where.go
+++ b/examples/entcpkg/ent/user/where.go
@@ -106,9 +106,19 @@ func NameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -129,16 +139,6 @@ func NameIsNil() predicate.User {
 // NameNotNil applies the NotNil predicate on the "name" field.
 func NameNotNil() predicate.User {
 	return predicate.User(sql.FieldNotNull(FieldName))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // AgeEQ applies the EQ predicate on the "age" field.

--- a/examples/fs/ent/file/where.go
+++ b/examples/fs/ent/file/where.go
@@ -112,9 +112,19 @@ func NameLTE(v string) predicate.File {
 	return predicate.File(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.File {
+	return predicate.File(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.File {
 	return predicate.File(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.File {
+	return predicate.File(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -125,16 +135,6 @@ func NameHasPrefix(v string) predicate.File {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.File {
 	return predicate.File(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.File {
-	return predicate.File(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.File {
-	return predicate.File(sql.FieldContainsFold(FieldName, v))
 }
 
 // DeletedEQ applies the EQ predicate on the "deleted" field.

--- a/examples/jsonencode/ent/card/where.go
+++ b/examples/jsonencode/ent/card/where.go
@@ -101,9 +101,19 @@ func NumberLTE(v string) predicate.Card {
 	return predicate.Card(sql.FieldLTE(FieldNumber, v))
 }
 
+// NumberEqualFold applies the EqualFold predicate on the "number" field.
+func NumberEqualFold(v string) predicate.Card {
+	return predicate.Card(sql.FieldEqualFold(FieldNumber, v))
+}
+
 // NumberContains applies the Contains predicate on the "number" field.
 func NumberContains(v string) predicate.Card {
 	return predicate.Card(sql.FieldContains(FieldNumber, v))
+}
+
+// NumberContainsFold applies the ContainsFold predicate on the "number" field.
+func NumberContainsFold(v string) predicate.Card {
+	return predicate.Card(sql.FieldContainsFold(FieldNumber, v))
 }
 
 // NumberHasPrefix applies the HasPrefix predicate on the "number" field.
@@ -114,16 +124,6 @@ func NumberHasPrefix(v string) predicate.Card {
 // NumberHasSuffix applies the HasSuffix predicate on the "number" field.
 func NumberHasSuffix(v string) predicate.Card {
 	return predicate.Card(sql.FieldHasSuffix(FieldNumber, v))
-}
-
-// NumberEqualFold applies the EqualFold predicate on the "number" field.
-func NumberEqualFold(v string) predicate.Card {
-	return predicate.Card(sql.FieldEqualFold(FieldNumber, v))
-}
-
-// NumberContainsFold applies the ContainsFold predicate on the "number" field.
-func NumberContainsFold(v string) predicate.Card {
-	return predicate.Card(sql.FieldContainsFold(FieldNumber, v))
 }
 
 // And groups predicates with the AND operator between them.

--- a/examples/jsonencode/ent/pet/where.go
+++ b/examples/jsonencode/ent/pet/where.go
@@ -152,9 +152,19 @@ func NameLTE(v string) predicate.Pet {
 	return predicate.Pet(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.Pet {
+	return predicate.Pet(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.Pet {
 	return predicate.Pet(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.Pet {
+	return predicate.Pet(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -165,16 +175,6 @@ func NameHasPrefix(v string) predicate.Pet {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.Pet {
 	return predicate.Pet(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.Pet {
-	return predicate.Pet(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.Pet {
-	return predicate.Pet(sql.FieldContainsFold(FieldName, v))
 }
 
 // OwnerIDEQ applies the EQ predicate on the "owner_id" field.

--- a/examples/jsonencode/ent/user/where.go
+++ b/examples/jsonencode/ent/user/where.go
@@ -147,9 +147,19 @@ func NameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -160,16 +170,6 @@ func NameHasPrefix(v string) predicate.User {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasPets applies the HasEdge predicate on the "pets" edge.

--- a/examples/m2m2types/ent/group/where.go
+++ b/examples/m2m2types/ent/group/where.go
@@ -102,9 +102,19 @@ func NameLTE(v string) predicate.Group {
 	return predicate.Group(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.Group {
+	return predicate.Group(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.Group {
 	return predicate.Group(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.Group {
+	return predicate.Group(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -115,16 +125,6 @@ func NameHasPrefix(v string) predicate.Group {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.Group {
 	return predicate.Group(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.Group {
-	return predicate.Group(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.Group {
-	return predicate.Group(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasUsers applies the HasEdge predicate on the "users" edge.

--- a/examples/m2m2types/ent/user/where.go
+++ b/examples/m2m2types/ent/user/where.go
@@ -147,9 +147,19 @@ func NameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -160,16 +170,6 @@ func NameHasPrefix(v string) predicate.User {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasGroups applies the HasEdge predicate on the "groups" edge.

--- a/examples/m2mbidi/ent/user/where.go
+++ b/examples/m2mbidi/ent/user/where.go
@@ -147,9 +147,19 @@ func NameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -160,16 +170,6 @@ func NameHasPrefix(v string) predicate.User {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasFriends applies the HasEdge predicate on the "friends" edge.

--- a/examples/m2mrecur/ent/user/where.go
+++ b/examples/m2mrecur/ent/user/where.go
@@ -147,9 +147,19 @@ func NameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -160,16 +170,6 @@ func NameHasPrefix(v string) predicate.User {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasFollowers applies the HasEdge predicate on the "followers" edge.

--- a/examples/migration/ent/card/where.go
+++ b/examples/migration/ent/card/where.go
@@ -124,9 +124,19 @@ func TypeLTE(v string) predicate.Card {
 	return predicate.Card(sql.FieldLTE(FieldType, v))
 }
 
+// TypeEqualFold applies the EqualFold predicate on the "type" field.
+func TypeEqualFold(v string) predicate.Card {
+	return predicate.Card(sql.FieldEqualFold(FieldType, v))
+}
+
 // TypeContains applies the Contains predicate on the "type" field.
 func TypeContains(v string) predicate.Card {
 	return predicate.Card(sql.FieldContains(FieldType, v))
+}
+
+// TypeContainsFold applies the ContainsFold predicate on the "type" field.
+func TypeContainsFold(v string) predicate.Card {
+	return predicate.Card(sql.FieldContainsFold(FieldType, v))
 }
 
 // TypeHasPrefix applies the HasPrefix predicate on the "type" field.
@@ -137,16 +147,6 @@ func TypeHasPrefix(v string) predicate.Card {
 // TypeHasSuffix applies the HasSuffix predicate on the "type" field.
 func TypeHasSuffix(v string) predicate.Card {
 	return predicate.Card(sql.FieldHasSuffix(FieldType, v))
-}
-
-// TypeEqualFold applies the EqualFold predicate on the "type" field.
-func TypeEqualFold(v string) predicate.Card {
-	return predicate.Card(sql.FieldEqualFold(FieldType, v))
-}
-
-// TypeContainsFold applies the ContainsFold predicate on the "type" field.
-func TypeContainsFold(v string) predicate.Card {
-	return predicate.Card(sql.FieldContainsFold(FieldType, v))
 }
 
 // NumberHashEQ applies the EQ predicate on the "number_hash" field.
@@ -189,9 +189,19 @@ func NumberHashLTE(v string) predicate.Card {
 	return predicate.Card(sql.FieldLTE(FieldNumberHash, v))
 }
 
+// NumberHashEqualFold applies the EqualFold predicate on the "number_hash" field.
+func NumberHashEqualFold(v string) predicate.Card {
+	return predicate.Card(sql.FieldEqualFold(FieldNumberHash, v))
+}
+
 // NumberHashContains applies the Contains predicate on the "number_hash" field.
 func NumberHashContains(v string) predicate.Card {
 	return predicate.Card(sql.FieldContains(FieldNumberHash, v))
+}
+
+// NumberHashContainsFold applies the ContainsFold predicate on the "number_hash" field.
+func NumberHashContainsFold(v string) predicate.Card {
+	return predicate.Card(sql.FieldContainsFold(FieldNumberHash, v))
 }
 
 // NumberHashHasPrefix applies the HasPrefix predicate on the "number_hash" field.
@@ -202,16 +212,6 @@ func NumberHashHasPrefix(v string) predicate.Card {
 // NumberHashHasSuffix applies the HasSuffix predicate on the "number_hash" field.
 func NumberHashHasSuffix(v string) predicate.Card {
 	return predicate.Card(sql.FieldHasSuffix(FieldNumberHash, v))
-}
-
-// NumberHashEqualFold applies the EqualFold predicate on the "number_hash" field.
-func NumberHashEqualFold(v string) predicate.Card {
-	return predicate.Card(sql.FieldEqualFold(FieldNumberHash, v))
-}
-
-// NumberHashContainsFold applies the ContainsFold predicate on the "number_hash" field.
-func NumberHashContainsFold(v string) predicate.Card {
-	return predicate.Card(sql.FieldContainsFold(FieldNumberHash, v))
 }
 
 // CvvHashEQ applies the EQ predicate on the "cvv_hash" field.
@@ -254,9 +254,19 @@ func CvvHashLTE(v string) predicate.Card {
 	return predicate.Card(sql.FieldLTE(FieldCvvHash, v))
 }
 
+// CvvHashEqualFold applies the EqualFold predicate on the "cvv_hash" field.
+func CvvHashEqualFold(v string) predicate.Card {
+	return predicate.Card(sql.FieldEqualFold(FieldCvvHash, v))
+}
+
 // CvvHashContains applies the Contains predicate on the "cvv_hash" field.
 func CvvHashContains(v string) predicate.Card {
 	return predicate.Card(sql.FieldContains(FieldCvvHash, v))
+}
+
+// CvvHashContainsFold applies the ContainsFold predicate on the "cvv_hash" field.
+func CvvHashContainsFold(v string) predicate.Card {
+	return predicate.Card(sql.FieldContainsFold(FieldCvvHash, v))
 }
 
 // CvvHashHasPrefix applies the HasPrefix predicate on the "cvv_hash" field.
@@ -267,16 +277,6 @@ func CvvHashHasPrefix(v string) predicate.Card {
 // CvvHashHasSuffix applies the HasSuffix predicate on the "cvv_hash" field.
 func CvvHashHasSuffix(v string) predicate.Card {
 	return predicate.Card(sql.FieldHasSuffix(FieldCvvHash, v))
-}
-
-// CvvHashEqualFold applies the EqualFold predicate on the "cvv_hash" field.
-func CvvHashEqualFold(v string) predicate.Card {
-	return predicate.Card(sql.FieldEqualFold(FieldCvvHash, v))
-}
-
-// CvvHashContainsFold applies the ContainsFold predicate on the "cvv_hash" field.
-func CvvHashContainsFold(v string) predicate.Card {
-	return predicate.Card(sql.FieldContainsFold(FieldCvvHash, v))
 }
 
 // ExpiresAtEQ applies the EQ predicate on the "expires_at" field.

--- a/examples/migration/ent/payment/where.go
+++ b/examples/migration/ent/payment/where.go
@@ -239,9 +239,19 @@ func DescriptionLTE(v string) predicate.Payment {
 	return predicate.Payment(sql.FieldLTE(FieldDescription, v))
 }
 
+// DescriptionEqualFold applies the EqualFold predicate on the "description" field.
+func DescriptionEqualFold(v string) predicate.Payment {
+	return predicate.Payment(sql.FieldEqualFold(FieldDescription, v))
+}
+
 // DescriptionContains applies the Contains predicate on the "description" field.
 func DescriptionContains(v string) predicate.Payment {
 	return predicate.Payment(sql.FieldContains(FieldDescription, v))
+}
+
+// DescriptionContainsFold applies the ContainsFold predicate on the "description" field.
+func DescriptionContainsFold(v string) predicate.Payment {
+	return predicate.Payment(sql.FieldContainsFold(FieldDescription, v))
 }
 
 // DescriptionHasPrefix applies the HasPrefix predicate on the "description" field.
@@ -252,16 +262,6 @@ func DescriptionHasPrefix(v string) predicate.Payment {
 // DescriptionHasSuffix applies the HasSuffix predicate on the "description" field.
 func DescriptionHasSuffix(v string) predicate.Payment {
 	return predicate.Payment(sql.FieldHasSuffix(FieldDescription, v))
-}
-
-// DescriptionEqualFold applies the EqualFold predicate on the "description" field.
-func DescriptionEqualFold(v string) predicate.Payment {
-	return predicate.Payment(sql.FieldEqualFold(FieldDescription, v))
-}
-
-// DescriptionContainsFold applies the ContainsFold predicate on the "description" field.
-func DescriptionContainsFold(v string) predicate.Payment {
-	return predicate.Payment(sql.FieldContainsFold(FieldDescription, v))
 }
 
 // StatusEQ applies the EQ predicate on the "status" field.

--- a/examples/migration/ent/pet/where.go
+++ b/examples/migration/ent/pet/where.go
@@ -123,9 +123,19 @@ func NameLTE(v string) predicate.Pet {
 	return predicate.Pet(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.Pet {
+	return predicate.Pet(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.Pet {
 	return predicate.Pet(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.Pet {
+	return predicate.Pet(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -136,16 +146,6 @@ func NameHasPrefix(v string) predicate.Pet {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.Pet {
 	return predicate.Pet(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.Pet {
-	return predicate.Pet(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.Pet {
-	return predicate.Pet(sql.FieldContainsFold(FieldName, v))
 }
 
 // AgeEQ applies the EQ predicate on the "age" field.

--- a/examples/migration/ent/session/where.go
+++ b/examples/migration/ent/session/where.go
@@ -225,9 +225,19 @@ func TokenLTE(v string) predicate.Session {
 	return predicate.Session(sql.FieldLTE(FieldToken, v))
 }
 
+// TokenEqualFold applies the EqualFold predicate on the "token" field.
+func TokenEqualFold(v string) predicate.Session {
+	return predicate.Session(sql.FieldEqualFold(FieldToken, v))
+}
+
 // TokenContains applies the Contains predicate on the "token" field.
 func TokenContains(v string) predicate.Session {
 	return predicate.Session(sql.FieldContains(FieldToken, v))
+}
+
+// TokenContainsFold applies the ContainsFold predicate on the "token" field.
+func TokenContainsFold(v string) predicate.Session {
+	return predicate.Session(sql.FieldContainsFold(FieldToken, v))
 }
 
 // TokenHasPrefix applies the HasPrefix predicate on the "token" field.
@@ -248,16 +258,6 @@ func TokenIsNil() predicate.Session {
 // TokenNotNil applies the NotNil predicate on the "token" field.
 func TokenNotNil() predicate.Session {
 	return predicate.Session(sql.FieldNotNull(FieldToken))
-}
-
-// TokenEqualFold applies the EqualFold predicate on the "token" field.
-func TokenEqualFold(v string) predicate.Session {
-	return predicate.Session(sql.FieldEqualFold(FieldToken, v))
-}
-
-// TokenContainsFold applies the ContainsFold predicate on the "token" field.
-func TokenContainsFold(v string) predicate.Session {
-	return predicate.Session(sql.FieldContainsFold(FieldToken, v))
 }
 
 // MethodIsNil applies the IsNil predicate on the "method" field.

--- a/examples/migration/ent/sessiondevice/where.go
+++ b/examples/migration/ent/sessiondevice/where.go
@@ -125,9 +125,19 @@ func IPAddressLTE(v string) predicate.SessionDevice {
 	return predicate.SessionDevice(sql.FieldLTE(FieldIPAddress, v))
 }
 
+// IPAddressEqualFold applies the EqualFold predicate on the "ip_address" field.
+func IPAddressEqualFold(v string) predicate.SessionDevice {
+	return predicate.SessionDevice(sql.FieldEqualFold(FieldIPAddress, v))
+}
+
 // IPAddressContains applies the Contains predicate on the "ip_address" field.
 func IPAddressContains(v string) predicate.SessionDevice {
 	return predicate.SessionDevice(sql.FieldContains(FieldIPAddress, v))
+}
+
+// IPAddressContainsFold applies the ContainsFold predicate on the "ip_address" field.
+func IPAddressContainsFold(v string) predicate.SessionDevice {
+	return predicate.SessionDevice(sql.FieldContainsFold(FieldIPAddress, v))
 }
 
 // IPAddressHasPrefix applies the HasPrefix predicate on the "ip_address" field.
@@ -138,16 +148,6 @@ func IPAddressHasPrefix(v string) predicate.SessionDevice {
 // IPAddressHasSuffix applies the HasSuffix predicate on the "ip_address" field.
 func IPAddressHasSuffix(v string) predicate.SessionDevice {
 	return predicate.SessionDevice(sql.FieldHasSuffix(FieldIPAddress, v))
-}
-
-// IPAddressEqualFold applies the EqualFold predicate on the "ip_address" field.
-func IPAddressEqualFold(v string) predicate.SessionDevice {
-	return predicate.SessionDevice(sql.FieldEqualFold(FieldIPAddress, v))
-}
-
-// IPAddressContainsFold applies the ContainsFold predicate on the "ip_address" field.
-func IPAddressContainsFold(v string) predicate.SessionDevice {
-	return predicate.SessionDevice(sql.FieldContainsFold(FieldIPAddress, v))
 }
 
 // UserAgentEQ applies the EQ predicate on the "user_agent" field.
@@ -190,9 +190,19 @@ func UserAgentLTE(v string) predicate.SessionDevice {
 	return predicate.SessionDevice(sql.FieldLTE(FieldUserAgent, v))
 }
 
+// UserAgentEqualFold applies the EqualFold predicate on the "user_agent" field.
+func UserAgentEqualFold(v string) predicate.SessionDevice {
+	return predicate.SessionDevice(sql.FieldEqualFold(FieldUserAgent, v))
+}
+
 // UserAgentContains applies the Contains predicate on the "user_agent" field.
 func UserAgentContains(v string) predicate.SessionDevice {
 	return predicate.SessionDevice(sql.FieldContains(FieldUserAgent, v))
+}
+
+// UserAgentContainsFold applies the ContainsFold predicate on the "user_agent" field.
+func UserAgentContainsFold(v string) predicate.SessionDevice {
+	return predicate.SessionDevice(sql.FieldContainsFold(FieldUserAgent, v))
 }
 
 // UserAgentHasPrefix applies the HasPrefix predicate on the "user_agent" field.
@@ -203,16 +213,6 @@ func UserAgentHasPrefix(v string) predicate.SessionDevice {
 // UserAgentHasSuffix applies the HasSuffix predicate on the "user_agent" field.
 func UserAgentHasSuffix(v string) predicate.SessionDevice {
 	return predicate.SessionDevice(sql.FieldHasSuffix(FieldUserAgent, v))
-}
-
-// UserAgentEqualFold applies the EqualFold predicate on the "user_agent" field.
-func UserAgentEqualFold(v string) predicate.SessionDevice {
-	return predicate.SessionDevice(sql.FieldEqualFold(FieldUserAgent, v))
-}
-
-// UserAgentContainsFold applies the ContainsFold predicate on the "user_agent" field.
-func UserAgentContainsFold(v string) predicate.SessionDevice {
-	return predicate.SessionDevice(sql.FieldContainsFold(FieldUserAgent, v))
 }
 
 // LocationEQ applies the EQ predicate on the "location" field.
@@ -255,9 +255,19 @@ func LocationLTE(v string) predicate.SessionDevice {
 	return predicate.SessionDevice(sql.FieldLTE(FieldLocation, v))
 }
 
+// LocationEqualFold applies the EqualFold predicate on the "location" field.
+func LocationEqualFold(v string) predicate.SessionDevice {
+	return predicate.SessionDevice(sql.FieldEqualFold(FieldLocation, v))
+}
+
 // LocationContains applies the Contains predicate on the "location" field.
 func LocationContains(v string) predicate.SessionDevice {
 	return predicate.SessionDevice(sql.FieldContains(FieldLocation, v))
+}
+
+// LocationContainsFold applies the ContainsFold predicate on the "location" field.
+func LocationContainsFold(v string) predicate.SessionDevice {
+	return predicate.SessionDevice(sql.FieldContainsFold(FieldLocation, v))
 }
 
 // LocationHasPrefix applies the HasPrefix predicate on the "location" field.
@@ -268,16 +278,6 @@ func LocationHasPrefix(v string) predicate.SessionDevice {
 // LocationHasSuffix applies the HasSuffix predicate on the "location" field.
 func LocationHasSuffix(v string) predicate.SessionDevice {
 	return predicate.SessionDevice(sql.FieldHasSuffix(FieldLocation, v))
-}
-
-// LocationEqualFold applies the EqualFold predicate on the "location" field.
-func LocationEqualFold(v string) predicate.SessionDevice {
-	return predicate.SessionDevice(sql.FieldEqualFold(FieldLocation, v))
-}
-
-// LocationContainsFold applies the ContainsFold predicate on the "location" field.
-func LocationContainsFold(v string) predicate.SessionDevice {
-	return predicate.SessionDevice(sql.FieldContainsFold(FieldLocation, v))
 }
 
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.

--- a/examples/migration/ent/user/where.go
+++ b/examples/migration/ent/user/where.go
@@ -152,9 +152,19 @@ func FirstNameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldFirstName, v))
 }
 
+// FirstNameEqualFold applies the EqualFold predicate on the "first_name" field.
+func FirstNameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldFirstName, v))
+}
+
 // FirstNameContains applies the Contains predicate on the "first_name" field.
 func FirstNameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldFirstName, v))
+}
+
+// FirstNameContainsFold applies the ContainsFold predicate on the "first_name" field.
+func FirstNameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldFirstName, v))
 }
 
 // FirstNameHasPrefix applies the HasPrefix predicate on the "first_name" field.
@@ -165,16 +175,6 @@ func FirstNameHasPrefix(v string) predicate.User {
 // FirstNameHasSuffix applies the HasSuffix predicate on the "first_name" field.
 func FirstNameHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldFirstName, v))
-}
-
-// FirstNameEqualFold applies the EqualFold predicate on the "first_name" field.
-func FirstNameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldFirstName, v))
-}
-
-// FirstNameContainsFold applies the ContainsFold predicate on the "first_name" field.
-func FirstNameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldFirstName, v))
 }
 
 // LastNameEQ applies the EQ predicate on the "last_name" field.
@@ -217,9 +217,19 @@ func LastNameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldLastName, v))
 }
 
+// LastNameEqualFold applies the EqualFold predicate on the "last_name" field.
+func LastNameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldLastName, v))
+}
+
 // LastNameContains applies the Contains predicate on the "last_name" field.
 func LastNameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldLastName, v))
+}
+
+// LastNameContainsFold applies the ContainsFold predicate on the "last_name" field.
+func LastNameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldLastName, v))
 }
 
 // LastNameHasPrefix applies the HasPrefix predicate on the "last_name" field.
@@ -230,16 +240,6 @@ func LastNameHasPrefix(v string) predicate.User {
 // LastNameHasSuffix applies the HasSuffix predicate on the "last_name" field.
 func LastNameHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldLastName, v))
-}
-
-// LastNameEqualFold applies the EqualFold predicate on the "last_name" field.
-func LastNameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldLastName, v))
-}
-
-// LastNameContainsFold applies the ContainsFold predicate on the "last_name" field.
-func LastNameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldLastName, v))
 }
 
 // TagsIsNil applies the IsNil predicate on the "tags" field.

--- a/examples/o2m2types/ent/pet/where.go
+++ b/examples/o2m2types/ent/pet/where.go
@@ -102,9 +102,19 @@ func NameLTE(v string) predicate.Pet {
 	return predicate.Pet(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.Pet {
+	return predicate.Pet(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.Pet {
 	return predicate.Pet(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.Pet {
+	return predicate.Pet(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -115,16 +125,6 @@ func NameHasPrefix(v string) predicate.Pet {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.Pet {
 	return predicate.Pet(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.Pet {
-	return predicate.Pet(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.Pet {
-	return predicate.Pet(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasOwner applies the HasEdge predicate on the "owner" edge.

--- a/examples/o2m2types/ent/user/where.go
+++ b/examples/o2m2types/ent/user/where.go
@@ -147,9 +147,19 @@ func NameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -160,16 +170,6 @@ func NameHasPrefix(v string) predicate.User {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasPets applies the HasEdge predicate on the "pets" edge.

--- a/examples/o2o2types/ent/card/where.go
+++ b/examples/o2o2types/ent/card/where.go
@@ -149,9 +149,19 @@ func NumberLTE(v string) predicate.Card {
 	return predicate.Card(sql.FieldLTE(FieldNumber, v))
 }
 
+// NumberEqualFold applies the EqualFold predicate on the "number" field.
+func NumberEqualFold(v string) predicate.Card {
+	return predicate.Card(sql.FieldEqualFold(FieldNumber, v))
+}
+
 // NumberContains applies the Contains predicate on the "number" field.
 func NumberContains(v string) predicate.Card {
 	return predicate.Card(sql.FieldContains(FieldNumber, v))
+}
+
+// NumberContainsFold applies the ContainsFold predicate on the "number" field.
+func NumberContainsFold(v string) predicate.Card {
+	return predicate.Card(sql.FieldContainsFold(FieldNumber, v))
 }
 
 // NumberHasPrefix applies the HasPrefix predicate on the "number" field.
@@ -162,16 +172,6 @@ func NumberHasPrefix(v string) predicate.Card {
 // NumberHasSuffix applies the HasSuffix predicate on the "number" field.
 func NumberHasSuffix(v string) predicate.Card {
 	return predicate.Card(sql.FieldHasSuffix(FieldNumber, v))
-}
-
-// NumberEqualFold applies the EqualFold predicate on the "number" field.
-func NumberEqualFold(v string) predicate.Card {
-	return predicate.Card(sql.FieldEqualFold(FieldNumber, v))
-}
-
-// NumberContainsFold applies the ContainsFold predicate on the "number" field.
-func NumberContainsFold(v string) predicate.Card {
-	return predicate.Card(sql.FieldContainsFold(FieldNumber, v))
 }
 
 // HasOwner applies the HasEdge predicate on the "owner" edge.

--- a/examples/o2o2types/ent/user/where.go
+++ b/examples/o2o2types/ent/user/where.go
@@ -147,9 +147,19 @@ func NameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -160,16 +170,6 @@ func NameHasPrefix(v string) predicate.User {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasCard applies the HasEdge predicate on the "card" edge.

--- a/examples/o2obidi/ent/user/where.go
+++ b/examples/o2obidi/ent/user/where.go
@@ -147,9 +147,19 @@ func NameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -160,16 +170,6 @@ func NameHasPrefix(v string) predicate.User {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasSpouse applies the HasEdge predicate on the "spouse" edge.

--- a/examples/privacyadmin/ent/user/where.go
+++ b/examples/privacyadmin/ent/user/where.go
@@ -101,9 +101,19 @@ func NameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -114,16 +124,6 @@ func NameHasPrefix(v string) predicate.User {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // And groups predicates with the AND operator between them.

--- a/examples/privacytenant/ent/group/where.go
+++ b/examples/privacytenant/ent/group/where.go
@@ -127,9 +127,19 @@ func NameLTE(v string) predicate.Group {
 	return predicate.Group(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.Group {
+	return predicate.Group(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.Group {
 	return predicate.Group(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.Group {
+	return predicate.Group(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -140,16 +150,6 @@ func NameHasPrefix(v string) predicate.Group {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.Group {
 	return predicate.Group(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.Group {
-	return predicate.Group(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.Group {
-	return predicate.Group(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasTenant applies the HasEdge predicate on the "tenant" edge.

--- a/examples/privacytenant/ent/tenant/where.go
+++ b/examples/privacytenant/ent/tenant/where.go
@@ -101,9 +101,19 @@ func NameLTE(v string) predicate.Tenant {
 	return predicate.Tenant(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.Tenant {
+	return predicate.Tenant(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.Tenant {
 	return predicate.Tenant(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.Tenant {
+	return predicate.Tenant(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -114,16 +124,6 @@ func NameHasPrefix(v string) predicate.Tenant {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.Tenant {
 	return predicate.Tenant(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.Tenant {
-	return predicate.Tenant(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.Tenant {
-	return predicate.Tenant(sql.FieldContainsFold(FieldName, v))
 }
 
 // And groups predicates with the AND operator between them.

--- a/examples/privacytenant/ent/user/where.go
+++ b/examples/privacytenant/ent/user/where.go
@@ -127,9 +127,19 @@ func NameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -140,16 +150,6 @@ func NameHasPrefix(v string) predicate.User {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // FoodsIsNil applies the IsNil predicate on the "foods" field.

--- a/examples/start/ent/car/where.go
+++ b/examples/start/ent/car/where.go
@@ -109,9 +109,19 @@ func ModelLTE(v string) predicate.Car {
 	return predicate.Car(sql.FieldLTE(FieldModel, v))
 }
 
+// ModelEqualFold applies the EqualFold predicate on the "model" field.
+func ModelEqualFold(v string) predicate.Car {
+	return predicate.Car(sql.FieldEqualFold(FieldModel, v))
+}
+
 // ModelContains applies the Contains predicate on the "model" field.
 func ModelContains(v string) predicate.Car {
 	return predicate.Car(sql.FieldContains(FieldModel, v))
+}
+
+// ModelContainsFold applies the ContainsFold predicate on the "model" field.
+func ModelContainsFold(v string) predicate.Car {
+	return predicate.Car(sql.FieldContainsFold(FieldModel, v))
 }
 
 // ModelHasPrefix applies the HasPrefix predicate on the "model" field.
@@ -122,16 +132,6 @@ func ModelHasPrefix(v string) predicate.Car {
 // ModelHasSuffix applies the HasSuffix predicate on the "model" field.
 func ModelHasSuffix(v string) predicate.Car {
 	return predicate.Car(sql.FieldHasSuffix(FieldModel, v))
-}
-
-// ModelEqualFold applies the EqualFold predicate on the "model" field.
-func ModelEqualFold(v string) predicate.Car {
-	return predicate.Car(sql.FieldEqualFold(FieldModel, v))
-}
-
-// ModelContainsFold applies the ContainsFold predicate on the "model" field.
-func ModelContainsFold(v string) predicate.Car {
-	return predicate.Car(sql.FieldContainsFold(FieldModel, v))
 }
 
 // RegisteredAtEQ applies the EQ predicate on the "registered_at" field.

--- a/examples/start/ent/group/where.go
+++ b/examples/start/ent/group/where.go
@@ -102,9 +102,19 @@ func NameLTE(v string) predicate.Group {
 	return predicate.Group(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.Group {
+	return predicate.Group(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.Group {
 	return predicate.Group(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.Group {
+	return predicate.Group(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -115,16 +125,6 @@ func NameHasPrefix(v string) predicate.Group {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.Group {
 	return predicate.Group(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.Group {
-	return predicate.Group(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.Group {
-	return predicate.Group(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasUsers applies the HasEdge predicate on the "users" edge.

--- a/examples/start/ent/user/where.go
+++ b/examples/start/ent/user/where.go
@@ -147,9 +147,19 @@ func NameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -160,16 +170,6 @@ func NameHasPrefix(v string) predicate.User {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasCars applies the HasEdge predicate on the "cars" edge.

--- a/examples/traversal/ent/group/where.go
+++ b/examples/traversal/ent/group/where.go
@@ -102,9 +102,19 @@ func NameLTE(v string) predicate.Group {
 	return predicate.Group(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.Group {
+	return predicate.Group(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.Group {
 	return predicate.Group(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.Group {
+	return predicate.Group(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -115,16 +125,6 @@ func NameHasPrefix(v string) predicate.Group {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.Group {
 	return predicate.Group(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.Group {
-	return predicate.Group(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.Group {
-	return predicate.Group(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasUsers applies the HasEdge predicate on the "users" edge.

--- a/examples/traversal/ent/pet/where.go
+++ b/examples/traversal/ent/pet/where.go
@@ -102,9 +102,19 @@ func NameLTE(v string) predicate.Pet {
 	return predicate.Pet(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.Pet {
+	return predicate.Pet(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.Pet {
 	return predicate.Pet(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.Pet {
+	return predicate.Pet(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -115,16 +125,6 @@ func NameHasPrefix(v string) predicate.Pet {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.Pet {
 	return predicate.Pet(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.Pet {
-	return predicate.Pet(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.Pet {
-	return predicate.Pet(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasFriends applies the HasEdge predicate on the "friends" edge.

--- a/examples/traversal/ent/user/where.go
+++ b/examples/traversal/ent/user/where.go
@@ -147,9 +147,19 @@ func NameLTE(v string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldName, v))
 }
 
+// NameEqualFold applies the EqualFold predicate on the "name" field.
+func NameEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldName, v))
+}
+
 // NameContains applies the Contains predicate on the "name" field.
 func NameContains(v string) predicate.User {
 	return predicate.User(sql.FieldContains(FieldName, v))
+}
+
+// NameContainsFold applies the ContainsFold predicate on the "name" field.
+func NameContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // NameHasPrefix applies the HasPrefix predicate on the "name" field.
@@ -160,16 +170,6 @@ func NameHasPrefix(v string) predicate.User {
 // NameHasSuffix applies the HasSuffix predicate on the "name" field.
 func NameHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldName, v))
-}
-
-// NameEqualFold applies the EqualFold predicate on the "name" field.
-func NameEqualFold(v string) predicate.User {
-	return predicate.User(sql.FieldEqualFold(FieldName, v))
-}
-
-// NameContainsFold applies the ContainsFold predicate on the "name" field.
-func NameContainsFold(v string) predicate.User {
-	return predicate.User(sql.FieldContainsFold(FieldName, v))
 }
 
 // HasPets applies the HasEdge predicate on the "pets" edge.


### PR DESCRIPTION
Adds `EqualFold` and `ContainsFold` for string types that look to be currently missing from `stringOps` which is used by template function `ops` for returning related operations for a given field (type).

Also, now deduplicate any operations which may be appended based on `Field.cfg.Storage.Ops(Field)`.