### PR TITLE
entc/gen: emit additional imports in tx.tmpl

### DIFF
--- a/entc/gen/template/tx.tmpl
+++ b/entc/gen/template/tx.tmpl
@@ -13,6 +13,7 @@ in the LICENSE file in the root directory of this source tree.
 import (
 	"context"
 	"sync"
+	{{- template "import/additional" $ }}
 
 	"entgo.io/ent/dialect"
 )


### PR DESCRIPTION
Fixes #4513.

`tx.tmpl` renders the feature blocks for the body (`matchTemplate "tx/additional/*"`), but its
import block is a fixed list, so imports contributed by features are never emitted. With
`sql/execquery` enabled, the generated `tx.go` gets `txDriver.ExecContext` / `QueryContext` but not
the `stdsql "database/sql"` import that `import/additional/stdsql` provides. `client.tmpl` already
renders `import/additional` inside its import block (`client.tmpl:69`).

Today that missing import is recovered after the fact by goimports in `assets.format()`, which
learns the alias from a sibling file in the same package (`client.go`). That pass runs concurrently
and each worker rewrites its file with `os.WriteFile`, which truncates before writing. If `tx.go`
is resolved while `client.go` is truncated, goimports cannot resolve the alias — and returns no
error — so `tx.go` is written without the import and the package fails to compile with
`undefined: stdsql`. Details and a reproduction are in #4513.

## The change

```gotemplate
 import (
 	"context"
 	"sync"
+	{{- template "import/additional" $ }}
 
 	"entgo.io/ent/dialect"
 )
```

Rendering it inside the standard library group keeps the import in the same place goimports puts it
today, so **the generated output does not change**: running `go generate ./...` in `entc/integration`
and `examples` produces no diff.

## Checks

- `go build ./...`
- `go test ./entc/gen/...`
- `go generate ./...` in `entc/integration` and `examples` → no diff in generated code

`fmt` is likewise absent from `tx.tmpl` and supplied by goimports, but it resolves from the standard
library by package name rather than from a sibling file, so it is not affected by this race. I left
it alone to keep the output identical.