### PR TITLE
dialect/sql: top level UNION/INTERSECT/EXCEPT

### DIFF
--- a/dialect/sql/builder.go
+++ b/dialect/sql/builder.go
@@ -2222,6 +2222,74 @@ func (s *Selector) IntersectAll(t TableView) *Selector {
 	return s
 }
 
+// setOpQuerier implements Querier for a compound set operation (UNION, EXCEPT,
+// INTERSECT) where every branch is wrapped in parentheses. This is required
+// when branches contain ORDER BY, LIMIT, or OFFSET (MySQL and SQL standard).
+// Use the package-level Union / UnionAll / Except / ExceptAll / Intersect /
+// IntersectAll functions to build one.
+type setOpQuerier struct {
+	Builder
+	op        string
+	selectors []*Selector
+}
+
+func (q *setOpQuerier) Query() (string, []any) {
+	b := q.Builder.clone()
+	for i, s := range q.selectors {
+		if i > 0 {
+			b.WriteString(" " + q.op + " ")
+		}
+		s.SetDialect(b.dialect)
+		s.SetTotal(b.total)
+		b.WriteString("(")
+		query, args := s.Query()
+		b.WriteString(query)
+		b.WriteString(")")
+		b.args = append(b.args, args...)
+		b.total += len(args)
+	}
+	return b.String(), b.args
+}
+
+// Union returns a Querier that combines selectors with UNION (DISTINCT),
+// wrapping every branch in parentheses. Use this instead of the chaining
+// method when branches carry their own ORDER BY, LIMIT, or OFFSET — MySQL
+// and the SQL standard require parentheses in that case.
+func Union(selectors ...*Selector) Querier {
+	return &setOpQuerier{op: string(setOpTypeUnion), selectors: selectors}
+}
+
+// UnionAll returns a Querier that combines selectors with UNION ALL, wrapping
+// every branch in parentheses. Use this instead of the chaining method when
+// branches carry their own ORDER BY, LIMIT, or OFFSET.
+func UnionAll(selectors ...*Selector) Querier {
+	return &setOpQuerier{op: string(setOpTypeUnion) + " ALL", selectors: selectors}
+}
+
+// Except returns a Querier that combines selectors with EXCEPT, wrapping every
+// branch in parentheses.
+func Except(selectors ...*Selector) Querier {
+	return &setOpQuerier{op: string(setOpTypeExcept), selectors: selectors}
+}
+
+// ExceptAll returns a Querier that combines selectors with EXCEPT ALL, wrapping
+// every branch in parentheses.
+func ExceptAll(selectors ...*Selector) Querier {
+	return &setOpQuerier{op: string(setOpTypeExcept) + " ALL", selectors: selectors}
+}
+
+// Intersect returns a Querier that combines selectors with INTERSECT, wrapping
+// every branch in parentheses.
+func Intersect(selectors ...*Selector) Querier {
+	return &setOpQuerier{op: string(setOpTypeIntersect), selectors: selectors}
+}
+
+// IntersectAll returns a Querier that combines selectors with INTERSECT ALL,
+// wrapping every branch in parentheses.
+func IntersectAll(selectors ...*Selector) Querier {
+	return &setOpQuerier{op: string(setOpTypeIntersect) + " ALL", selectors: selectors}
+}
+
 // Prefix prefixes the query with list of queries.
 func (s *Selector) Prefix(queries ...Querier) *Selector {
 	s.prefix = append(s.prefix, queries...)

--- a/dialect/sql/builder_test.go
+++ b/dialect/sql/builder_test.go
@@ -1794,6 +1794,64 @@ func TestSelector_UnionOrderBy(t *testing.T) {
 	require.Equal(t, `SELECT * FROM "users" WHERE "active" UNION SELECT * FROM "old_users1" ORDER BY "users"."whatever"`, query)
 }
 
+// TestUnionAllFunc verifies the package-level UnionAll (and friends) wrap every
+// branch in parentheses, enabling per-branch ORDER BY / LIMIT and an optional
+// outer ORDER BY / LIMIT on the union result via a wrapping SELECT.
+func TestUnionAllFunc(t *testing.T) {
+	t.Run("BothBranchesParenthesized", func(t *testing.T) {
+		migSel := Select("id", "kind").
+			From(Table("migration_deployments")).
+			OrderBy(Desc("end_time"), Desc("id")).
+			Limit(20)
+		schemaSel := Select("id", "kind").
+			From(Table("schema_deployments")).
+			OrderBy(Desc("end_time"), Desc("id")).
+			Limit(20)
+		query, args := UnionAll(migSel, schemaSel).Query()
+		require.Equal(t,
+			"(SELECT `id`, `kind` FROM `migration_deployments` ORDER BY `end_time` DESC, `id` DESC LIMIT 20) UNION ALL (SELECT `id`, `kind` FROM `schema_deployments` ORDER BY `end_time` DESC, `id` DESC LIMIT 20)",
+			query,
+		)
+		require.Nil(t, args)
+	})
+
+	t.Run("WithOuterOrderAndLimit", func(t *testing.T) {
+		// Per-branch LIMIT push-down + outer ORDER BY / LIMIT on the union result.
+		// Use sql.Queries to compose: WITH `all` AS (...) SELECT ... ORDER BY ... LIMIT ...
+		migSel := Select("id", "kind").From(Table("t1")).OrderBy(Desc("end_time")).Limit(20)
+		schemaSel := Select("id", "kind").From(Table("t2")).OrderBy(Desc("end_time")).Limit(20)
+		inner := UnionAll(migSel, schemaSel)
+		outer := Select("id", "kind").From(Table("all")).OrderBy(Desc("end_time")).Limit(10).Offset(0)
+		query, _ := Queries{
+			Raw("WITH `all` AS ("), inner, Raw(")"),
+			outer,
+		}.Query()
+		require.Equal(t,
+			"WITH `all` AS ( (SELECT `id`, `kind` FROM `t1` ORDER BY `end_time` DESC LIMIT 20) UNION ALL (SELECT `id`, `kind` FROM `t2` ORDER BY `end_time` DESC LIMIT 20) ) SELECT `id`, `kind` FROM `all` ORDER BY `end_time` DESC LIMIT 10 OFFSET 0",
+			query,
+		)
+	})
+
+	t.Run("DialectPropagation", func(t *testing.T) {
+		// Dialect must flow into branch selectors via state interface.
+		migSel := Dialect(dialect.Postgres).Select("id").From(Table("t1")).Limit(5)
+		schemaSel := Dialect(dialect.Postgres).Select("id").From(Table("t2")).Limit(5)
+		q := &setOpQuerier{op: "UNION ALL", selectors: []*Selector{migSel, schemaSel}}
+		q.SetDialect(dialect.Postgres)
+		query, _ := q.Query()
+		// Postgres uses $N placeholders; identifiers use double-quotes.
+		require.Equal(t, `(SELECT "id" FROM "t1" LIMIT 5) UNION ALL (SELECT "id" FROM "t2" LIMIT 5)`, query)
+	})
+
+	t.Run("Union", func(t *testing.T) {
+		query, _ := Union(
+			Select("*").From(Table("t1")).OrderBy("x"),
+			Select("*").From(Table("t2")).OrderBy("x"),
+		).Query()
+		require.Equal(t, "(SELECT * FROM `t1` ORDER BY `x`) UNION (SELECT * FROM `t2` ORDER BY `x`)", query)
+	})
+}
+
 func TestUpdateBuilder_SetExpr(t *testing.T) {
 	d := Dialect(dialect.Postgres)
 	excluded := d.Table("excluded")


### PR DESCRIPTION
Standard SQL (and MySQL) require parentheses on the union/intersect/except.

The current chaining methods do not allow to put parentheses on the first branch. Thus the new top-level functions.