### PR TITLE
ability to add additional fiels to type xxMutation {}

### DIFF
--- a/entc/gen/template.go
+++ b/entc/gen/template.go
@@ -206,7 +206,7 @@ var (
 		"query/additional/*",
 		"privacy/additional/*",
 		"privacy/additional/*/*",
-		"mutation/model/fields/*",
+		"mutation/fields/*",
 	}
 	// templates holds the Go templates for the code generation.
 	templates *Template

--- a/entc/gen/template.go
+++ b/entc/gen/template.go
@@ -206,6 +206,7 @@ var (
 		"query/additional/*",
 		"privacy/additional/*",
 		"privacy/additional/*/*",
+		"mutation/model/fields/*",
 	}
 	// templates holds the Go templates for the code generation.
 	templates *Template

--- a/entc/gen/template/builder/mutation.tmpl
+++ b/entc/gen/template/builder/mutation.tmpl
@@ -72,9 +72,8 @@ type {{ $mutation }} struct {
 	done bool
 	oldValue func(context.Context) (*{{ $n.Name }}, error)
 	predicates []predicate.{{ $n.Name }}
-
 	{{- /* Additional fields can be added. */}}
-	{{- with $tmpls := matchTemplate "mutation/model/fields/*"  }}
+	{{- with $tmpls := matchTemplate "mutation/fields/*"  }}
 		{{- range $tmpl := $tmpls }}
 			{{- xtemplate $tmpl $n }}
 		{{- end }}

--- a/entc/gen/template/builder/mutation.tmpl
+++ b/entc/gen/template/builder/mutation.tmpl
@@ -72,6 +72,13 @@ type {{ $mutation }} struct {
 	done bool
 	oldValue func(context.Context) (*{{ $n.Name }}, error)
 	predicates []predicate.{{ $n.Name }}
+
+	{{- /* Additional fields can be added. */}}
+	{{- with $tmpls := matchTemplate "mutation/model/fields/*"  }}
+		{{- range $tmpl := $tmpls }}
+			{{- xtemplate $tmpl $n }}
+		{{- end }}
+	{{- end }}
 }
 
 var _ ent.Mutation = (*{{ $mutation }})(nil)


### PR DESCRIPTION
I am building an extension that can Add MediaPicker support to any Model via Annotation and integration with GraphQL.

So this extension will automatically generate the additional types for Mutation and generate the graphql types and bind them with `type xxMutation {}`

```go
func (Post) Annotations() []schema.Annotation {
  return []schema.Annotation{
    entsaasmedia.MediaFields(entsaasmedia.FieldOption{Name: "featured"}, entsaasmedia.FieldOption{Name: "icon"})
  }
}
```

So we need a way to customize the mutation type to add additional fields without copying the whole `mutation.tmpl` file in custom templates directory and then override