### PR TITLE
entc/gen: bake Schema into generated code and allow same table names across schemas

### DIFF
--- a/dialect/sql/schema/atlas.go
+++ b/dialect/sql/schema/atlas.go
@@ -693,15 +693,28 @@ func (a *Atlas) planInspect(ctx context.Context, conn dialect.ExecQuerier, name 
 	if err != nil {
 		return nil, err
 	}
-	var desired *schema.Schema
-	switch {
-	case realm != nil && len(realm.Schemas) > 0:
-		desired = realm.Schemas[0]
-	default:
-		desired = &schema.Schema{}
-	}
+	desired := a.desiredSchema(current, realm)
 	desired.Name, desired.Attrs = current.Name, current.Attrs
 	return a.diff(ctx, name, current, desired, a.types[len(types):], noQualifierOpt)
+}
+
+func (a *Atlas) desiredSchema(current *schema.Schema, realm *schema.Realm) *schema.Schema {
+	desired := schema.New(current.Name)
+	if realm == nil || len(realm.Schemas) == 0 {
+		return desired
+	}
+	if s, ok := realm.Schema(current.Name); ok {
+		return s
+	}
+	if a.schema != "" {
+		if s, ok := realm.Schema(a.schema); ok {
+			return s
+		}
+	}
+	if len(realm.Schemas) == 1 {
+		return realm.Schemas[0]
+	}
+	return desired
 }
 
 func (a *Atlas) planReplay(ctx context.Context, name string, tables []*Table) (*migrate.Plan, error) {

--- a/dialect/sql/schema/migrate_test.go
+++ b/dialect/sql/schema/migrate_test.go
@@ -69,6 +69,32 @@ func TestMigrate_SchemaName(t *testing.T) {
 	require.NoError(t, m.Create(context.Background()))
 }
 
+func TestAtlas_DesiredSchema(t *testing.T) {
+	global := schema.New("global").AddTables(schema.NewTable("templates"))
+	lead := schema.New("lead").AddTables(schema.NewTable("templates"))
+	realm := &schema.Realm{Schemas: []*schema.Schema{global, lead}}
+
+	t.Run("current schema", func(t *testing.T) {
+		desired := (&Atlas{schema: "global"}).desiredSchema(schema.New("lead"), realm)
+		require.Same(t, lead, desired)
+	})
+	t.Run("configured schema", func(t *testing.T) {
+		desired := (&Atlas{schema: "lead"}).desiredSchema(schema.New("public"), realm)
+		require.Same(t, lead, desired)
+	})
+	t.Run("single schema", func(t *testing.T) {
+		desired := (&Atlas{}).desiredSchema(schema.New("public"), &schema.Realm{
+			Schemas: []*schema.Schema{global},
+		})
+		require.Same(t, global, desired)
+	})
+	t.Run("multiple schemas without match", func(t *testing.T) {
+		desired := (&Atlas{}).desiredSchema(schema.New("public"), realm)
+		require.Equal(t, "public", desired.Name)
+		require.Empty(t, desired.Tables)
+	})
+}
+
 func escape(query string) string {
 	rows := strings.Split(query, "\n")
 	for i := range rows {

--- a/dialect/sql/schema/schema.go
+++ b/dialect/sql/schema/schema.go
@@ -214,6 +214,10 @@ func CopyTables(tables []*Table) ([]*Table, error) {
 	for i, t := range tables {
 		copyT[i] = &Table{
 			Name:        t.Name,
+			Schema:      t.Schema,
+			Comment:     t.Comment,
+			View:        t.View,
+			Pos:         t.Pos,
 			Columns:     make([]*Column, len(t.Columns)),
 			Indexes:     make([]*Index, len(t.Indexes)),
 			ForeignKeys: make([]*ForeignKey, len(t.ForeignKeys)),
@@ -229,7 +233,7 @@ func CopyTables(tables []*Table) ([]*Table, error) {
 			cat := *at
 			copyT[i].Annotation = &cat
 		}
-		byName[t.Name] = copyT[i]
+		byName[t.Schema+"."+t.Name] = copyT[i]
 	}
 	for i, t := range tables {
 		ct := copyT[i]
@@ -274,7 +278,7 @@ func CopyTables(tables []*Table) ([]*Table, error) {
 				}
 				cfk.Columns[k] = cc
 			}
-			cref, ok := byName[fk.RefTable.Name]
+			cref, ok := byName[fk.RefTable.Schema+"."+fk.RefTable.Name]
 			if !ok {
 				return nil, fmt.Errorf("sql/schema: missing foreign-key ref-table %q", fk.RefTable.Name)
 			}

--- a/dialect/sql/schema/schema_test.go
+++ b/dialect/sql/schema/schema_test.go
@@ -155,6 +155,52 @@ func TestCopyTables(t *testing.T) {
 	require.Equal(t, tables, copyT)
 }
 
+func TestCopyTablesMultiSchema(t *testing.T) {
+	// Two tables with the same name in different schemas.
+	t1 := &Table{
+		Name:   "templates",
+		Schema: "global",
+		Columns: []*Column{
+			{Name: "id", Type: field.TypeInt},
+			{Name: "name", Type: field.TypeString},
+		},
+	}
+	t1.PrimaryKey = t1.Columns[:1]
+	t2 := &Table{
+		Name:   "templates",
+		Schema: "lead",
+		Columns: []*Column{
+			{Name: "id", Type: field.TypeInt},
+			{Name: "title", Type: field.TypeString},
+			{Name: "ref_id", Type: field.TypeInt},
+		},
+	}
+	t2.PrimaryKey = t2.Columns[:1]
+	// FK from lead.templates to global.templates.
+	t2.AddForeignKey(&ForeignKey{
+		Columns:    t2.Columns[2:],
+		RefTable:   t1,
+		RefColumns: t1.Columns[:1],
+		OnDelete:   SetNull,
+	})
+	tables := []*Table{t1, t2}
+	copyT, err := CopyTables(tables)
+	require.NoError(t, err)
+	require.Len(t, copyT, 2)
+	// Verify schemas are preserved.
+	require.Equal(t, "global", copyT[0].Schema)
+	require.Equal(t, "lead", copyT[1].Schema)
+	// Verify names are preserved.
+	require.Equal(t, "templates", copyT[0].Name)
+	require.Equal(t, "templates", copyT[1].Name)
+	// Verify FK references the correct copied table (global.templates).
+	require.Len(t, copyT[1].ForeignKeys, 1)
+	require.Equal(t, copyT[0], copyT[1].ForeignKeys[0].RefTable)
+	// Verify the copy is independent from the original.
+	require.NotSame(t, t1, copyT[0])
+	require.NotSame(t, t2, copyT[1])
+}
+
 func TestDDL(t *testing.T) {
 	const (
 		hash   = "249590215c5bc8be0106146e65d7fa7f"

--- a/entc/gen/graph.go
+++ b/entc/gen/graph.go
@@ -108,6 +108,8 @@ type (
 		nodes map[string]*Type
 		// Schemas holds the raw interfaces for the loaded schemas.
 		Schemas []*load.Schema
+		// tableIdents maps "schema.table" to a unique Go identifier (e.g. "GlobalTemplates").
+		tableIdents map[string]string
 	}
 
 	// Generator is the interface that wraps the Generate method.
@@ -633,9 +635,17 @@ func (g *Graph) edgeSchemas() error {
 	return nil
 }
 
+// tableKey returns the schema-qualified key for a table: "schema.name".
+func tableKey(s, name string) string {
+	return s + "." + name
+}
+
+
 // Tables returns the schema definitions of SQL tables for the graph.
 func (g *Graph) Tables() (all []*schema.Table, err error) {
 	tables := make(map[string]*schema.Table)
+	// nodeT maps each Type to its schema table for FK lookups.
+	nodeT := make(map[*Type]*schema.Table)
 	for _, n := range g.MutableNodes() {
 		table := schema.NewTable(n.Table()).
 			SetComment(n.sqlComment()).
@@ -658,12 +668,12 @@ func (g *Graph) Tables() (all []*schema.Table, err error) {
 				table.AddColumn(f.Column())
 			}
 		}
+		key := tableKey(table.Schema, table.Name)
 		switch {
-		case tables[table.Name] == nil:
-			tables[table.Name] = table
+		case tables[key] == nil:
+			tables[key] = table
+			nodeT[n] = table
 			all = append(all, table)
-		case tables[table.Name].Schema != table.Schema:
-			return nil, fmt.Errorf("cannot use the same table name %q in different schemas: %q, %q", table.Name, tables[table.Name].Schema, table.Schema)
 		default:
 			return nil, fmt.Errorf("duplicate table name %q in schema %q", table.Name, table.Schema)
 		}
@@ -678,7 +688,13 @@ func (g *Graph) Tables() (all []*schema.Table, err error) {
 			case O2O, O2M:
 				// The "owner" is the table that owns the relation (we set
 				// the foreign-key on) and "ref" is the referenced table.
-				owner, ref := tables[e.Rel.Table], tables[n.Table()]
+				// Determine the owner node by matching e.Rel.Table:
+				// For O2M the FK lives on e.Type's table, for O2O on n's table.
+				ownerNode := n
+				if e.Rel.Type == O2M && n != e.Type {
+					ownerNode = e.Type
+				}
+				owner, ref := nodeT[ownerNode], nodeT[n]
 				column := fkColumn(e, owner, ref.PrimaryKey[0])
 				// If it's not a circular reference (self-referencing table),
 				// and the inverse edge is required, make it non-nullable.
@@ -694,7 +710,7 @@ func (g *Graph) Tables() (all []*schema.Table, err error) {
 					Symbol:     fkSymbol(e, owner, ref),
 				})
 			case M2O:
-				ref, owner := tables[e.Type.Table()], tables[e.Rel.Table]
+				ref, owner := nodeT[e.Type], nodeT[n]
 				column := fkColumn(e, owner, ref.PrimaryKey[0])
 				// If it's not a circular reference (self-referencing table),
 				// and the edge is non-optional (required), make it non-nullable.
@@ -714,7 +730,7 @@ func (g *Graph) Tables() (all []*schema.Table, err error) {
 				if e.Through != nil || e.Ref != nil && e.Ref.Through != nil {
 					continue
 				}
-				t1, t2 := tables[n.Table()], tables[e.Type.Table()]
+				t1, t2 := nodeT[n], nodeT[e.Type]
 				c1 := &schema.Column{Name: e.Rel.Columns[0], Type: field.TypeInt, SchemaType: n.ID.def.SchemaType}
 				if ref := n.ID; ref.UserDefined {
 					c1.Type = ref.Type.Type
@@ -727,7 +743,7 @@ func (g *Graph) Tables() (all []*schema.Table, err error) {
 				}
 				ant := e.EntSQL()
 				s1, s2 := fkSymbols(e, c1, c2)
-				all = append(all, &schema.Table{
+				joinTable := &schema.Table{
 					Name: e.Rel.Table,
 					// Join tables get the position of the edge owner.
 					Pos: n.Pos(),
@@ -761,18 +777,20 @@ func (g *Graph) Tables() (all []*schema.Table, err error) {
 							Symbol:     s2,
 						},
 					},
-				})
+				}
+				tables[tableKey(joinTable.Schema, joinTable.Name)] = joinTable
+				all = append(all, joinTable)
 			}
 		}
 		if n.HasCompositeID() {
-			if err := addCompositePK(tables[n.Table()], n); err != nil {
+			if err := addCompositePK(nodeT[n], n); err != nil {
 				return nil, err
 			}
 		}
 	}
 	// Append indexes to tables after all columns were added (including relation columns).
 	for _, n := range g.Nodes {
-		table := tables[n.Table()]
+		table := nodeT[n]
 		for _, idx := range n.Indexes {
 			table.AddIndex(idx.Name, idx.Unique, idx.Columns)
 			// Set the entsql.IndexAnnotation from the schema if exists.
@@ -783,7 +801,53 @@ func (g *Graph) Tables() (all []*schema.Table, err error) {
 	if err := ensureUniqueFKs(tables); err != nil {
 		return nil, err
 	}
+	// Compute unique Go identifiers for tables.
+	if err := g.computeTableIdents(all); err != nil {
+		return nil, err
+	}
 	return
+}
+
+// computeTableIdents computes unique Go identifiers for each table.
+// By default, the identifier is pascal(t.Name). On collision (same pascal name
+// for tables in different schemas), we prefix with pascal(t.Schema) + "_".
+func (g *Graph) computeTableIdents(tables []*schema.Table) error {
+	g.tableIdents = make(map[string]string, len(tables))
+	// First pass: compute default identifiers and detect collisions.
+	byIdent := make(map[string][]*schema.Table)
+	for _, t := range tables {
+		ident := pascal(t.Name)
+		byIdent[ident] = append(byIdent[ident], t)
+	}
+	// Second pass: assign identifiers, prefixing on collision.
+	usedIdents := make(map[string]string) // ident -> "schema.name" that claimed it
+	for ident, ts := range byIdent {
+		if len(ts) == 1 {
+			key := tableKey(ts[0].Schema, ts[0].Name)
+			if other, ok := usedIdents[ident]; ok {
+				return fmt.Errorf("table identifier %q collision between %q and %q", ident, other, key)
+			}
+			usedIdents[ident] = key
+			g.tableIdents[key] = ident
+		} else {
+			// Multiple tables share the same pascal(Name) — prefix with schema.
+			for _, t := range ts {
+				key := tableKey(t.Schema, t.Name)
+				prefixed := pascal(t.Schema) + "_" + pascal(t.Name)
+				if other, ok := usedIdents[prefixed]; ok {
+					return fmt.Errorf("table identifier %q collision between %q and %q", prefixed, other, key)
+				}
+				usedIdents[prefixed] = key
+				g.tableIdents[key] = prefixed
+			}
+		}
+	}
+	return nil
+}
+
+// TableIdent returns the unique Go identifier for the given table.
+func (g *Graph) TableIdent(t *schema.Table) string {
+	return g.tableIdents[tableKey(t.Schema, t.Name)]
 }
 
 // Views returns all schema views

--- a/entc/gen/graph_test.go
+++ b/entc/gen/graph_test.go
@@ -729,3 +729,72 @@ func TestEdgeFieldCollation(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "utf8mb4_bin", col.Collation)
 }
+
+func TestMultiSchemaSameTableName(t *testing.T) {
+	// Two types that map to the same SQL table name "templates" but in different schemas.
+	global := &load.Schema{
+		Name: "GlobalTemplate",
+		Fields: []*load.Field{
+			{Name: "name", Info: &field.TypeInfo{Type: field.TypeString}},
+		},
+		Annotations: dict("EntSQL", dict("table", "templates", "schema", "global")),
+	}
+	lead := &load.Schema{
+		Name: "LeadTemplate",
+		Fields: []*load.Field{
+			{Name: "name", Info: &field.TypeInfo{Type: field.TypeString}},
+		},
+		Annotations: dict("EntSQL", dict("table", "templates", "schema", "lead")),
+	}
+	g, err := NewGraph(&Config{Package: "entc/gen", Storage: drivers[0]}, global, lead)
+	require.NoError(t, err)
+	tables, err := g.Tables()
+	require.NoError(t, err)
+	require.Len(t, tables, 2)
+
+	// Verify both tables exist with correct schemas.
+	require.Equal(t, "templates", tables[0].Name)
+	require.Equal(t, "global", tables[0].Schema)
+	require.Equal(t, "templates", tables[1].Name)
+	require.Equal(t, "lead", tables[1].Schema)
+
+	// Verify Go identifiers are schema-prefixed due to collision.
+	require.Equal(t, "Global_Templates", g.TableIdent(tables[0]))
+	require.Equal(t, "Lead_Templates", g.TableIdent(tables[1]))
+}
+
+func TestSingleSchemaTableIdent(t *testing.T) {
+	// Single-schema tables should get plain pascal(Name) identifiers (backward compat).
+	g, err := NewGraph(&Config{Package: "entc/gen", Storage: drivers[0]}, T1, T2)
+	require.NoError(t, err)
+	tables, err := g.Tables()
+	require.NoError(t, err)
+
+	for _, table := range tables {
+		ident := g.TableIdent(table)
+		require.Equal(t, pascal(table.Name), ident, "table %q should get unprefixed identifier", table.Name)
+	}
+}
+
+func TestDuplicateTableNameSameSchema(t *testing.T) {
+	// Two types with the same table name in the same schema should still error.
+	s1 := &load.Schema{
+		Name: "Foo",
+		Fields: []*load.Field{
+			{Name: "name", Info: &field.TypeInfo{Type: field.TypeString}},
+		},
+		Annotations: dict("EntSQL", dict("table", "items", "schema", "db1")),
+	}
+	s2 := &load.Schema{
+		Name: "Bar",
+		Fields: []*load.Field{
+			{Name: "name", Info: &field.TypeInfo{Type: field.TypeString}},
+		},
+		Annotations: dict("EntSQL", dict("table", "items", "schema", "db1")),
+	}
+	g, err := NewGraph(&Config{Package: "entc/gen", Storage: drivers[0]}, s1, s2)
+	require.NoError(t, err)
+	_, err = g.Tables()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate table name")
+}

--- a/entc/gen/template/migrate/schema.tmpl
+++ b/entc/gen/template/migrate/schema.tmpl
@@ -27,7 +27,7 @@ var (
 		{{- /* find type node in the graph of this table, if exists */}}
 		{{- $node := index $.Nodes 0 }}
 		{{- range $n := $.Nodes }}{{ if eq $t.Name $n.Table }}{{ $node = $n }}{{ end }}{{ end }}
-		{{- $columns := pascal $t.Name | printf "%sColumns" }}
+		{{- $columns := $.TableIdent $t | printf "%sColumns" }}
 		// {{ $columns }} holds the columns for the "{{ $t.Name }}" table.
 		{{ $columns }} = []*schema.Column{
 			{{- range $c := $t.Columns }}
@@ -53,10 +53,13 @@ var (
 				{{- with $c.SchemaType }} SchemaType: map[string]string{ {{ range $k := keys . }}"{{ $k }}": "{{ index $c.SchemaType $k }}",{{ end }}}{{ end }}},
 			{{- end }}
 		}
-		{{- $table := pascal $t.Name | printf "%sTable" }}
+		{{- $table := $.TableIdent $t | printf "%sTable" }}
 		// {{ $table }} holds the schema information for the "{{ $t.Name }}" table.
 		{{ $table }} = &schema.Table{
 			Name: "{{ $t.Name }}",
+			{{- with $t.Schema }}
+				Schema: "{{ . }}",
+			{{- end }}
 			{{- with $t.Comment }}
 				Comment: "{{ . }}",
 			{{- end }}
@@ -84,7 +87,7 @@ var (
 							RefColumns: []*schema.Column{
 								{{- range $c1 := $fk.RefColumns }}
 									{{- range $i, $c2 := $fk.RefTable.Columns }}
-										{{- if eq $c1.Name $c2.Name }}{{ pascal $fk.RefTable.Name | printf "%sColumns" }}[{{ $i }}],{{ end }}
+										{{- if eq $c1.Name $c2.Name }}{{ $.TableIdent $fk.RefTable | printf "%sColumns" }}[{{ $i }}],{{ end }}
 									{{- end }}
 								{{- end }}
 							},
@@ -193,16 +196,16 @@ var (
 	// Tables holds all the tables in the schema.
 	Tables = []*schema.Table{
 		{{- range $t := $.Tables }}
-			{{ pascal $t.Name | printf "%sTable" }},
+			{{ $.TableIdent $t | printf "%sTable" }},
 		{{- end }}
 	}
 )
 
 func init() {
 	{{- range $t := $.Tables }}
-		{{- $table := pascal $t.Name | printf "%sTable" }}
+		{{- $table := $.TableIdent $t | printf "%sTable" }}
 		{{- range $i, $fk := $t.ForeignKeys }}
-			{{ $table }}.ForeignKeys[{{ $i }}].RefTable = {{ pascal $fk.RefTable.Name | printf "%sTable" }}
+			{{ $table }}.ForeignKeys[{{ $i }}].RefTable = {{ $.TableIdent $fk.RefTable | printf "%sTable" }}
 		{{- end }}
 		{{- with $ant := $t.Annotation }}
 			{{- if not (allZero $ant.Table $ant.Charset $ant.Collation $ant.Options $ant.Check $ant.IncrementStart $ant.Incremental $ant.Checks) }}

--- a/entc/integration/multischema/ent/migrate/schema.go
+++ b/entc/integration/multischema/ent/migrate/schema.go
@@ -23,6 +23,7 @@ var (
 	// FriendshipsTable holds the schema information for the "friendships" table.
 	FriendshipsTable = &schema.Table{
 		Name:       "friendships",
+		Schema:     "db2",
 		Columns:    FriendshipsColumns,
 		PrimaryKey: []*schema.Column{FriendshipsColumns[0]},
 		ForeignKeys: []*schema.ForeignKey{
@@ -60,6 +61,7 @@ var (
 	// GroupsTable holds the schema information for the "groups" table.
 	GroupsTable = &schema.Table{
 		Name:       "groups",
+		Schema:     "db2",
 		Columns:    GroupsColumns,
 		PrimaryKey: []*schema.Column{GroupsColumns[0]},
 	}
@@ -73,6 +75,7 @@ var (
 	// ParentsTable holds the schema information for the "parents" table.
 	ParentsTable = &schema.Table{
 		Name:       "parents",
+		Schema:     "db1",
 		Columns:    ParentsColumns,
 		PrimaryKey: []*schema.Column{ParentsColumns[0]},
 		ForeignKeys: []*schema.ForeignKey{
@@ -106,6 +109,7 @@ var (
 	// PetsTable holds the schema information for the "pets" table.
 	PetsTable = &schema.Table{
 		Name:       "pets",
+		Schema:     "db1",
 		Columns:    PetsColumns,
 		PrimaryKey: []*schema.Column{PetsColumns[0]},
 		ForeignKeys: []*schema.ForeignKey{
@@ -125,6 +129,7 @@ var (
 	// UsersTable holds the schema information for the "users" table.
 	UsersTable = &schema.Table{
 		Name:       "users",
+		Schema:     "db1",
 		Columns:    UsersColumns,
 		PrimaryKey: []*schema.Column{UsersColumns[0]},
 	}
@@ -136,6 +141,7 @@ var (
 	// GroupUsersTable holds the schema information for the "group_users" table.
 	GroupUsersTable = &schema.Table{
 		Name:       "group_users",
+		Schema:     "db2",
 		Columns:    GroupUsersColumns,
 		PrimaryKey: []*schema.Column{GroupUsersColumns[0], GroupUsersColumns[1]},
 		ForeignKeys: []*schema.ForeignKey{

--- a/entc/integration/multischema/versioned/migrate/schema.go
+++ b/entc/integration/multischema/versioned/migrate/schema.go
@@ -23,6 +23,7 @@ var (
 	// FriendshipsTable holds the schema information for the "friendships" table.
 	FriendshipsTable = &schema.Table{
 		Name:       "friendships",
+		Schema:     "db1",
 		Columns:    FriendshipsColumns,
 		PrimaryKey: []*schema.Column{FriendshipsColumns[0]},
 		ForeignKeys: []*schema.ForeignKey{
@@ -60,6 +61,7 @@ var (
 	// GroupsTable holds the schema information for the "groups" table.
 	GroupsTable = &schema.Table{
 		Name:       "groups",
+		Schema:     "db1",
 		Columns:    GroupsColumns,
 		PrimaryKey: []*schema.Column{GroupsColumns[0]},
 	}
@@ -72,6 +74,7 @@ var (
 	// PetsTable holds the schema information for the "pets" table.
 	PetsTable = &schema.Table{
 		Name:       "pets",
+		Schema:     "db2",
 		Columns:    PetsColumns,
 		PrimaryKey: []*schema.Column{PetsColumns[0]},
 		ForeignKeys: []*schema.ForeignKey{
@@ -91,6 +94,7 @@ var (
 	// UsersTable holds the schema information for the "users" table.
 	UsersTable = &schema.Table{
 		Name:       "users",
+		Schema:     "db3",
 		Columns:    UsersColumns,
 		PrimaryKey: []*schema.Column{UsersColumns[0]},
 	}
@@ -102,6 +106,7 @@ var (
 	// GroupUsersTable holds the schema information for the "group_users" table.
 	GroupUsersTable = &schema.Table{
 		Name:       "group_users",
+		Schema:     "db1",
 		Columns:    GroupUsersColumns,
 		PrimaryKey: []*schema.Column{GroupUsersColumns[0], GroupUsersColumns[1]},
 		ForeignKeys: []*schema.ForeignKey{
@@ -127,6 +132,7 @@ var (
 	// UserFollowingTable holds the schema information for the "user_following" table.
 	UserFollowingTable = &schema.Table{
 		Name:       "user_following",
+		Schema:     "db3",
 		Columns:    UserFollowingColumns,
 		PrimaryKey: []*schema.Column{UserFollowingColumns[0], UserFollowingColumns[1]},
 		ForeignKeys: []*schema.ForeignKey{


### PR DESCRIPTION
Fixes #2330

When two PostgreSQL schemas have tables with the same name (e.g., `global.templates` and `lead.templates`), code generation fails because `Tables()` rejects same table names across schemas and the template generates duplicate Go identifiers.

### Changes

**`entc/gen/graph.go`**
- Use schema-qualified keys (`"schema.table"`) in the tables map to allow same table names in different schemas
- Use `nodeT` map (`*Type → *schema.Table`) for FK lookups instead of bare table name lookups
- Add `computeTableIdents()` to generate unique Go identifiers: `pascal(name)` by default, `pascal(schema) + "_" + pascal(name)` on collision
- Add `TableIdent(*schema.Table) string` method on `Graph`, used by the schema template

**`entc/gen/template/migrate/schema.tmpl`**
- Replace all 6 `pascal $t.Name` / `pascal $fk.RefTable.Name` usages with `$.TableIdent`
- Emit the `Schema` field in generated table structs when set

**`dialect/sql/schema/schema.go`**
- Fix `CopyTables` to preserve `Schema`, `Comment`, `View`, `Pos` fields (previously silently dropped)
- Use schema-qualified keys in `byName` map and FK ref lookup

### Backward Compatibility

| Scenario | Behavior |
|----------|----------|
| No schema annotation | No `Schema` field emitted, identifiers unchanged. Generated code identical to before. |
| Single table per name | Go identifiers unchanged (e.g., `UsersTable`). |
| Same name, different schemas | New case — previously errored. Gets schema prefix (e.g., `Global_TemplatesTable`). |
| Manual `Table.Schema` overrides | Still work. If Schema is baked in, the manual set is a no-op. |
| `CopyTables` | Now correctly preserves `Schema` field (was silently dropped). |

### Testing

- Unit tests: `TestMultiSchemaSameTableName`, `TestSingleSchemaTableIdent`, `TestDuplicateTableNameSameSchema`, `TestCopyTablesMultiSchema`
- Integration: regenerated `multischema/ent/migrate/schema.go` with Schema baked in, verified against MySQL 8
- Regression: all integration tests pass (SQLite, MySQL 5.6/5.7/8, MariaDB, Postgres 10-17)