### PR TITLE
entc/gen: resolve merge conflicts on file load

### DIFF
--- a/entc/entc.go
+++ b/entc/entc.go
@@ -393,15 +393,15 @@ func mayRecover(err error, schemaPath string, cfg *gen.Config) error {
 	if err := internal.CheckDir(schemaPath); err != nil {
 		return fmt.Errorf("schema failure: %w", err)
 	}
-	target := filepath.Join(cfg.Target, "internal/schema.go")
 	if ok, _ := cfg.FeatureEnabled(gen.FeatureGlobalID.Name); ok {
-		if internal.CheckDir(gen.IncrementStartsFilePath(target)) != nil {
+		if internal.CheckDir(filepath.Dir(gen.IncrementStartsFilePath(cfg.Target))) != nil {
 			// Resolve the conflict by accepting the remote version of the file.
 			if err := gen.ResolveIncrementStartsConflict(cfg.Target); err != nil {
 				return err
 			}
 		}
 	}
+	target := filepath.Join(cfg.Target, "internal/schema.go")
 	return (&internal.Snapshot{Path: target, Config: cfg}).Restore()
 }
 

--- a/entc/gen/globalid_test.go
+++ b/entc/gen/globalid_test.go
@@ -97,8 +97,8 @@ const IncrementStarts = %s
 	require.NoError(t, os.WriteFile(p, []byte(cflct), 0644))
 
 	// Expect an error when there is a file conflict.
-	// g, err := gen.NewGraph(c, s...)
-	// require.Error(t, err)
+	_, err := gen.NewGraph(c, s...)
+	require.Error(t, err)
 	// Conflict is resolved to "accept theirs".
 	require.NoError(t, gen.ResolveIncrementStartsConflict(c.Target))
 	require.NoError(t, internal.CheckDir(filepath.Dir(p)))


### PR DESCRIPTION
If there is no conflict in the schema, the existing logic will not attempt to resolve a conflict. Therefore, if there is a conflict on file load, there now also is an attempt to fix the conflict.