### PR TITLE
M2M Bulk through add insertion bug for #4130

### DIFF
--- a/entc/gen/template/dialect/sql/create.tmpl
+++ b/entc/gen/template/dialect/sql/create.tmpl
@@ -97,7 +97,10 @@ func ({{ $receiver }} *{{ $builder }}) createSpec() (*{{ $.Name }}, *sqlgraph.Cr
 	{{- end }}
 	{{- range $e := $.EdgesWithID }}
 		if nodes := {{ $mutation }}.{{ $e.StructField }}IDs(); len(nodes) > 0 {
-			{{- with extend $ "Edge" $e "Nodes" true "Zero" "nil" }}
+			{{- /* Recompute defaults for every through edge */}}
+		  {{- if $e.Through }}for _, node := range nodes { {{end}}
+		  {{- $hasThrough := ne $e.Through nil}}
+			{{- with extend $ "Edge" $e "Nodes" (not $hasThrough) "Zero" "nil" "Through" ($hasThrough)}}
 				{{ template "dialect/sql/defedge" . }}{{/* defined in sql/update.tmpl */}}
 			{{- end }}
 			{{- if $e.OwnFK }}
@@ -105,6 +108,7 @@ func ({{ $receiver }} *{{ $builder }}) createSpec() (*{{ $.Name }}, *sqlgraph.Cr
 				_node.{{ $fk.StructField }} = {{ if $fk.Field.NillableValue }}&{{ end }}nodes[0]
 			{{- end }}
 			_spec.Edges = append(_spec.Edges, edge)
+		  {{- if $e.Through }}}{{end}}
 		}
 	{{- end }}
 	return _node, _spec{{ if $.HasValueScanner }}, nil{{ end }}

--- a/entc/gen/template/dialect/sql/update.tmpl
+++ b/entc/gen/template/dialect/sql/update.tmpl
@@ -150,10 +150,14 @@ func ({{ $receiver }} *{{ $builder }}) sqlSave(ctx context.Context) ({{ $ret }} 
 			}
 		{{- end }}
 		if nodes := {{ $mutation }}.{{ $e.StructField }}IDs(); len(nodes) > 0 {
-			{{- with extend $ "Edge" $e "Nodes" true "Zero" $zero }}
+	    {{- /* Recompute defaults for every through edge */}}
+		  {{- if $e.Through }}for _, node := range nodes { {{end}}
+		  {{- $hasThrough := ne $e.Through nil}}
+			{{- with extend $ "Edge" $e "Nodes" (not $hasThrough) "Zero" $zero "Through" ($hasThrough) }}
 				{{ template "dialect/sql/defedge" . }}
 			{{- end }}
 			_spec.Edges.Add = append(_spec.Edges.Add, edge)
+		  {{- if $e.Through }}}{{end}}
 		}
 	{{- end }}
 	{{- /* Allow mutating the sqlgraph.UpdateSpec by ent extensions or user templates.*/}}
@@ -207,6 +211,9 @@ func ({{ $receiver }} *{{ $builder }}) sqlSave(ctx context.Context) ({{ $ret }} 
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
+	{{- end }}
+	{{- with $.Scope.Through }}
+		edge.Target.Nodes = append(edge.Target.Nodes, node)
 	{{- end }}
 	{{- with $e.Through }}
 		{{- if .HasDefault }}


### PR DESCRIPTION
This PR fixes issue #4130, which involved adding multiple M2M rows to a table using `Through` tables. Previously, the same default values were reused for every row, which was fine for fields like `created_at` with a default date. However, this caused issues when using a DefaultID generator, leading to potential duplicate primary key errors.

With this update, the affected `Through` edges are modified to ensure the "default" builder is called for each new row, preventing these errors.

This change has been tested in several production projects, and all tests are passing.

Thanks for taking a look! 