### PR TITLE
doc: remove `-d` flag in `go get` commands

### DIFF
--- a/doc/md/code-gen.md
+++ b/doc/md/code-gen.md
@@ -9,7 +9,7 @@ The project comes with a codegen tool called `ent`. In order to install
 `ent` run the following command:
 
 ```bash
-go get -d entgo.io/ent/cmd/ent
+go get entgo.io/ent/cmd/ent
 ``` 
 
 ## Initialize A New Schema
@@ -60,7 +60,7 @@ go mod init <project>
 And then, re-run the following command in order to add `ent` to your `go.mod` file:
 
 ```console
-go get -d entgo.io/ent/cmd/ent
+go get entgo.io/ent/cmd/ent
 ```
 
 Add a `generate.go` file to your project under `<project>/ent`:

--- a/doc/md/tutorial-setup.md
+++ b/doc/md/tutorial-setup.md
@@ -25,7 +25,7 @@ go mod init todo
 Run the following Go commands to install Ent, and tell it to initialize the project structure along with a `Todo` schema.
 
 ```console
-go get -d entgo.io/ent/cmd/ent
+go get entgo.io/ent/cmd/ent
 ```
 
 ```console


### PR DESCRIPTION
As pointed [here](https://go.dev/doc/go-get-install-deprecation), since Go 1.18, `go get` always act as `go get -d`.