### PR TITLE
propagate context to From selector in (*query).selector

### DIFF
--- a/dialect/sql/sqlgraph/graph.go
+++ b/dialect/sql/sqlgraph/graph.go
@@ -1070,6 +1070,7 @@ func (q *query) selector(ctx context.Context) (*sql.Selector, error) {
 		WithContext(ctx)
 	if q.From != nil {
 		selector = q.From
+		selector.WithContext(ctx)
 	}
 	selector.Select(selector.Columns(q.Node.Columns...)...)
 	if order := q.Order; order != nil {

--- a/entc/integration/multischema/multischema_test.go
+++ b/entc/integration/multischema/multischema_test.go
@@ -164,6 +164,13 @@ func TestMySQL(t *testing.T) {
 	require.Len(t, sib, 2)
 	require.True(t, slices.ContainsFunc(sib, func(u *ent.User) bool { return u.Name == el.Name }))
 	require.True(t, slices.ContainsFunc(sib, func(u *ent.User) bool { return u.Name == jo.Name }))
+
+	// Cross-schema edge predicate: QueryGroups().Where(HasUsersWith(...))
+	// must qualify group_users with db2, since the connection defaults to db1.
+	got := a8m.QueryGroups().
+		Where(group.HasUsersWith(user.ID(a8m.ID))).
+		CountX(ctx)
+	require.Equal(t, 1, got) // a8m was removed from GitHub above; only GitLab remains
 }
 
 func TestVersionedMigration(t *testing.T) {


### PR DESCRIPTION
When using multischema, the schema was not getting prepended to the tables in the query. I believe it was because the ctx was not attached, and therefore the schema config was not present.