### PR TITLE
fix: set the dialect for the generated query

### DIFF
--- a/cmd/entfix/entfix.go
+++ b/cmd/entfix/entfix.go
@@ -82,7 +82,8 @@ func (cmd *GlobalID) Run(ctx context.Context) error {
 		return err
 	}
 	rows := &sql.Rows{}
-	query, args := sql.Select("type").
+	query, args := sql.Dialect(cmd.Dialect).
+		Select("type").
 		From(sql.Table(schema.TypeTable)).
 		OrderBy(sql.Asc("id")).
 		Query()


### PR DESCRIPTION
different quote characters are used by different dialects