### PR TITLE
Prepend fix for #4159

### DIFF
--- a/dialect/sql/builder.go
+++ b/dialect/sql/builder.go
@@ -2254,6 +2254,16 @@ func (s *Selector) SelectDistinct(columns ...string) *Selector {
 	return s.Select(columns...).Distinct()
 }
 
+// SelectExpr changes the columns selection of the SELECT statement
+// with custom list of expressions.
+func (s *Selector) SelectExpr(exprs ...Querier) *Selector {
+	s.selection = make([]selection, len(exprs))
+	for i := range exprs {
+		s.selection[i] = selection{x: exprs[i]}
+	}
+	return s
+}
+
 // AppendSelect appends additional columns to the SELECT statement.
 func (s *Selector) AppendSelect(columns ...string) *Selector {
 	for i := range columns {
@@ -2265,16 +2275,6 @@ func (s *Selector) AppendSelect(columns ...string) *Selector {
 // AppendSelectAs appends additional column to the SELECT statement with the given alias.
 func (s *Selector) AppendSelectAs(column, as string) *Selector {
 	s.selection = append(s.selection, selection{c: column, as: as})
-	return s
-}
-
-// SelectExpr changes the columns selection of the SELECT statement
-// with custom list of expressions.
-func (s *Selector) SelectExpr(exprs ...Querier) *Selector {
-	s.selection = make([]selection, len(exprs))
-	for i := range exprs {
-		s.selection[i] = selection{x: exprs[i]}
-	}
 	return s
 }
 
@@ -2298,6 +2298,40 @@ func (s *Selector) AppendSelectExprAs(expr Querier, as string) *Selector {
 		x:  x,
 		as: as,
 	})
+	return s
+}
+
+// PrependSelect prepends additional columns to the SELECT statement.
+func (s *Selector) PrependSelect(columns ...string) *Selector {
+	for i := range columns {
+		s.selection = append([]selection{{c: columns[i]}}, s.selection...)
+	}
+	return s
+}
+
+// PrependSelectAs prepends an additional column to the SELECT statement with the given alias.
+func (s *Selector) PrependSelectAs(column, as string) *Selector {
+	s.selection = append([]selection{{c: column, as: as}}, s.selection...)
+	return s
+}
+
+// PrependSelectExpr prepends additional expressions to the SELECT statement.
+func (s *Selector) PrependSelectExpr(exprs ...Querier) *Selector {
+	for i := range exprs {
+		s.selection = append([]selection{{x: exprs[i]}}, s.selection...)
+	}
+	return s
+}
+
+// PrependSelectExprAs prepends additional expressions to the SELECT statement with the given name.
+func (s *Selector) PrependSelectExprAs(expr Querier, as string) *Selector {
+	x := expr
+	if _, ok := expr.(*raw); !ok {
+		x = ExprFunc(func(b *Builder) {
+			b.S("(").Join(expr).S(")")
+		})
+	}
+	s.selection = append([]selection{{x: x, as: as}}, s.selection...)
 	return s
 }
 

--- a/entc/gen/template/dialect/sql/query.tmpl
+++ b/entc/gen/template/dialect/sql/query.tmpl
@@ -135,9 +135,7 @@ func ({{ $receiver }} *{{ $builder }}) sqlAll(ctx context.Context, hooks ...quer
 				{{- $fk1idx := 1 }}{{- $fk2idx := 0 }}{{ if $e.IsInverse }}{{ $fk1idx = 0 }}{{ $fk2idx = 1 }}{{ end }}
 				s.Join(joinT).On(s.C({{ $edgeid }}), joinT.C({{ $.Package }}.{{ $e.PKConstant }}[{{ $fk1idx }}]))
 				s.Where(sql.InValues(joinT.C({{ $.Package }}.{{ $e.PKConstant }}[{{ $fk2idx }}]), edgeIDs...))
-				columns := s.SelectedColumns()
-				s.Select(joinT.C({{ $.Package }}.{{ $e.PKConstant }}[{{ $fk2idx }}]))
-				s.AppendSelect(columns...)
+				s.PrependSelect(joinT.C({{ $.Package }}.{{ $e.PKConstant }}[{{ $fk2idx }}]))
 				s.SetDistinct(false)
 			})
 			if err := query.prepareQuery(ctx); err != nil {


### PR DESCRIPTION
This PR fixes an issue with the M2M load function where additional select expressions added in the `With{Node}` query functions were being lost. The problem occurred because the selected columns were copied, the join column was selected, and then the selected columns were added back—but the expressions aren't included in `SelectedColumns`

By switching to prepending instead of appending + copying, we keep the expressions, so everything works as expected. This change has been tested in several production projects, and all tests are passing.

I have also added comments to explain the new prepend functions.

Thanks for taking a look!