### PR TITLE
Add error handling for nil builders when calling Exec for Upsert

### DIFF
--- a/entc/gen/template/dialect/sql/feature/upsert.tmpl
+++ b/entc/gen/template/dialect/sql/feature/upsert.tmpl
@@ -389,6 +389,9 @@ func (u *{{ $upsertBulk }}) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+	    if b == nil {
+            return fmt.Errorf("{{ $pkg }}: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+	    }
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("{{ $pkg }}: OnConflict was set for builder %d. Set it on the {{ $builder }} instead", i)
 		}

--- a/entc/integration/customid/ent/account_create.go
+++ b/entc/integration/customid/ent/account_create.go
@@ -531,6 +531,9 @@ func (u *AccountUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the AccountCreateBulk instead", i)
 		}

--- a/entc/integration/customid/ent/blob_create.go
+++ b/entc/integration/customid/ent/blob_create.go
@@ -662,6 +662,9 @@ func (u *BlobUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the BlobCreateBulk instead", i)
 		}

--- a/entc/integration/customid/ent/bloblink_create.go
+++ b/entc/integration/customid/ent/bloblink_create.go
@@ -582,6 +582,9 @@ func (u *BlobLinkUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the BlobLinkCreateBulk instead", i)
 		}

--- a/entc/integration/customid/ent/car_create.go
+++ b/entc/integration/customid/ent/car_create.go
@@ -718,6 +718,9 @@ func (u *CarUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the CarCreateBulk instead", i)
 		}

--- a/entc/integration/customid/ent/device_create.go
+++ b/entc/integration/customid/ent/device_create.go
@@ -503,6 +503,9 @@ func (u *DeviceUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the DeviceCreateBulk instead", i)
 		}

--- a/entc/integration/customid/ent/doc_create.go
+++ b/entc/integration/customid/ent/doc_create.go
@@ -622,6 +622,9 @@ func (u *DocUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the DocCreateBulk instead", i)
 		}

--- a/entc/integration/customid/ent/group_create.go
+++ b/entc/integration/customid/ent/group_create.go
@@ -438,6 +438,9 @@ func (u *GroupUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the GroupCreateBulk instead", i)
 		}

--- a/entc/integration/customid/ent/intsid_create.go
+++ b/entc/integration/customid/ent/intsid_create.go
@@ -478,6 +478,9 @@ func (u *IntSIDUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the IntSIDCreateBulk instead", i)
 		}

--- a/entc/integration/customid/ent/link_create.go
+++ b/entc/integration/customid/ent/link_create.go
@@ -499,6 +499,9 @@ func (u *LinkUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the LinkCreateBulk instead", i)
 		}

--- a/entc/integration/customid/ent/mixinid_create.go
+++ b/entc/integration/customid/ent/mixinid_create.go
@@ -547,6 +547,9 @@ func (u *MixinIDUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the MixinIDCreateBulk instead", i)
 		}

--- a/entc/integration/customid/ent/note_create.go
+++ b/entc/integration/customid/ent/note_create.go
@@ -591,6 +591,9 @@ func (u *NoteUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the NoteCreateBulk instead", i)
 		}

--- a/entc/integration/customid/ent/other_create.go
+++ b/entc/integration/customid/ent/other_create.go
@@ -430,6 +430,9 @@ func (u *OtherUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the OtherCreateBulk instead", i)
 		}

--- a/entc/integration/customid/ent/pet_create.go
+++ b/entc/integration/customid/ent/pet_create.go
@@ -570,6 +570,9 @@ func (u *PetUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the PetCreateBulk instead", i)
 		}

--- a/entc/integration/customid/ent/revision_create.go
+++ b/entc/integration/customid/ent/revision_create.go
@@ -411,6 +411,9 @@ func (u *RevisionUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the RevisionCreateBulk instead", i)
 		}

--- a/entc/integration/customid/ent/session_create.go
+++ b/entc/integration/customid/ent/session_create.go
@@ -472,6 +472,9 @@ func (u *SessionUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the SessionCreateBulk instead", i)
 		}

--- a/entc/integration/customid/ent/token_create.go
+++ b/entc/integration/customid/ent/token_create.go
@@ -531,6 +531,9 @@ func (u *TokenUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the TokenCreateBulk instead", i)
 		}

--- a/entc/integration/customid/ent/user_create.go
+++ b/entc/integration/customid/ent/user_create.go
@@ -537,6 +537,9 @@ func (u *UserUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the UserCreateBulk instead", i)
 		}

--- a/entc/integration/edgeschema/ent/attachedfile_create.go
+++ b/entc/integration/edgeschema/ent/attachedfile_create.go
@@ -615,6 +615,9 @@ func (u *AttachedFileUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the AttachedFileCreateBulk instead", i)
 		}

--- a/entc/integration/edgeschema/ent/file_create.go
+++ b/entc/integration/edgeschema/ent/file_create.go
@@ -472,6 +472,9 @@ func (u *FileUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the FileCreateBulk instead", i)
 		}

--- a/entc/integration/edgeschema/ent/friendship_create.go
+++ b/entc/integration/edgeschema/ent/friendship_create.go
@@ -631,6 +631,9 @@ func (u *FriendshipUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the FriendshipCreateBulk instead", i)
 		}

--- a/entc/integration/edgeschema/ent/group_create.go
+++ b/entc/integration/edgeschema/ent/group_create.go
@@ -590,6 +590,9 @@ func (u *GroupUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the GroupCreateBulk instead", i)
 		}

--- a/entc/integration/edgeschema/ent/grouptag_create.go
+++ b/entc/integration/edgeschema/ent/grouptag_create.go
@@ -537,6 +537,9 @@ func (u *GroupTagUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the GroupTagCreateBulk instead", i)
 		}

--- a/entc/integration/edgeschema/ent/process_create.go
+++ b/entc/integration/edgeschema/ent/process_create.go
@@ -444,6 +444,9 @@ func (u *ProcessUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the ProcessCreateBulk instead", i)
 		}

--- a/entc/integration/edgeschema/ent/relationship_create.go
+++ b/entc/integration/edgeschema/ent/relationship_create.go
@@ -700,6 +700,9 @@ func (u *RelationshipUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the RelationshipCreateBulk instead", i)
 		}

--- a/entc/integration/edgeschema/ent/relationshipinfo_create.go
+++ b/entc/integration/edgeschema/ent/relationshipinfo_create.go
@@ -440,6 +440,9 @@ func (u *RelationshipInfoUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the RelationshipInfoCreateBulk instead", i)
 		}

--- a/entc/integration/edgeschema/ent/role_create.go
+++ b/entc/integration/edgeschema/ent/role_create.go
@@ -548,6 +548,9 @@ func (u *RoleUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the RoleCreateBulk instead", i)
 		}

--- a/entc/integration/edgeschema/ent/roleuser_create.go
+++ b/entc/integration/edgeschema/ent/roleuser_create.go
@@ -582,6 +582,9 @@ func (u *RoleUserUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the RoleUserCreateBulk instead", i)
 		}

--- a/entc/integration/edgeschema/ent/tag_create.go
+++ b/entc/integration/edgeschema/ent/tag_create.go
@@ -576,6 +576,9 @@ func (u *TagUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the TagCreateBulk instead", i)
 		}

--- a/entc/integration/edgeschema/ent/tweet_create.go
+++ b/entc/integration/edgeschema/ent/tweet_create.go
@@ -615,6 +615,9 @@ func (u *TweetUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the TweetCreateBulk instead", i)
 		}

--- a/entc/integration/edgeschema/ent/tweetlike_create.go
+++ b/entc/integration/edgeschema/ent/tweetlike_create.go
@@ -588,6 +588,9 @@ func (u *TweetLikeUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the TweetLikeCreateBulk instead", i)
 		}

--- a/entc/integration/edgeschema/ent/tweettag_create.go
+++ b/entc/integration/edgeschema/ent/tweettag_create.go
@@ -657,6 +657,9 @@ func (u *TweetTagUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the TweetTagCreateBulk instead", i)
 		}

--- a/entc/integration/edgeschema/ent/user_create.go
+++ b/entc/integration/edgeschema/ent/user_create.go
@@ -770,6 +770,9 @@ func (u *UserUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the UserCreateBulk instead", i)
 		}

--- a/entc/integration/edgeschema/ent/usergroup_create.go
+++ b/entc/integration/edgeschema/ent/usergroup_create.go
@@ -609,6 +609,9 @@ func (u *UserGroupUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the UserGroupCreateBulk instead", i)
 		}

--- a/entc/integration/edgeschema/ent/usertweet_create.go
+++ b/entc/integration/edgeschema/ent/usertweet_create.go
@@ -609,6 +609,9 @@ func (u *UserTweetUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the UserTweetCreateBulk instead", i)
 		}

--- a/entc/integration/ent/api_create.go
+++ b/entc/integration/ent/api_create.go
@@ -376,6 +376,9 @@ func (u *ApiUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the APICreateBulk instead", i)
 		}

--- a/entc/integration/ent/builder_create.go
+++ b/entc/integration/ent/builder_create.go
@@ -376,6 +376,9 @@ func (u *BuilderUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the BuilderCreateBulk instead", i)
 		}

--- a/entc/integration/ent/card_create.go
+++ b/entc/integration/ent/card_create.go
@@ -757,6 +757,9 @@ func (u *CardUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the CardCreateBulk instead", i)
 		}

--- a/entc/integration/ent/comment_create.go
+++ b/entc/integration/ent/comment_create.go
@@ -866,6 +866,9 @@ func (u *CommentUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the CommentCreateBulk instead", i)
 		}

--- a/entc/integration/ent/exvaluescan_create.go
+++ b/entc/integration/ent/exvaluescan_create.go
@@ -853,6 +853,9 @@ func (u *ExValueScanUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the ExValueScanCreateBulk instead", i)
 		}

--- a/entc/integration/ent/fieldtype_create.go
+++ b/entc/integration/ent/fieldtype_create.go
@@ -5856,6 +5856,9 @@ func (u *FieldTypeUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the FieldTypeCreateBulk instead", i)
 		}

--- a/entc/integration/ent/file_create.go
+++ b/entc/integration/ent/file_create.go
@@ -974,6 +974,9 @@ func (u *FileUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the FileCreateBulk instead", i)
 		}

--- a/entc/integration/ent/filetype_create.go
+++ b/entc/integration/ent/filetype_create.go
@@ -618,6 +618,9 @@ func (u *FileTypeUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the FileTypeCreateBulk instead", i)
 		}

--- a/entc/integration/ent/goods_create.go
+++ b/entc/integration/ent/goods_create.go
@@ -376,6 +376,9 @@ func (u *GoodsUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the GoodsCreateBulk instead", i)
 		}

--- a/entc/integration/ent/group_create.go
+++ b/entc/integration/ent/group_create.go
@@ -887,6 +887,9 @@ func (u *GroupUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the GroupCreateBulk instead", i)
 		}

--- a/entc/integration/ent/groupinfo_create.go
+++ b/entc/integration/ent/groupinfo_create.go
@@ -563,6 +563,9 @@ func (u *GroupInfoUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the GroupInfoCreateBulk instead", i)
 		}

--- a/entc/integration/ent/item_create.go
+++ b/entc/integration/ent/item_create.go
@@ -528,6 +528,9 @@ func (u *ItemUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the ItemCreateBulk instead", i)
 		}

--- a/entc/integration/ent/license_create.go
+++ b/entc/integration/ent/license_create.go
@@ -520,6 +520,9 @@ func (u *LicenseUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the LicenseCreateBulk instead", i)
 		}

--- a/entc/integration/ent/node_create.go
+++ b/entc/integration/ent/node_create.go
@@ -635,6 +635,9 @@ func (u *NodeUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the NodeCreateBulk instead", i)
 		}

--- a/entc/integration/ent/pc_create.go
+++ b/entc/integration/ent/pc_create.go
@@ -376,6 +376,9 @@ func (u *PCUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the PCCreateBulk instead", i)
 		}

--- a/entc/integration/ent/pet_create.go
+++ b/entc/integration/ent/pet_create.go
@@ -826,6 +826,9 @@ func (u *PetUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the PetCreateBulk instead", i)
 		}

--- a/entc/integration/ent/spec_create.go
+++ b/entc/integration/ent/spec_create.go
@@ -408,6 +408,9 @@ func (u *SpecUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the SpecCreateBulk instead", i)
 		}

--- a/entc/integration/ent/task_create.go
+++ b/entc/integration/ent/task_create.go
@@ -1014,6 +1014,9 @@ func (u *TaskUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the TaskCreateBulk instead", i)
 		}

--- a/entc/integration/ent/user_create.go
+++ b/entc/integration/ent/user_create.go
@@ -1682,6 +1682,9 @@ func (u *UserUpsertBulk) Exec(ctx context.Context) error {
 		return u.create.err
 	}
 	for i, b := range u.create.builders {
+		if b == nil {
+			return fmt.Errorf("ent: missing builder at index %d, unexpected nil builder passed to CreateBulk", i)
+		}
 		if len(b.conflict) != 0 {
 			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the UserCreateBulk instead", i)
 		}

--- a/entc/integration/integration_test.go
+++ b/entc/integration/integration_test.go
@@ -382,6 +382,16 @@ func Upsert(t *testing.T, client *ent.Client) {
 	require.Equal(t, "1111", users[1].Phone)
 	require.Equal(t, "B", users[1].Name)
 
+	// Return error from Exec when nil passed to CreateBulk
+	builders2 := []*ent.UserCreate{
+		nil,
+	}
+	err = client.User.CreateBulk(builders2...).
+		OnConflictColumns(user.FieldPhone).
+		UpdateNewValues().
+		Exec(ctx)
+	require.Error(t, err)
+
 	// Setting primary key manually.
 	a := client.Item.Create().SetID("A").SaveX(ctx)
 	require.Equal(t, "A", a.ID)


### PR DESCRIPTION
A small contribution to add a check to the Exec call as part of the Upsert functionality.

Occasionally I would see cases where developers mistakenly construct a slice of builders usually by instantiating a slice with a set length and then not setting a builder for each index resulting in nils being passed to the CreateBulk method.

This would then result in a panic from the Exec call when it tries to call len on the b.conflict property.

This change checks if b is nil and returns an error to hopefully help people more easily debug this type of issue.