### PR TITLE
dialect/sql/sqlgraph: report check constraint violation with `IsCheckConstraintError`

### DIFF
--- a/dialect/sql/sqlgraph/errors.go
+++ b/dialect/sql/sqlgraph/errors.go
@@ -12,7 +12,10 @@ import (
 // IsConstraintError returns true if the error resulted from a database constraint violation.
 func IsConstraintError(err error) bool {
 	var e *ConstraintError
-	return errors.As(err, &e) || IsUniqueConstraintError(err) || IsForeignKeyConstraintError(err)
+	return errors.As(err, &e) ||
+		IsUniqueConstraintError(err) ||
+		IsForeignKeyConstraintError(err) ||
+		IsCheckConstraintError(err)
 }
 
 // IsUniqueConstraintError reports if the error resulted from a DB uniqueness constraint violation.
@@ -44,6 +47,24 @@ func IsForeignKeyConstraintError(err error) bool {
 		"Error 1452",                      // MySQL (Cannot add or update a child row).
 		"violates foreign key constraint", // Postgres
 		"FOREIGN KEY constraint failed",   // SQLite
+	} {
+		if strings.Contains(err.Error(), s) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsCheckConstraintError reports if the error resulted from a database check constraint violation.
+// e.g. a value does not satisfy a check condition.
+func IsCheckConstraintError(err error) bool {
+	if err == nil {
+		return false
+	}
+	for _, s := range []string{
+		"Error 3819",                // MySQL
+		"violates check constraint", // Postgres
+		"CHECK constraint failed",   // SQLite
 	} {
 		if strings.Contains(err.Error(), s) {
 			return true

--- a/dialect/sql/sqlgraph/graph_test.go
+++ b/dialect/sql/sqlgraph/graph_test.go
@@ -2569,6 +2569,7 @@ func TestIsConstraintError(t *testing.T) {
 		expectedConstraint bool
 		expectedFK         bool
 		expectedUnique     bool
+		expectedCheck      bool
 	}{
 		{
 			name: "MySQL FK",
@@ -2578,6 +2579,7 @@ func TestIsConstraintError(t *testing.T) {
 			expectedConstraint: true,
 			expectedFK:         true,
 			expectedUnique:     false,
+			expectedCheck:      false,
 		},
 		{
 			name:               "SQLite FK",
@@ -2585,6 +2587,7 @@ func TestIsConstraintError(t *testing.T) {
 			expectedConstraint: true,
 			expectedFK:         true,
 			expectedUnique:     false,
+			expectedCheck:      false,
 		},
 		{
 			name:               "Postgres FK",
@@ -2592,6 +2595,7 @@ func TestIsConstraintError(t *testing.T) {
 			expectedConstraint: true,
 			expectedFK:         true,
 			expectedUnique:     false,
+			expectedCheck:      false,
 		},
 		{
 			name: "MySQL FK",
@@ -2600,6 +2604,7 @@ func TestIsConstraintError(t *testing.T) {
 			expectedConstraint: true,
 			expectedFK:         true,
 			expectedUnique:     false,
+			expectedCheck:      false,
 		},
 		{
 			name:               "SQLite FK",
@@ -2607,6 +2612,7 @@ func TestIsConstraintError(t *testing.T) {
 			expectedConstraint: true,
 			expectedFK:         true,
 			expectedUnique:     false,
+			expectedCheck:      false,
 		},
 		{
 			name:               "Postgres FK",
@@ -2614,6 +2620,7 @@ func TestIsConstraintError(t *testing.T) {
 			expectedConstraint: true,
 			expectedFK:         true,
 			expectedUnique:     false,
+			expectedCheck:      false,
 		},
 		{
 			name:               "MySQL Unique",
@@ -2621,6 +2628,7 @@ func TestIsConstraintError(t *testing.T) {
 			expectedConstraint: true,
 			expectedFK:         false,
 			expectedUnique:     true,
+			expectedCheck:      false,
 		},
 		{
 			name:               "SQLite Unique",
@@ -2628,6 +2636,7 @@ func TestIsConstraintError(t *testing.T) {
 			expectedConstraint: true,
 			expectedFK:         false,
 			expectedUnique:     true,
+			expectedCheck:      false,
 		},
 		{
 			name:               "Postgres Unique",
@@ -2635,6 +2644,31 @@ func TestIsConstraintError(t *testing.T) {
 			expectedConstraint: true,
 			expectedFK:         false,
 			expectedUnique:     true,
+			expectedCheck:      false,
+		},
+		{
+			name:               "MySQL Check",
+			errMessage:         `insert node to table "users": Error 3819: Check constraint 'users_age_check' is violated`,
+			expectedConstraint: true,
+			expectedFK:         false,
+			expectedUnique:     false,
+			expectedCheck:      true,
+		},
+		{
+			name:               "SQLite Check",
+			errMessage:         `insert node to table "users": CHECK constraint failed: age >= 18`,
+			expectedConstraint: true,
+			expectedFK:         false,
+			expectedUnique:     false,
+			expectedCheck:      true,
+		},
+		{
+			name:               "Postgres Check",
+			errMessage:         `insert node to table "users": pq: new row for relation "users" violates check constraint "users_age_check"`,
+			expectedConstraint: true,
+			expectedFK:         false,
+			expectedUnique:     false,
+			expectedCheck:      true,
 		},
 	}
 	for _, tt := range tests {
@@ -2643,6 +2677,7 @@ func TestIsConstraintError(t *testing.T) {
 			require.EqualValues(t, tt.expectedConstraint, IsConstraintError(err))
 			require.EqualValues(t, tt.expectedFK, IsForeignKeyConstraintError(err))
 			require.EqualValues(t, tt.expectedUnique, IsUniqueConstraintError(err))
+			require.EqualValues(t, tt.expectedCheck, IsCheckConstraintError(err))
 		})
 	}
 }


### PR DESCRIPTION
- Issue: Currently, entc does not support verifying Check constraint violations
- Implementation: Add the new function `IsCheckConstraintError` to check the returned error message.