### PR TITLE
dialect/sql: fix error formatting 

### DIFF
--- a/dialect/sql/schema/atlas.go
+++ b/dialect/sql/schema/atlas.go
@@ -201,7 +201,10 @@ func (a *Atlas) NamedDiff(ctx context.Context, name string, tables ...*Table) er
 
 func (a *Atlas) cleanSchema(ctx context.Context, name string, err0 error) (err error) {
 	defer func() {
-		if err0 != nil {
+		switch {
+		case err == nil:
+			err = err0
+		case err != nil && err0 != nil:
 			err = fmt.Errorf("%v: %w", err0, err)
 		}
 	}()

--- a/dialect/sql/schema/atlas.go
+++ b/dialect/sql/schema/atlas.go
@@ -201,11 +201,8 @@ func (a *Atlas) NamedDiff(ctx context.Context, name string, tables ...*Table) er
 
 func (a *Atlas) cleanSchema(ctx context.Context, name string, err0 error) (err error) {
 	defer func() {
-		switch {
-		case err == nil:
-			err = err0
-		case err != nil && err0 != nil:
-			err = fmt.Errorf("%v: %w", err0, err)
+		if err0 != nil {
+			err = errors.Join(err, err0)
 		}
 	}()
 	s, err := a.atDriver.InspectSchema(ctx, name, nil)


### PR DESCRIPTION
before:
`Error: migration checks are available to logged-in users only. Use 'atlas login' to access this feature: %!w(<nil>)`

after:
`Error: migration checks are available to logged-in users only. Use 'atlas login' to access this feature`