### PR TITLE
fix MySQL JSON append args for MariaDB

### DIFF
--- a/dialect/sql/sqljson/dialect.go
+++ b/dialect/sql/sqljson/dialect.go
@@ -129,7 +129,7 @@ func (d *mysql) marshalArgs(args []any) []any {
 func (d *mysql) appendArg(b *sql.Builder, v any) {
 	switch {
 	case !isPrimitive(v):
-		b.Argf("CAST(? AS JSON)", marshalArg(v))
+		b.Argf("JSON_EXTRACT(?, '$')", marshalArg(v))
 	default:
 		b.Arg(v)
 	}


### PR DESCRIPTION
## Summary

Replace `CAST(? AS JSON)` with `JSON_EXTRACT(?, '$')` when appending marshaled JSON values in the MySQL `sqljson` dialect.

MariaDB treats `JSON` as an alias for `LONGTEXT` and does not support `CAST(... AS JSON)`. As a result, `sqljson.Append` fails on MariaDB when appending non-primitive values such as objects, maps, structs, or arrays.

Using `JSON_EXTRACT(?, '$')` parses the argument as JSON and returns the root JSON value, preserving the intended append semantics for marshaled values while working on both MySQL and MariaDB.

## Problem

Given a schema field that stores a slice of objects:

```go
field.JSON("metadata", []map[string]string{}).
    Default([]map[string]string{}).
    StructTag(`json:"metadata"`)
```

Appending a non-primitive element on MariaDB:

```go
_, err := client.Entity.UpdateOneID(id).
    AppendMetadata([]map[string]string{
        {
            "key":  "value",
            "time": time.Now().Format(time.RFC3339),
        },
    }).
    Save(ctx)
```

can generate an update containing `CAST(? AS JSON)` and fail with:

```text
Error 1064 (42000): You have an error in your SQL syntax; check the manual that
corresponds to your MariaDB server version for the right syntax to use near
'JSON)) END WHERE `id` = ?' at line 1
```

The failing SQL is generated by the MySQL `sqljson` dialect for non-primitive append arguments:

```sql
JSON_ARRAY_APPEND(`metadata`, '$', CAST(? AS JSON))
```

This works for MySQL, but not for MariaDB.

## Fix

In `dialect/sql/sqljson/dialect.go`, update the non-primitive branch of `(*mysql).appendArg` to emit:

```sql
JSON_EXTRACT(?, '$')
```

instead of:

```sql
CAST(? AS JSON)
```

resulting in:

Before:

```sql
JSON_ARRAY_APPEND(`metadata`, '$', CAST(? AS JSON))
```

After:

```sql
JSON_ARRAY_APPEND(`metadata`, '$', JSON_EXTRACT(?, '$'))
```