### PR TITLE
fix: docs show single line text for multiline example

### DIFF
--- a/doc/md/sql-integration.md
+++ b/doc/md/sql-integration.md
@@ -9,7 +9,7 @@ The following examples show how to pass a custom `sql.DB` object to `ent.Client`
 
 First option:
 
-```go
+```go title="cmd/main.go"
 package main
 
 import (
@@ -35,7 +35,7 @@ func Open() (*ent.Client, error) {
 
 Second option:
 
-```go
+```go title="cmd/main.go"
 package main
 
 import (
@@ -62,7 +62,7 @@ func Open() (*ent.Client, error) {
 
 ## Use Opencensus With MySQL
 
-```go
+```go title="cmd/main.go"
 package main
 
 import (
@@ -108,7 +108,7 @@ func Open(dsn string) *ent.Client {
 
 ## Use pgx with PostgreSQL
 
-```go
+```go title="cmd/main.go"
 package main
 
 import (


### PR DESCRIPTION
<img width="2784" height="1868" alt="CleanShot 2025-12-07 at 17 32 22@2x" src="https://github.com/user-attachments/assets/f7392682-2c88-450b-8aab-47a140ae68df" />

not sure if this will help, but seems to be on and off again.