### PR TITLE
entc/gen: remove auto-increment for user-defined primary keys regardl…

### DIFF
--- a/entc/gen/type.go
+++ b/entc/gen/type.go
@@ -1633,8 +1633,8 @@ func (f Field) PK() *schema.Column {
 		Comment:   f.sqlComment(),
 		Increment: f.incremental(f.Type.Type.Integer()),
 	}
-	// If the PK was defined by the user, and it is UUID or string.
-	if f.UserDefined && !f.Type.Numeric() {
+	// If the PK was defined by the user
+	if f.UserDefined {
 		c.Increment = false
 		c.Type = f.Type.Type
 		c.Unique = f.Unique


### PR DESCRIPTION
This is a fix for issue #4498

I removed the check `&& !f.Type.Numeric()`.

> **Note:** If ent gives the user an option to manually set an `int` field as `incremental` (I am not sure there is a way to do that anyway) and the user has a custom `id` of type `int` and set that as `incremental`, this change will block that functionality.

**Tests:**
Some tests failed but they failed even before my change. I hope the maintainer can run github actions to check if it fails there too.