### PR TITLE
feat(go.mod): use major version instead of minor version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module entgo.io/ent
 
-go 1.23.0
+go 1.23
 
 require (
 	ariga.io/atlas v0.19.1-0.20240203083654-5948b60a8e43


### PR DESCRIPTION
Avoid environment and toolchain conflicts.