### PR TITLE
Enum Builder takes a string, should take an any

### DIFF
--- a/schema/field/field.go
+++ b/schema/field/field.go
@@ -248,7 +248,7 @@ func (b *stringBuilder) Validate(fn func(string) error) *stringBuilder {
 }
 
 // Default sets the default value of the field.
-func (b *stringBuilder) Default(s string) *stringBuilder {
+func (b *stringBuilder) Default(s any) *stringBuilder {
 	b.desc.Default = s
 	return b
 }
@@ -1041,7 +1041,7 @@ func (b *enumBuilder) NamedValues(namevalue ...string) *enumBuilder {
 }
 
 // Default sets the default value of the field.
-func (b *enumBuilder) Default(value string) *enumBuilder {
+func (b *enumBuilder) Default(value any) *enumBuilder {
 	b.desc.Default = value
 	return b
 }


### PR DESCRIPTION
Without an any, one can pass an enum value to it, and if one tries a string representation of the enum, one ends up with code that will fail to compile as it will generate

var TypeDefault EnumType = "some string"