### PR TITLE
docs(schema/field): fix UUID field example to use uuid.UUID{} instead of uuid.New()

### DIFF
--- a/schema/field/field.go
+++ b/schema/field/field.go
@@ -147,7 +147,8 @@ func Enum(name string) *enumBuilder {
 
 // UUID returns a new Field with type UUID. An example for defining UUID field is as follows:
 //
-//	field.UUID("id", uuid.New())
+//	field.UUID("id", uuid.UUID{}).
+//		Default(uuid.New)
 func UUID(name string, typ driver.Valuer) *uuidBuilder {
 	rt := reflect.TypeOf(typ)
 	b := &uuidBuilder{&Descriptor{


### PR DESCRIPTION
The UUID field example was using `uuid.New()` as the second parameter, which passes a concrete value instead of a type. This is misleading and may cause errors in usage.

Updated the example to use `uuid.UUID{}` as the zero value type, along with `.Default(uuid.New)` to show how to generate new UUIDs correctly.

This better aligns with official documentation: https://entgo.io/docs/schema-fields/#id-field
