### PR TITLE
libsql support

### DIFF
--- a/dialect/dialect.go
+++ b/dialect/dialect.go
@@ -20,6 +20,7 @@ const (
 	SQLite   = "sqlite3"
 	Postgres = "postgres"
 	Gremlin  = "gremlin"
+	LibSQL   = "libsql"
 )
 
 // ExecQuerier wraps the 2 database operations.

--- a/dialect/sql/sqlgraph/graph.go
+++ b/dialect/sql/sqlgraph/graph.go
@@ -1906,7 +1906,7 @@ func (c *creator) insertLastID(ctx context.Context, insert *sql.InsertBuilder) e
 		return err
 	}
 	// MySQL does not support the "RETURNING" clause.
-	if insert.Dialect() != dialect.MySQL {
+	if insert.Dialect() != dialect.MySQL && insert.Dialect() != dialect.LibSQL {
 		rows := &sql.Rows{}
 		if err := c.tx.Query(ctx, query, args, rows); err != nil {
 			return err


### PR DESCRIPTION
I have been using ent with https://turso.tech in development for a couple of month now and everything is working well except for creating records using ent.

Whenever I call `.Save()` function, the record will be created but and error will be returned. I dug into the issue and found that libsql does not support the "RETURNING" clause, just like MySQL.

This change is working well for me, but I am not sure if I need to do a full libsql driver.

Example connection:

```
	drv, err := sql.Open("libsql", viper.GetString("turso_database_url")+"?authToken="+viper.GetString("turso_auth_token"))
	if err != nil {
		config.Logger.Error("failed to open db", zap.Error(err))
		os.Exit(1)
	}

	Client := gen.NewClient(gen.Driver(drv))
```
