### PR TITLE
schema/field: validate rune length with `MinRuneLen` / `MaxRuneLen`

### DIFF
--- a/schema/field/field.go
+++ b/schema/field/field.go
@@ -15,6 +15,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"entgo.io/ent/schema"
 )
@@ -222,6 +223,18 @@ func (b *stringBuilder) MinLen(i int) *stringBuilder {
 	return b
 }
 
+// MinRuneLen adds a rune length validator for this field.
+// Operation fails if the rune count of the string is less than the given value.
+func (b *stringBuilder) MinRuneLen(i int) *stringBuilder {
+	b.desc.Validators = append(b.desc.Validators, func(v string) error {
+		if utf8.RuneCountInString(v) < i {
+			return errors.New("value is less than the required rune length")
+		}
+		return nil
+	})
+	return b
+}
+
 // NotEmpty adds a length validator for this field.
 // Operation fails if the length of the string is zero.
 func (b *stringBuilder) NotEmpty() *stringBuilder {
@@ -235,6 +248,19 @@ func (b *stringBuilder) MaxLen(i int) *stringBuilder {
 	b.desc.Validators = append(b.desc.Validators, func(v string) error {
 		if len(v) > i {
 			return errors.New("value is greater than the required length")
+		}
+		return nil
+	})
+	return b
+}
+
+// MaxRuneLen adds a rune length validator for this field.
+// Operation fails if the rune count of the string is greater than the given value.
+func (b *stringBuilder) MaxRuneLen(i int) *stringBuilder {
+	b.desc.Size = i
+	b.desc.Validators = append(b.desc.Validators, func(v string) error {
+		if utf8.RuneCountInString(v) > i {
+			return errors.New("value is greater than the required rune length")
 		}
 		return nil
 	})

--- a/schema/field/field_test.go
+++ b/schema/field/field_test.go
@@ -975,3 +975,43 @@ func TestTypeConstName(t *testing.T) {
 	typ = 21
 	assert.Equal(t, "invalid", typ.ConstName())
 }
+
+func TestString_MinRuneLen(t *testing.T) {
+	fd := field.String("name").MinRuneLen(5).Descriptor()
+	assert.Len(t, fd.Validators, 1)
+
+	err := fd.Validators[0].(func(string) error)("hello")
+	assert.NoError(t, err)
+
+	err = fd.Validators[0].(func(string) error)("hi")
+	assert.EqualError(t, err, "value is less than the required rune length")
+
+	err = fd.Validators[0].(func(string) error)("你好")
+	assert.EqualError(t, err, "value is less than the required rune length")
+
+	err = fd.Validators[0].(func(string) error)("你好世界！")
+	assert.NoError(t, err)
+
+	err = fd.Validators[0].(func(string) error)("")
+	assert.Error(t, err)
+}
+
+func TestString_MaxRuneLen(t *testing.T) {
+	fd := field.String("name").MaxRuneLen(5).Descriptor()
+	assert.Len(t, fd.Validators, 1)
+
+	err := fd.Validators[0].(func(string) error)("hello")
+	assert.NoError(t, err)
+
+	err = fd.Validators[0].(func(string) error)("hello world")
+	assert.EqualError(t, err, "value is greater than the required rune length")
+
+	err = fd.Validators[0].(func(string) error)("你好世界你好")
+	assert.EqualError(t, err, "value is greater than the required rune length")
+
+	err = fd.Validators[0].(func(string) error)("你好世界！")
+	assert.NoError(t, err)
+
+	err = fd.Validators[0].(func(string) error)("")
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
- **Issue**: The original `MaxLen` validator used `len(v)` (byte count), while databases like MySQL/PostgreSQL/SQLite define `varchar(size)` as **character count** (not bytes). This caused inconsistent validation for multi-byte characters (e.g., Chinese, Emoji).
- **Fix**: Switched to `utf8.RuneCountInString(v)` to count Unicode characters, ensuring the validation aligns with database constraints.
- **Impact**: All supported databases (MySQL/PostgreSQL/SQLite) now have consistent character-length checks at both application and database layers.
- **Future Compatibility**:
  - For Oracle/SQL Server (where `varchar` uses byte counts by default), explicit syntax like `varchar(N CHAR)` or `nvarchar` can enforce character limits. This change does not affect existing logic but should be noted for future dialect support.