### PR TITLE
doc: add warning for Unwrap

### DIFF
--- a/doc/md/transactions.md
+++ b/doc/md/transactions.md
@@ -62,6 +62,11 @@ You must call `Unwrap()` if you are querying edges off of a created entity after
 
 The full example exists in [GitHub](https://github.com/ent/ent/tree/master/examples/traversal).
 
+:::warning Note
+Calling `Unwrap()` on a non-transactional entity (i.e., after a transaction has been committed or rolled back) will
+cause a panic.
+:::
+
 ## Transactional Client
 
 Sometimes, you have an existing code that already works with `*ent.Client`, and you want to change it (or wrap it)

--- a/doc/md/transactions.md
+++ b/doc/md/transactions.md
@@ -60,12 +60,12 @@ func rollback(tx *ent.Tx, err error) error {
 
 You must call `Unwrap()` if you are querying edges off of a created entity after a successful transaction (example: `a8m.QueryGroups()`). Unwrap restores the state of the underlying client embedded within the entity to a non-transactable version. 
 
-The full example exists in [GitHub](https://github.com/ent/ent/tree/master/examples/traversal).
-
 :::warning Note
 Calling `Unwrap()` on a non-transactional entity (i.e., after a transaction has been committed or rolled back) will
 cause a panic.
 :::
+
+The full example exists in [GitHub](https://github.com/ent/ent/tree/master/examples/traversal).
 
 ## Transactional Client
 

--- a/entc/gen/template/ent.tmpl
+++ b/entc/gen/template/ent.tmpl
@@ -111,7 +111,6 @@ func ({{ $receiver }} *{{ $.Name }}) Update() *{{ $.UpdateOneName }} {
 
 // Unwrap unwraps the {{ $.Name }} entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
-// Unwrap will panic if {{ $.Name }} is not a transactional entity.
 func ({{ $receiver }} *{{ $.Name }}) Unwrap() *{{ $.Name }} {
 	_tx, ok := {{ $receiver }}.config.driver.(*txDriver)
 	if !ok {

--- a/entc/gen/template/ent.tmpl
+++ b/entc/gen/template/ent.tmpl
@@ -111,6 +111,7 @@ func ({{ $receiver }} *{{ $.Name }}) Update() *{{ $.UpdateOneName }} {
 
 // Unwrap unwraps the {{ $.Name }} entity that was returned from a transaction after it was closed,
 // so that all future queries will be executed through the driver which created the transaction.
+// Unwrap will panic if {{ $.Name }} is not a transactional entity.
 func ({{ $receiver }} *{{ $.Name }}) Unwrap() *{{ $.Name }} {
 	_tx, ok := {{ $receiver }}.config.driver.(*txDriver)
 	if !ok {


### PR DESCRIPTION
Adds documentation to both generated code and the website noting that calling `someEntity.Unwrap()` on a non-transactional entity will cause a panic.

I wasn't 100% sure if the generated code needed to be included in this PR, but I left it out for now since it's easier to read. 

Please let me know if there's anything I'm missing here. Thank you!