### PR TITLE
bugfix: fixed broken client.go generation when last node is a view

### DIFF
--- a/entc/gen/template/client.tmpl
+++ b/entc/gen/template/client.tmpl
@@ -481,15 +481,23 @@ func (c *{{ $client }}) mutate(ctx context.Context, m *{{ $n.MutationName }}) (V
 // hooks and interceptors per client, for fast access.
 type (
 	{{- $leni := len $.Nodes | add -1 }}
-	{{- $hooks := slist }}
+	{{- $hookNodes := list }}
 	{{- $inters := slist }}
 	{{- range $i, $n := $.Nodes }}
+		{{ if not $n.IsView }}{{- $hookNodes = append $hookNodes $n }}{{ end }}
 		{{- if eq $i $leni }}
-			{{ if not $n.IsView }}{{- $hooks = append $hooks (printf "%s []ent.Hook" $n.Name) }}{{ end }}
 			{{- $inters = append $inters (printf "%s []ent.Interceptor" $n.Name) }}
 		{{- else }}
-			{{ if not $n.IsView }}{{- $hooks = append $hooks (print $n.Name ",") }}{{ end }}
 			{{- $inters = append $inters (print $n.Name ",") }}
+		{{- end }}
+	{{- end }}
+	{{- $leni = len $hookNodes | add -1 }}
+	{{- $hooks := slist }}
+	{{- range $i, $n := $hookNodes }}
+		{{- if eq $i $leni }}
+			{{- $hooks = append $hooks (printf "%s []ent.Hook" $n.Name) }}
+		{{- else }}
+			{{- $hooks = append $hooks (printf "%s," $n.Name) }}
 		{{- end }}
 	{{- end }}
 	hooks struct {


### PR DESCRIPTION
First of all: thanks for all the work put into this great project.

I ran into a bug with the new «Views» feature. The generation of the `client.go` breaks if the last node in the nodes list at https://github.com/ent/ent/blob/master/entc/gen/template/client.tmpl#L483 is a view and not a table. Then the following code gets generated:

```
// hooks and interceptors per client, for fast access.
type (
	hooks struct {
		Table1, Table2,
	}
	inters struct {
		Table1, Table2, View1 []ent.Interceptor
	}
)
```

To fix this I added a second list that only contains the tables and introduced another loop to compile the $hooks slice.

The generated code then looks like this:

```
// hooks and interceptors per client, for fast access.
type (
	hooks struct {
		Table1, Table2 []ent.Hook
	}
	inters struct {
		Table1, Table2, View1 []ent.Interceptor
	}
)
```

I ran all the integration tests and they passed.

Please let me know if I should change or improve something.

Have a nice day!