### PR TITLE
fix: use bigint for uint32 and uint16 in postgres driver

### DIFF
--- a/dialect/sql/schema/postgres.go
+++ b/dialect/sql/schema/postgres.go
@@ -112,11 +112,11 @@ func (d *Postgres) atTypeC(c1 *Column, c2 *schema.Column) error {
 	switch c1.Type {
 	case field.TypeBool:
 		t = &schema.BoolType{T: postgres.TypeBoolean}
-	case field.TypeUint8, field.TypeInt8, field.TypeInt16, field.TypeUint16:
+	case field.TypeUint8, field.TypeInt8, field.TypeInt16:
 		t = &schema.IntegerType{T: postgres.TypeSmallInt}
-	case field.TypeInt32, field.TypeUint32:
+	case field.TypeUint16, field.TypeInt32:
 		t = &schema.IntegerType{T: postgres.TypeInt}
-	case field.TypeInt, field.TypeUint, field.TypeInt64, field.TypeUint64:
+	case field.TypeUint32, field.TypeInt, field.TypeUint, field.TypeInt64, field.TypeUint64:
 		t = &schema.IntegerType{T: postgres.TypeBigInt}
 	case field.TypeFloat32:
 		t = &schema.FloatType{T: c1.scanTypeOr(postgres.TypeReal)}


### PR DESCRIPTION
I could not store the max values of `uint32` using the default schema types.
To me it seems that the mapping is incorrect:

https://github.com/ent/ent/blob/b91f8daf0e3267a1c7818f8120e83a36d56054b3/dialect/sql/schema/postgres.go#L117-L118

`integer` type in PG ranges from `-2147483648 to +2147483647` (https://www.postgresql.org/docs/current/datatype-numeric.html) - which is not sufficient.

I then checked the other types and think that `uint16` also needs to be fixed.