### PR TITLE
fix: allow GoType + Value scanner in mixins

### DIFF
--- a/entc/gen/type.go
+++ b/entc/gen/type.go
@@ -474,7 +474,7 @@ func (t Type) MixedInFields() []int {
 		fields = append(fields, t.ID)
 	}
 	for _, f := range fields {
-		if f.Position != nil && f.Position.MixedIn && (f.Default || f.UpdateDefault || f.Validators > 0) {
+		if f.Position != nil && f.Position.MixedIn && (f.Default || f.UpdateDefault || f.Validators > 0 || f.HasValueScanner()) {
 			idx[f.Position.MixinIndex] = struct{}{}
 		}
 	}


### PR DESCRIPTION
This patch fixes issue #3785, where such mixins

```
func (FooMixin) Fields() []ent.Field {
	return []ent.Field{
		field.String("fooUrl").
			StorageKey("foo_url").
			SchemaType(/* ... */).
			GoType(new(url.URL)).
			ValueScanner(field.BinaryValueScanner[*url.URL]{}),
	}
}
```

Result in `ent/runtime.go:20:17: undefined: userMixinFields0` errors.

Validated against our own codebase and works as expected.