### PR TITLE
doc/website: Add Example for field.Text Usage

### DIFF
--- a/doc/md/schema-fields.mdx
+++ b/doc/md/schema-fields.mdx
@@ -87,6 +87,9 @@ func (User) Fields() []ent.Field {
 			Default(false),
 		field.String("name").
 			Unique(),
+		// string field without limitation on the size
+		field.Text("note").
+			Default(""),
 		field.Time("created_at").
 			Default(time.Now),
 		field.JSON("url", &url.URL{}).


### PR DESCRIPTION
I noticed that the field page does not include an example for field.Text. To address this, I have added a sample usage.

Additionally, I have attempted to describe the differences between field.Text and field.String. However, if there is a better way to differentiate them, please feel free to suggest or update accordingly.

Thank you.