### PR TITLE
dialect/entsql: allow to define auto increment start value

### DIFF
--- a/dialect/entsql/annotation.go
+++ b/dialect/entsql/annotation.go
@@ -126,6 +126,17 @@ type Annotation struct {
 	//
 	Incremental *bool `json:"incremental,omitempty"`
 
+	// IncrementStart defines the auto-incremental start value of a column. For example:
+	//
+	//  incrementStart := 100
+	//  entsql.Annotation{
+	//      IncrementStart: &incrementStart,
+	//  }
+	//
+	// By default, this value is nil defaulting to whatever the database settings are.
+	//
+	IncrementStart *int64 `json:"increment_start,omitempty"`
+
 	// OnDelete specifies a custom referential action for DELETE operations on parent
 	// table that has matching rows in the child table.
 	//
@@ -414,6 +425,9 @@ func (a Annotation) Merge(other schema.Annotation) schema.Annotation {
 	}
 	if i := ant.Incremental; i != nil {
 		a.Incremental = i
+	}
+	if i := ant.IncrementStart; i != nil {
+		a.IncrementStart = i
 	}
 	if od := ant.OnDelete; od != "" {
 		a.OnDelete = od

--- a/entc/gen/type.go
+++ b/entc/gen/type.go
@@ -1612,7 +1612,7 @@ func (f Field) Column() *schema.Column {
 }
 
 // incremental returns if the column has an incremental behavior.
-// If no value is defined externally, we use a provided def flag
+// If no value is defined externally, we use a provided def flag.
 func (f Field) incremental(def bool) bool {
 	if ant := f.EntSQL(); ant != nil && ant.Incremental != nil {
 		return *ant.Incremental


### PR DESCRIPTION
Preparation to rewrite the universal id feature to rely on type ranges defined statically in the schema instead of dynamically in a database.