### PR TITLE
fix(entc/template): support non-int numeric IDs in Noder

### DIFF
--- a/entc/integration/template/ent/node.go
+++ b/entc/integration/template/ent/node.go
@@ -162,7 +162,7 @@ func (c *Client) Noder(ctx context.Context, id int) (Noder, error) {
 	if err != nil {
 		return nil, err
 	}
-	idx := id / (1<<32 - 1)
+	idx := int(id) / (1<<32 - 1)
 	if idx < 0 || idx >= len(tables) {
 		return nil, fmt.Errorf("cannot resolve table from id %v: %w", id, &NotFoundError{"invalid/unknown"})
 	}

--- a/entc/integration/template/ent/template/node.tmpl
+++ b/entc/integration/template/ent/template/node.tmpl
@@ -110,7 +110,7 @@ func (c *Client) Noder(ctx context.Context, id {{ $.IDType }}) (Noder, error) {
 		}
 		idx := idv/(1<<32 - 1)
 	{{- else }}
-		idx := id/(1<<32 - 1)
+		idx := int(id)/(1<<32 - 1)
 	{{- end }}
 	if idx < 0 || idx >= len(tables) {
 		return nil, fmt.Errorf("cannot resolve table from id %v: %w", id, &NotFoundError{"invalid/unknown"})


### PR DESCRIPTION
Closes #2241

<!-- Drafted by an agent run; please review carefully before merging. -->

## Repo
ent/ent

## Issue
https://github.com/ent/ent/issues/2241

## Root cause
The custom `node.tmpl` template (and its committed generated `node.go`) computes the table index with `idx := id/(1<<32 - 1)`. The literal `1<<32 - 1` (= 4294967295) overflows `int32`, so when a schema's ID type is `int32` (or any narrower numeric type) the generated code fails to compile with: `cannot convert the constant (1<<32 - 1) to the type int32`.

## Fix
Convert `id` to plain `int` before the division: `idx := int(id)/(1<<32 - 1)`. This keeps the constant in its untyped-int form, matches the `int`-typed `idx` already used to index the `tables` slice, and is a no-op for the existing default `int` ID type.

## Regression test
`entc/integration/template/template_test.go::TestCustomTemplate` already exercises `client.Node(ctx, id)` (the patched `Noder` path) and continues to pass after the fix; the patched expression remains valid for the default `int` ID type used in the integration schema, while the template change ensures generation with `int32` (or other narrower numeric) ID types produces compilable Go.

## Risk
low

## Verification
Ran `go test ./template/...` from `entc/integration/` — PASS (`ok entgo.io/ent/entc/integration/template 0.377s`). Also confirmed `go build ./template/...` succeeds.
