### PR TITLE
Add the ability to enforce adding table columns in user defined order

### DIFF
--- a/dialect/entsql/annotation.go
+++ b/dialect/entsql/annotation.go
@@ -193,6 +193,10 @@ type Annotation struct {
 	//	}
 	ViewFor map[string]string `json:"view_for,omitempty"`
 
+	// TableFieldOrder tells ent to use the user provided Field order for columns,
+	// and to not push all Edges till the end of the column list
+	TableFieldOrder bool `json:"table_field_order,omitempty"`
+
 	// error occurs during annotation build. This field is not
 	// serialized to JSON and used only by the codegen loader.
 	err error
@@ -297,6 +301,10 @@ func ViewFor(dialect string, as func(*sql.Selector)) *Annotation {
 			ViewFor: map[string]string{dialect: q},
 		}
 	}
+}
+
+func TableFieldOrder() *Annotation {
+	return &Annotation{TableFieldOrder: true}
 }
 
 // Default specifies a literal default value of a column. Note that using

--- a/entc/gen/graph.go
+++ b/entc/gen/graph.go
@@ -649,11 +649,12 @@ func (g *Graph) Tables() (all []*schema.Table, err error) {
 		default:
 			table.SetAnnotation(ant).SetSchema(ant.Schema)
 		}
+		nAnt := n.EntSQL()
 		for _, f := range n.Fields {
 			if a := f.EntSQL(); a != nil && a.Skip {
 				continue
 			}
-			if !f.IsEdgeField() {
+			if (nAnt != nil && nAnt.TableFieldOrder) || !f.IsEdgeField() {
 				table.AddColumn(f.Column())
 			}
 		}


### PR DESCRIPTION
We had a problem with migrations that when we add fields to ent tables, that ent wants to generate the schema in a different order than what one would get by altering the table.  This enables the user to request that ent generate the table columns in the order specified in fields array.