### PR TITLE
dialect/sql/schema: revert min length logic for state reader

### DIFF
--- a/dialect/sql/schema/atlas.go
+++ b/dialect/sql/schema/atlas.go
@@ -528,7 +528,6 @@ func (a *Atlas) StateReader(tables ...*Table) migrate.StateReaderFunc {
 			}
 			a.sqlDialect = drv
 		}
-		a.setupTables(tables)
 		return a.realm(tables)
 	}
 }

--- a/dialect/sql/schema/schema_test.go
+++ b/dialect/sql/schema/schema_test.go
@@ -302,7 +302,7 @@ CREATE UNIQUE INDEX $name$ ON $pets$ ($name$ DESC);
 CREATE VIEW $pets_without_fur$ ($id$, $name$, $owner_id$) AS SELECT id, name, owner_id FROM pets;
 `, "$", "`"),
 		},
-		{dialect.MySQL, "5.6", my(191)},
+		{dialect.MySQL, "5.6", my(255)},
 		{dialect.MySQL, "5.7", my(255)},
 		{dialect.MySQL, "8", my(255)},
 		{dialect.Postgres, "12", pg},


### PR DESCRIPTION
While this change is correct and eventually should land, currently it is creating too many noise in existing projects. Therefore, this change is reverted until a better solution is found.

Closes https://github.com/ariga/atlas/issues/3437