### PR TITLE
dialect: add `NULLS NOT DISTINCT` in Postgres 15

### DIFF
--- a/dialect/entsql/annotation.go
+++ b/dialect/entsql/annotation.go
@@ -596,6 +596,19 @@ type IndexAnnotation struct {
 	//		)
 	//	CREATE INDEX "table_a" ON "table"("a") WHERE (b AND c > 0)
 	Where string
+
+	// NullsNotDistinct defines a unique index with nulls not distinct.
+	// In PostgreSQL, the following annotation maps to:
+	//
+	//	index.Fields("a").
+	//		Unique().
+	//		Annotations(
+	//			entsql.NullsNotDistinct(),
+	//		)
+	//
+	//	CREATE UNIQUE INDEX "table_a" ON "table"("a") NULLS NOT DISTINCT
+	//
+	NullsNotDistinct bool
 }
 
 // Prefix returns a new index annotation with a single string column index.
@@ -751,6 +764,22 @@ func IndexWhere(pred string) *IndexAnnotation {
 	return &IndexAnnotation{Where: pred}
 }
 
+// NullsNotDistinct defines a unique index with nulls not distinct.
+// In PostgreSQL, the following annotation maps to:
+//
+//	index.Fields("a").
+//		Unique().
+//		Annotations(
+//			entsql.NullsNotDistinct(),
+//		)
+//
+//	CREATE UNIQUE INDEX "table_a" ON "table"("a") NULLS NOT DISTINCT
+func NullsNotDistinct() *IndexAnnotation {
+	return &IndexAnnotation{
+		NullsNotDistinct: true,
+	}
+}
+
 // Name describes the annotation name.
 func (IndexAnnotation) Name() string {
 	return "EntSQLIndexes"
@@ -818,6 +847,9 @@ func (a IndexAnnotation) Merge(other schema.Annotation) schema.Annotation {
 	}
 	if ant.Where != "" {
 		a.Where = ant.Where
+	}
+	if ant.NullsNotDistinct {
+		a.NullsNotDistinct = ant.NullsNotDistinct
 	}
 	return a
 }

--- a/dialect/sql/schema/postgres.go
+++ b/dialect/sql/schema/postgres.go
@@ -837,6 +837,9 @@ func (d *Postgres) atIndex(idx1 *Index, t2 *schema.Table, idx2 *schema.Index) er
 		}
 		idx2.AddAttrs(&postgres.IndexInclude{Columns: columns})
 	}
+	if compareVersions(d.version, "15.0.0") >= 0 && idx1.Unique && idx1.Annotation != nil && idx1.Annotation.NullsNotDistinct {
+		idx2.AddAttrs(&postgres.IndexNullsDistinct{V: !idx1.Annotation.NullsNotDistinct})
+	}
 	if idx1.Annotation != nil && idx1.Annotation.Where != "" {
 		idx2.AddAttrs(&postgres.IndexPredicate{P: idx1.Annotation.Where})
 	}

--- a/entc/gen/template/migrate/schema.tmpl
+++ b/entc/gen/template/migrate/schema.tmpl
@@ -182,6 +182,9 @@ var (
 									{{- with $ant.Where }}
 										Where: {{ quote . }},
 									{{- end }}
+									{{- with $ant.NullsNotDistinct }}
+										NullsNotDistinct: {{ quote . }},
+									{{- end }}
 								},
 							{{- end }}
 						},

--- a/entc/integration/migrate/entv2/migrate/schema.go
+++ b/entc/integration/migrate/entv2/migrate/schema.go
@@ -239,6 +239,14 @@ var (
 					},
 				},
 			},
+			{
+				Name:    "user_nickname_phone",
+				Unique:  true,
+				Columns: []*schema.Column{UsersColumns[7], UsersColumns[8]},
+				Annotation: &entsql.IndexAnnotation{
+					NullsNotDistinct: true,
+				},
+			},
 		},
 	}
 	// ZoosColumns holds the columns for the "zoos" table.

--- a/entc/integration/migrate/entv2/schema/user.go
+++ b/entc/integration/migrate/entv2/schema/user.go
@@ -180,6 +180,9 @@ func (User) Indexes() []ent.Index {
 			Annotations(
 				entsql.OpClassColumn("phone", "bpchar_pattern_ops"),
 			),
+		// For PostgreSQL, users can define unique indexes with nulls not distinct.
+		index.Fields("nickname", "phone").
+			Unique().Annotations(entsql.NullsNotDistinct()),
 	}
 }
 


### PR DESCRIPTION
`NULLS NOT DISTINCT` option is a feature that has been available since Postgres 15.

close https://github.com/ent/ent/issues/3592

More detailed information can be found in the following documents:
- [UNIQUE NULLS NOT DISTINCT](https://www.postgresql.org/about/featurematrix/detail/392/)
- [Release Notes PostgreSQL 15.0](https://www.postgresql.org/docs/release/15.0/)