### PR TITLE
Add 'Schema' to the restricted global identifiers

### DIFF
--- a/entc/gen/type.go
+++ b/entc/gen/type.go
@@ -2293,6 +2293,7 @@ var (
 		"Max",
 		"Mean",
 		"Min",
+		"Schema",
 		"Sum",
 		"Policy",
 		"Query",


### PR DESCRIPTION
I created a new object called `Schema` for a project I was working on and was surprised that things weren't how i expected it.   

* The `schema` directory was updated and the `schema/schema.go` was overwritten.  
* There was a confiicdt with the `Client.Schema` migration pointer.  

Overall it seems bad to try to use `Schema` as an object name so this adds it to the list of Global indentifiers.  Both `schema` and `Schema` are both bad (for packages and objects) but just the uppercate `Schema` should cover both and provide a better error message?

## Test Plan
```
go run ./cmd/entc new Schema
ent/new: new schema Schema: schema name conflicts with ent predeclared identifier "Schema"
exit status 1
```