### PR TITLE
HasPrefixFold and HasSuffixFold

### DIFF
--- a/dialect/sql/builder.go
+++ b/dialect/sql/builder.go
@@ -1781,6 +1781,14 @@ func (p *Predicate) HasSuffix(col, suffix string) *Predicate {
 	return p.escapedLike(col, "%", "", suffix)
 }
 
+// HasSuffixFold is a helper predicate that checks suffix using the ILIKE predicate.
+func HasSuffixFold(col, suffix string) *Predicate { return P().HasSuffixFold(col, suffix) }
+
+// HasSuffixFold is a helper predicate that checks suffix using the ILIKE predicate.
+func (p *Predicate) HasSuffixFold(col, suffix string) *Predicate {
+	return p.escapedILike(col, "%", "", suffix)
+}
+
 // EqualFold is a helper predicate that applies the "=" predicate with case-folding.
 func EqualFold(col, sub string) *Predicate { return P().EqualFold(col, sub) }
 

--- a/dialect/sql/builder_test.go
+++ b/dialect/sql/builder_test.go
@@ -568,6 +568,45 @@ func TestBuilder(t *testing.T) {
 			wantArgs:  []any{1, "a8m%"},
 		},
 		{
+			input: Dialect(dialect.Postgres).
+				Update("users").
+				Set("name", "foo").
+				Where(And(HasSuffixFold("nickname", "a8m"), Contains("lastname", "mash"))),
+			wantQuery: `UPDATE "users" SET "name" = $1 WHERE "nickname" ILIKE $2 AND "lastname" LIKE $3`,
+			wantArgs:  []any{"foo", "%a8m", "%mash%"},
+		},
+		{
+			input: Update("users").
+				Add("age", 1).
+				Where(HasSuffixFold("nickname", "a8m")),
+			wantQuery: "UPDATE `users` SET `age` = COALESCE(`users`.`age`, 0) + ? WHERE `nickname` ILIKE ?",
+			wantArgs:  []any{1, "%a8m"},
+		},
+		{
+			input: Update("users").
+				Set("age", 1).
+				Add("age", 2).
+				Where(HasSuffixFold("nickname", "a8m")),
+			wantQuery: "UPDATE `users` SET `age` = ?, `age` = COALESCE(`users`.`age`, 0) + ? WHERE `nickname` ILIKE ?",
+			wantArgs:  []any{1, 2, "%a8m"},
+		},
+		{
+			input: Update("users").
+				Add("age", 2).
+				Set("age", 1).
+				Where(HasSuffixFold("nickname", "a8m")),
+			wantQuery: "UPDATE `users` SET `age` = ? WHERE `nickname` ILIKE ?",
+			wantArgs:  []any{1, "%a8m"},
+		},
+		{
+			input: Dialect(dialect.Postgres).
+				Update("users").
+				Add("age", 1).
+				Where(HasSuffixFold("nickname", "a8m")),
+			wantQuery: `UPDATE "users" SET "age" = COALESCE("users"."age", 0) + $1 WHERE "nickname" ILIKE $2`,
+			wantArgs:  []any{1, "%a8m"},
+		},
+		{
 			input: Update("users").
 				Add("age", 1).
 				Set("nickname", "a8m").

--- a/dialect/sql/builder_test.go
+++ b/dialect/sql/builder_test.go
@@ -525,7 +525,7 @@ func TestBuilder(t *testing.T) {
 			input: Update("users").
 				Set("name", "foo").
 				Where(And(HasPrefixFold("nickname", "a8m"), Contains("lastname", "mash"))),
-			wantQuery: "UPDATE `users` SET `name` = ? WHERE `nickname` ILIKE ? AND `lastname` LIKE ?",
+			wantQuery: "UPDATE `users` SET `name` = ? WHERE LOWER(`nickname`) LIKE ? AND `lastname` LIKE ?",
 			wantArgs:  []any{"foo", "a8m%", "%mash%"},
 		},
 		{
@@ -540,7 +540,7 @@ func TestBuilder(t *testing.T) {
 			input: Update("users").
 				Add("age", 1).
 				Where(HasPrefixFold("nickname", "a8m")),
-			wantQuery: "UPDATE `users` SET `age` = COALESCE(`users`.`age`, 0) + ? WHERE `nickname` ILIKE ?",
+			wantQuery: "UPDATE `users` SET `age` = COALESCE(`users`.`age`, 0) + ? WHERE LOWER(`nickname`) LIKE ?",
 			wantArgs:  []any{1, "a8m%"},
 		},
 		{
@@ -548,7 +548,7 @@ func TestBuilder(t *testing.T) {
 				Set("age", 1).
 				Add("age", 2).
 				Where(HasPrefixFold("nickname", "a8m")),
-			wantQuery: "UPDATE `users` SET `age` = ?, `age` = COALESCE(`users`.`age`, 0) + ? WHERE `nickname` ILIKE ?",
+			wantQuery: "UPDATE `users` SET `age` = ?, `age` = COALESCE(`users`.`age`, 0) + ? WHERE LOWER(`nickname`) LIKE ?",
 			wantArgs:  []any{1, 2, "a8m%"},
 		},
 		{
@@ -556,7 +556,7 @@ func TestBuilder(t *testing.T) {
 				Add("age", 2).
 				Set("age", 1).
 				Where(HasPrefixFold("nickname", "a8m")),
-			wantQuery: "UPDATE `users` SET `age` = ? WHERE `nickname` ILIKE ?",
+			wantQuery: "UPDATE `users` SET `age` = ? WHERE LOWER(`nickname`) LIKE ?",
 			wantArgs:  []any{1, "a8m%"},
 		},
 		{
@@ -579,7 +579,7 @@ func TestBuilder(t *testing.T) {
 			input: Update("users").
 				Add("age", 1).
 				Where(HasSuffixFold("nickname", "a8m")),
-			wantQuery: "UPDATE `users` SET `age` = COALESCE(`users`.`age`, 0) + ? WHERE `nickname` ILIKE ?",
+			wantQuery: "UPDATE `users` SET `age` = COALESCE(`users`.`age`, 0) + ? WHERE LOWER(`nickname`) LIKE ?",
 			wantArgs:  []any{1, "%a8m"},
 		},
 		{
@@ -587,7 +587,7 @@ func TestBuilder(t *testing.T) {
 				Set("age", 1).
 				Add("age", 2).
 				Where(HasSuffixFold("nickname", "a8m")),
-			wantQuery: "UPDATE `users` SET `age` = ?, `age` = COALESCE(`users`.`age`, 0) + ? WHERE `nickname` ILIKE ?",
+			wantQuery: "UPDATE `users` SET `age` = ?, `age` = COALESCE(`users`.`age`, 0) + ? WHERE LOWER(`nickname`) LIKE ?",
 			wantArgs:  []any{1, 2, "%a8m"},
 		},
 		{
@@ -595,7 +595,7 @@ func TestBuilder(t *testing.T) {
 				Add("age", 2).
 				Set("age", 1).
 				Where(HasSuffixFold("nickname", "a8m")),
-			wantQuery: "UPDATE `users` SET `age` = ? WHERE `nickname` ILIKE ?",
+			wantQuery: "UPDATE `users` SET `age` = ? WHERE LOWER(`nickname`) LIKE ?",
 			wantArgs:  []any{1, "%a8m"},
 		},
 		{

--- a/dialect/sql/builder_test.go
+++ b/dialect/sql/builder_test.go
@@ -523,6 +523,52 @@ func TestBuilder(t *testing.T) {
 		},
 		{
 			input: Update("users").
+				Set("name", "foo").
+				Where(And(HasPrefixFold("nickname", "a8m"), Contains("lastname", "mash"))),
+			wantQuery: "UPDATE `users` SET `name` = ? WHERE `nickname` ILIKE ? AND `lastname` LIKE ?",
+			wantArgs:  []any{"foo", "a8m%", "%mash%"},
+		},
+		{
+			input: Dialect(dialect.Postgres).
+				Update("users").
+				Set("name", "foo").
+				Where(And(HasPrefixFold("nickname", "a8m"), Contains("lastname", "mash"))),
+			wantQuery: `UPDATE "users" SET "name" = $1 WHERE "nickname" ILIKE $2 AND "lastname" LIKE $3`,
+			wantArgs:  []any{"foo", "a8m%", "%mash%"},
+		},
+		{
+			input: Update("users").
+				Add("age", 1).
+				Where(HasPrefixFold("nickname", "a8m")),
+			wantQuery: "UPDATE `users` SET `age` = COALESCE(`users`.`age`, 0) + ? WHERE `nickname` ILIKE ?",
+			wantArgs:  []any{1, "a8m%"},
+		},
+		{
+			input: Update("users").
+				Set("age", 1).
+				Add("age", 2).
+				Where(HasPrefixFold("nickname", "a8m")),
+			wantQuery: "UPDATE `users` SET `age` = ?, `age` = COALESCE(`users`.`age`, 0) + ? WHERE `nickname` ILIKE ?",
+			wantArgs:  []any{1, 2, "a8m%"},
+		},
+		{
+			input: Update("users").
+				Add("age", 2).
+				Set("age", 1).
+				Where(HasPrefixFold("nickname", "a8m")),
+			wantQuery: "UPDATE `users` SET `age` = ? WHERE `nickname` ILIKE ?",
+			wantArgs:  []any{1, "a8m%"},
+		},
+		{
+			input: Dialect(dialect.Postgres).
+				Update("users").
+				Add("age", 1).
+				Where(HasPrefixFold("nickname", "a8m")),
+			wantQuery: `UPDATE "users" SET "age" = COALESCE("users"."age", 0) + $1 WHERE "nickname" ILIKE $2`,
+			wantArgs:  []any{1, "a8m%"},
+		},
+		{
+			input: Update("users").
 				Add("age", 1).
 				Set("nickname", "a8m").
 				Add("version", 10).

--- a/dialect/sql/sql.go
+++ b/dialect/sql/sql.go
@@ -170,6 +170,13 @@ func FieldHasSuffix(name string, suffix string) func(*Selector) {
 	}
 }
 
+// FieldHasSuffixFold returns a raw predicate to check if the field has the given suffix with case-folding
+func FieldHasSuffixFold(name string, suffix string) func(*Selector) {
+	return func(s *Selector) {
+		s.Where(HasSuffixFold(s.C(name), suffix))
+	}
+}
+
 // FieldContains returns a raw predicate to check if the field contains the given substring.
 func FieldContains(name string, substr string) func(*Selector) {
 	return func(s *Selector) {

--- a/dialect/sql/sql.go
+++ b/dialect/sql/sql.go
@@ -156,6 +156,13 @@ func FieldHasPrefix(name string, prefix string) func(*Selector) {
 	}
 }
 
+// FieldHasPrefixFold returns a raw predicate to check if the field has the given prefix with case-folding
+func FieldHasPrefixFold(name string, prefix string) func(*Selector) {
+	return func(s *Selector) {
+		s.Where(HasPrefixFold(s.C(name), prefix))
+	}
+}
+
 // FieldHasSuffix returns a raw predicate to check if the field has the given suffix.
 func FieldHasSuffix(name string, suffix string) func(*Selector) {
 	return func(s *Selector) {

--- a/dialect/sql/sql_test.go
+++ b/dialect/sql/sql_test.go
@@ -336,6 +336,24 @@ func TestFieldHasPrefix(t *testing.T) {
 	})
 }
 
+func TestFieldHasPrefixFold(t *testing.T) {
+	p := FieldHasPrefixFold("name", "a8m")
+	t.Run("MySQL", func(t *testing.T) {
+		s := Dialect(dialect.MySQL).Select("*").From(Table("users"))
+		p(s)
+		query, args := s.Query()
+		require.Equal(t, "SELECT * FROM `users` WHERE `users`.`name` ILIKE ?", query)
+		require.Equal(t, []any{"a8m%"}, args)
+	})
+	t.Run("PostgreSQL", func(t *testing.T) {
+		s := Dialect(dialect.Postgres).Select("*").From(Table("users"))
+		p(s)
+		query, args := s.Query()
+		require.Equal(t, `SELECT * FROM "users" WHERE "users"."name" ILIKE $1`, query)
+		require.Equal(t, []any{"a8m%"}, args)
+	})
+}
+
 func TestFieldHasSuffix(t *testing.T) {
 	p := FieldHasSuffix("name", "a8m")
 	t.Run("MySQL", func(t *testing.T) {

--- a/dialect/sql/sql_test.go
+++ b/dialect/sql/sql_test.go
@@ -342,7 +342,7 @@ func TestFieldHasPrefixFold(t *testing.T) {
 		s := Dialect(dialect.MySQL).Select("*").From(Table("users"))
 		p(s)
 		query, args := s.Query()
-		require.Equal(t, "SELECT * FROM `users` WHERE `users`.`name` ILIKE ?", query)
+		require.Equal(t, "SELECT * FROM `users` WHERE `users`.`name` COLLATE utf8mb4_general_ci LIKE ?", query)
 		require.Equal(t, []any{"a8m%"}, args)
 	})
 	t.Run("PostgreSQL", func(t *testing.T) {
@@ -378,7 +378,7 @@ func TestFieldHasSuffixFold(t *testing.T) {
 		s := Dialect(dialect.MySQL).Select("*").From(Table("users"))
 		p(s)
 		query, args := s.Query()
-		require.Equal(t, "SELECT * FROM `users` WHERE `users`.`name` ILIKE ?", query)
+		require.Equal(t, "SELECT * FROM `users` WHERE `users`.`name` COLLATE utf8mb4_general_ci LIKE ?", query)
 		require.Equal(t, []any{"%a8m"}, args)
 	})
 	t.Run("PostgreSQL", func(t *testing.T) {

--- a/dialect/sql/sql_test.go
+++ b/dialect/sql/sql_test.go
@@ -372,6 +372,24 @@ func TestFieldHasSuffix(t *testing.T) {
 	})
 }
 
+func TestFieldHasSuffixFold(t *testing.T) {
+	p := FieldHasSuffixFold("name", "a8m")
+	t.Run("MySQL", func(t *testing.T) {
+		s := Dialect(dialect.MySQL).Select("*").From(Table("users"))
+		p(s)
+		query, args := s.Query()
+		require.Equal(t, "SELECT * FROM `users` WHERE `users`.`name` ILIKE ?", query)
+		require.Equal(t, []any{"%a8m"}, args)
+	})
+	t.Run("PostgreSQL", func(t *testing.T) {
+		s := Dialect(dialect.Postgres).Select("*").From(Table("users"))
+		p(s)
+		query, args := s.Query()
+		require.Equal(t, `SELECT * FROM "users" WHERE "users"."name" ILIKE $1`, query)
+		require.Equal(t, []any{"%a8m"}, args)
+	})
+}
+
 func TestFieldContains(t *testing.T) {
 	p := FieldContains("name", "a8m")
 	t.Run("MySQL", func(t *testing.T) {


### PR DESCRIPTION
The `HasPrefix` and `HasSuffix` always generate `LIKE` operator which is case sensitive. In some of the operations, we want case insensitive operations instead and this PR adds methods to the sql package:

- `FieldHasPrefixFold`
- `FieldHasSuffixFold`

To support that, the underlying builder gets following methods:

- `HasPrefixFold`
- `HasPrefixFold` on `Predicate` type.
- `HasSuffixFold`
- `HasSuffixFold` on `Predicate` type.

FYI @a8m 