### PR TITLE
dialect/sql: Support the RETURNING clause in DELETE

### DIFF
--- a/dialect/sql/builder.go
+++ b/dialect/sql/builder.go
@@ -1146,7 +1146,7 @@ func (u *UpdateBuilder) Prefix(stmts ...Querier) *UpdateBuilder {
 	return u
 }
 
-// Returning adds the `RETURNING` clause to the insert statement.
+// Returning adds the `RETURNING` clause to the update statement.
 // Supported by SQLite and PostgreSQL.
 func (u *UpdateBuilder) Returning(columns ...string) *UpdateBuilder {
 	u.returning = columns

--- a/dialect/sql/builder_test.go
+++ b/dialect/sql/builder_test.go
@@ -826,6 +826,34 @@ func TestBuilder(t *testing.T) {
 			wantArgs:  []any{"foo", 10, "bar", 20, "admin"},
 		},
 		{
+			input: Dialect(dialect.Postgres).
+				Delete("users").
+				Where(NotNull("parent_id")).
+				Returning("*"),
+			wantQuery: `DELETE FROM "users" WHERE "parent_id" IS NOT NULL RETURNING *`,
+		},
+		{
+			input: Dialect(dialect.Postgres).
+				Delete("users").
+				Where(NotNull("parent_id")).
+				Returning("id", "name"),
+			wantQuery: `DELETE FROM "users" WHERE "parent_id" IS NOT NULL RETURNING "id", "name"`,
+		},
+		{
+			input: Dialect(dialect.SQLite).
+				Delete("users").
+				Where(NotNull("parent_id")).
+				Returning("*"),
+			wantQuery: "DELETE FROM `users` WHERE `parent_id` IS NOT NULL RETURNING *",
+		},
+		{
+			input: Dialect(dialect.SQLite).
+				Delete("users").
+				Where(NotNull("parent_id")).
+				Returning("id", "name"),
+			wantQuery: "DELETE FROM `users` WHERE `parent_id` IS NOT NULL RETURNING `id`, `name`",
+		},
+		{
 			input:     Select().From(Table("users")),
 			wantQuery: "SELECT * FROM `users`",
 		},


### PR DESCRIPTION
Currently, the RETURNING clause is supported for INSERT and UPDATE statements, but not for DELETE. I’d appreciate it if you could add DELETE support.